### PR TITLE
Python 3 compatibility: basestring, unicode(), xrange()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 cache: pip
 python:
   - "2.7"
-  # - "3.6"  # enable when compliant
+  - "3.6"
 install:
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -1,16 +1,8 @@
 # Copyright 2017 Kensho Technologies, Inc.
 from .expressions import Expression
-from .helpers import (CompilerEntity, ensure_unicode_string, safe_quoted_string,
-                      validate_marked_location, validate_safe_string)
-try:
-    basestring        # Python 2
-except NameError
-    basestring = str  # Python 3
-    unicode = str
-try:
-    xrange            # Python 2
-except NameError:
-    xrange = range    # Python 3
+from .helpers import (basestring, CompilerEntity, ensure_unicode_string,
+                      safe_quoted_string, unicode, validate_marked_location,
+                      validate_safe_string, xrange)
 
 
 class BasicBlock(CompilerEntity):

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Kensho Technologies, Inc.
 from .expressions import Expression
 from .helpers import (basestring, CompilerEntity, ensure_unicode_string,
-                      safe_quoted_string, unicode, validate_marked_location,
+                      safe_quoted_string, validate_marked_location,
                       validate_safe_string, xrange)
 
 

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -6,6 +6,7 @@ try:
     basestring        # Python 2
 except NameError
     basestring = str  # Python 3
+    unicode = str
 try:
     xrange            # Python 2
 except NameError:

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -3,9 +3,13 @@ from .expressions import Expression
 from .helpers import (CompilerEntity, ensure_unicode_string, safe_quoted_string,
                       validate_marked_location, validate_safe_string)
 try:
-  basestring        # Python 2
+    basestring        # Python 2
 except NameError
-  basestring = str  # Python 3
+    basestring = str  # Python 3
+try:
+    xrange            # Python 2
+except NameError:
+    xrange = range    # Python 3
 
 
 class BasicBlock(CompilerEntity):

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -2,6 +2,10 @@
 from .expressions import Expression
 from .helpers import (CompilerEntity, ensure_unicode_string, safe_quoted_string,
                       validate_marked_location, validate_safe_string)
+try:
+  basestring        # Python 2
+except NameError
+  basestring = str  # Python 3
 
 
 class BasicBlock(CompilerEntity):

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -3,12 +3,9 @@ from graphql import GraphQLList, GraphQLNonNull
 
 from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
-from .helpers import (CompilerEntity, Location, ensure_unicode_string, is_graphql_type,
-                      safe_quoted_string, strip_non_null_from_type, validate_safe_string)
-try:
-    basestring        # Python 2
-except NameError
-    basestring = str  # Python 3
+from .helpers import (basestring, CompilerEntity, Location, ensure_unicode_string,
+                      is_graphql_type, safe_quoted_string, strip_non_null_from_type,
+                      validate_safe_string)
 
 
 # Since MATCH uses $-prefixed keywords to indicate special values,

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -5,6 +5,10 @@ from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .helpers import (CompilerEntity, Location, ensure_unicode_string, is_graphql_type,
                       safe_quoted_string, strip_non_null_from_type, validate_safe_string)
+try:
+    basestring        # Python 2
+except NameError
+    basestring = str  # Python 3
 
 
 # Since MATCH uses $-prefixed keywords to indicate special values,

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -6,6 +6,14 @@ from graphql import GraphQLEnumType, GraphQLNonNull, GraphQLScalarType, GraphQLS
 
 from ..exceptions import GraphQLCompilationError
 
+try:               # Python 2
+    unicode = unicode
+    basestring = basestring
+    xrange = xrange
+except NameError:  # Python 3
+    basestring = str  
+    unicode = str
+    xrange = range
 
 VARIABLE_ALLOWED_CHARS = frozenset(unicode(string.ascii_letters + string.digits + '_'))
 

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -1,6 +1,11 @@
 # Copyright 2017 Kensho Technologies, Inc.
 import re
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 def remove_custom_formatting(query):
     """Prepare the query string for pretty-printing by removing all unusual formatting."""

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -12,6 +12,10 @@ from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .representations import represent_float_as_str, type_check_and_str
+try:               # Python 2
+    basestring
+except NameError:  # Python 3
+    basestring = unicode = str  
 
 
 def _safe_gremlin_string(value):

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -11,6 +11,10 @@ from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .representations import represent_float_as_str, type_check_and_str
+try:               # Python 2
+    basestring
+except NameError:  # Python 3
+    basestring = unicode = str  
 
 
 def _safe_match_string(value):

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -34,8 +34,7 @@ def compare_ir_blocks(test_case, expected_blocks, received_blocks):
         test_case.fail(u'Not the same number of blocks:\n\n'
                        u'{}'.format(mismatch_message))
 
-    for i in xrange(len(expected_blocks)):
-        expected = expected_blocks[i]
+    for i, expected in enumerate(expected_blocks):
         received = received_blocks[i]
         test_case.assertEquals(expected, received,
                                msg=u'Blocks at position {} were different: {} vs {}\n\n'

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -438,7 +438,7 @@ class IrGenerationErrorTests(unittest.TestCase):
             if num_args >= len(variable_names):
                 raise AssertionError('Invalid test data, too many variables to represent.')
 
-            args = (variable_names[i] for i in xrange(num_args))
+            args = (variable_names[i] for i in range(num_args))
             array_contents = u','.join(u'"${}"'.format(x) for x in args)
             return u'[{}]'.format(array_contents)
 

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(name=package_name,
           'Programming Language :: Python :: 2.7',
       ],
       keywords='graphql database compiler orientdb',
-      python_requires='>=2.7, <3',
+      python_requires='>=2.7, <3.7',
       )


### PR DESCRIPTION
Fixes for 30 flake8 errors on Python 3...

flake8 testing of https://github.com/kensho-technologies/graphql-compiler on Python 3.6.2

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

```
./graphql_compiler/debugging_utils.py:19:18: F821 undefined name 'xrange'
        for i in xrange(0, len(too_many_parts) - 1, 2)
                 ^

./graphql_compiler/debugging_utils.py:24:14: F821 undefined name 'xrange'
    for i in xrange(1, len(parts)):
             ^

./graphql_compiler/debugging_utils.py:87:26: F821 undefined name 'xrange'
                for i in xrange(1, len(separate_keywords) - 1, 2):
                         ^

./graphql_compiler/compiler/blocks.py:55:35: F821 undefined name 'basestring'
                all(isinstance(x, basestring) for x in self.start_class)):
                                  ^

./graphql_compiler/compiler/blocks.py:98:35: F821 undefined name 'basestring'
                all(isinstance(x, basestring) for x in self.target_class)):
                                  ^

./graphql_compiler/compiler/blocks.py:256:43: F821 undefined name 'basestring'
        if not isinstance(self.direction, basestring):
                                          ^

./graphql_compiler/compiler/blocks.py:320:43: F821 undefined name 'basestring'
        if not isinstance(self.direction, basestring):
                                          ^

./graphql_compiler/compiler/blocks.py:347:22: F821 undefined name 'xrange'
            for i in xrange(self.depth + 1)
                     ^

./graphql_compiler/compiler/expressions.py:78:35: F821 undefined name 'basestring'
        if isinstance(self.value, basestring):
                                  ^

./graphql_compiler/compiler/expressions.py:102:37: F821 undefined name 'basestring'
        elif isinstance(self.value, basestring):
                                    ^

./graphql_compiler/compiler/expressions.py:107:36: F821 undefined name 'basestring'
            elif all(isinstance(x, basestring) for x in self.value):
                                   ^

./graphql_compiler/compiler/expressions.py:182:41: F821 undefined name 'unicode'
        match_variable_name = '{%s}' % (unicode(variable_with_no_dollar_sign),)
                                        ^

./graphql_compiler/compiler/expressions.py:206:20: F821 undefined name 'unicode'
            return unicode(self.variable_name)
                   ^

./graphql_compiler/compiler/expressions.py:237:16: F821 undefined name 'unicode'
        return unicode(self.field_name)
               ^

./graphql_compiler/compiler/expressions.py:619:42: F821 undefined name 'unicode'
        if not isinstance(self.operator, unicode):
                                         ^

./graphql_compiler/compiler/helpers.py:10:36: F821 undefined name 'unicode'
VARIABLE_ALLOWED_CHARS = frozenset(unicode(string.ascii_letters + string.digits + '_'))
                                   ^

./graphql_compiler/compiler/helpers.py:60:30: F821 undefined name 'basestring'
    if not isinstance(value, basestring):
                             ^

./graphql_compiler/compiler/helpers.py:62:12: F821 undefined name 'unicode'
    return unicode(value)
           ^

./graphql_compiler/compiler/helpers.py:100:30: F821 undefined name 'basestring'
    if not isinstance(value, basestring):
                             ^

./graphql_compiler/compiler/helpers.py:158:44: F821 undefined name 'basestring'
        if field and not isinstance(field, basestring):
                                           ^

./graphql_compiler/compiler/helpers.py:185:34: F821 undefined name 'basestring'
        if not isinstance(child, basestring):
                                 ^

./graphql_compiler/compiler/helpers.py:199:60: F821 undefined name 'unicode'
        mark_name = u'__'.join(self.query_path) + u'___' + unicode(self.visit_counter)
                                                           ^

./graphql_compiler/query_formatting/gremlin_formatting.py:19:30: F821 undefined name 'basestring'
    if not isinstance(value, basestring):
                             ^

./graphql_compiler/query_formatting/gremlin_formatting.py:89:43: F821 undefined name 'basestring'
        if not isinstance(argument_value, basestring):
                                          ^

./graphql_compiler/query_formatting/gremlin_formatting.py:90:30: F821 undefined name 'unicode'
            argument_value = unicode(argument_value)
                             ^

./graphql_compiler/query_formatting/match_formatting.py:18:30: F821 undefined name 'basestring'
    if not isinstance(value, basestring):
                             ^

./graphql_compiler/query_formatting/match_formatting.py:75:43: F821 undefined name 'basestring'
        if not isinstance(argument_value, basestring):
                                          ^

./graphql_compiler/query_formatting/match_formatting.py:76:30: F821 undefined name 'unicode'
            argument_value = unicode(argument_value)
                             ^

./graphql_compiler/tests/test_helpers.py:37:14: F821 undefined name 'xrange'
    for i in xrange(len(expected_blocks)):
             ^

./graphql_compiler/tests/test_ir_generation_errors.py:441:48: F821 undefined name 'xrange'
            args = (variable_names[i] for i in xrange(num_args))
                                               ^
```