### PR TITLE
Python 3 compatibility via compat.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: python
 cache: pip
 python:
-  - "2.7"
-  # - "3.6"  # enable when compliant
+  - 2.7
+  - 3.6
 install:
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ install:
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt
   - pip install -e .
+before_script:
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - pydocstyle graphql_compiler/
   - isort --check-only --verbose --recursive graphql_compiler/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ install:
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt
   - pip install -e .
-before_script:
-  - pip install flake8
-  # stop the build if there are Python syntax errors or undefined names
-  - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - pydocstyle graphql_compiler/
   - isort --check-only --verbose --recursive graphql_compiler/

--- a/graphql_compiler/compat.py
+++ b/graphql_compiler/compat.py
@@ -2,7 +2,6 @@
 
 """A minimal compatibility shim for Python 2 and Python 3."""
 
-# pylint: disable=redefined-builtin
 
 try:               # Python 2
     basestring = basestring

--- a/graphql_compiler/compat.py
+++ b/graphql_compiler/compat.py
@@ -7,7 +7,9 @@
 # pylint: disable=redefined-builtin
 
 try:               # Python 2
-    basestring
+    basestring = basestring
+    unicode = unicode
+    xrange = xrange
 except NameError:  # Python 3
     basestring = str  
     unicode = str

--- a/graphql_compiler/compat.py
+++ b/graphql_compiler/compat.py
@@ -2,6 +2,8 @@
 
 """A minimal compatibility shim for Python 2 and Python 3."""
 
+# pylint: disable=redefined-builtin
+
 
 try:               # Python 2
     basestring = basestring

--- a/graphql_compiler/compat.py
+++ b/graphql_compiler/compat.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env/python
 
-"""
-    A minimal compatibility shim for Python 2 and Python 3.
-"""
+"""A minimal compatibility shim for Python 2 and Python 3."""
 
 # pylint: disable=redefined-builtin
 
 try:               # Python 2
     basestring = basestring
     unicode = unicode
-    xrange = xrange
+    xrange = xrange          
 except NameError:  # Python 3
     basestring = str  
     unicode = str
-    xrange = range
+    xrange = range  # pylint: disable=redefined-variable-type
  

--- a/graphql_compiler/compat.py
+++ b/graphql_compiler/compat.py
@@ -7,9 +7,8 @@
 try:               # Python 2
     basestring = basestring
     unicode = unicode
-    xrange = xrange          
+    xrange = xrange
 except NameError:  # Python 3
-    basestring = str  
+    basestring = str
     unicode = str
     xrange = range  # pylint: disable=redefined-variable-type
- 

--- a/graphql_compiler/compat.py
+++ b/graphql_compiler/compat.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env/python
+
+"""
+    A minimal compatibility shim for Python 2 and Python 3.
+"""
+
+# pylint: disable=redefined-builtin
+
+try:               # Python 2
+    basestring
+except NameError:  # Python 3
+    basestring = str  
+    unicode = str
+    xrange = range
+ 

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -2,7 +2,7 @@
 from .expressions import Expression
 from .helpers import (CompilerEntity, ensure_unicode_string, safe_quoted_string,
                       validate_marked_location, validate_safe_string)
-import ..compat.py
+from ..compat import basestring, xrange
 
 class BasicBlock(CompilerEntity):
     """A basic operation block of the GraphQL compiler."""

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -4,6 +4,7 @@ from .helpers import (CompilerEntity, ensure_unicode_string, safe_quoted_string,
                       validate_marked_location, validate_safe_string)
 from ..compat import basestring, xrange
 
+
 class BasicBlock(CompilerEntity):
     """A basic operation block of the GraphQL compiler."""
 

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Kensho Technologies, Inc.
 
-from ..compat import basestring, xrange
+from ..compat import basestring, xrange  # pylint: disable=redefined-builtin
 from .expressions import Expression
 from .helpers import (CompilerEntity, ensure_unicode_string, safe_quoted_string,
                       validate_marked_location, validate_safe_string)

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -125,7 +125,7 @@ class ConstructResult(BasicBlock):
         """
         self.fields = {
             ensure_unicode_string(key): value
-            for key, value in fields.iteritems()
+            for key, value in fields.items()
         }
 
         # All key values are normalized to unicode before being passed to the parent constructor,
@@ -139,7 +139,7 @@ class ConstructResult(BasicBlock):
             raise TypeError(u'Expected dict fields, got: {} {}'.format(
                 type(self.fields).__name__, self.fields))
 
-        for key, value in self.fields.iteritems():
+        for key, value in self.fields.items():
             validate_safe_string(key)
             if not isinstance(value, Expression):
                 raise TypeError(
@@ -150,7 +150,7 @@ class ConstructResult(BasicBlock):
         """Create an updated version (if needed) of the ConstructResult via the visitor pattern."""
         new_fields = {}
 
-        for key, value in self.fields.iteritems():
+        for key, value in self.fields.items():
             new_value = value.visit_and_update(visitor_fn)
             if new_value is not value:
                 new_fields[key] = new_value

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -1,8 +1,9 @@
 # Copyright 2017 Kensho Technologies, Inc.
+
+from ..compat import basestring, xrange
 from .expressions import Expression
 from .helpers import (CompilerEntity, ensure_unicode_string, safe_quoted_string,
                       validate_marked_location, validate_safe_string)
-from ..compat import basestring, xrange
 
 
 class BasicBlock(CompilerEntity):

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -2,7 +2,7 @@
 from .expressions import Expression
 from .helpers import (CompilerEntity, ensure_unicode_string, safe_quoted_string,
                       validate_marked_location, validate_safe_string)
-
+import ..compat.py
 
 class BasicBlock(CompilerEntity):
     """A basic operation block of the GraphQL compiler."""

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -225,7 +225,7 @@ if not (vertex_directives_prohibited_on_root <= vertex_only_directives):
 
 def _validate_property_directives(directives):
     """Validate the directives that appear at a property field."""
-    for directive_name in directives.iterkeys():
+    for directive_name in directives:
         if directive_name in vertex_only_directives:
             raise GraphQLCompilationError(
                 u'Found vertex-only directive {} set on property.'.format(directive_name))
@@ -233,7 +233,7 @@ def _validate_property_directives(directives):
 
 def _validate_vertex_directives(directives):
     """Validate the directives that appear at a vertex field."""
-    for directive_name in directives.iterkeys():
+    for directive_name in directives:
         if directive_name in property_only_directives:
             raise GraphQLCompilationError(
                 u'Found property-only directive {} set on vertex.'.format(directive_name))
@@ -681,7 +681,7 @@ def _compile_root_ast_to_ir(schema, ast):
 
     # Ensure the GraphQL query root doesn't have any vertex directives
     # that are disallowed on the root node.
-    directives_present_at_root = set(_get_directives(base_ast).iterkeys())
+    directives_present_at_root = set(_get_directives(base_ast))
     disallowed_directives = directives_present_at_root & vertex_directives_prohibited_on_root
     if disallowed_directives:
         raise GraphQLCompilationError(u'Found prohibited directives on root vertex: '
@@ -697,7 +697,7 @@ def _compile_root_ast_to_ir(schema, ast):
     basic_blocks.append(_compile_output_step(outputs_context))
     output_metadata = {
         name: OutputMetadata(type=value['type'], optional=value['optional'])
-        for name, value in outputs_context.iteritems()
+        for name, value in outputs_context.items()
     }
 
     return basic_blocks, output_metadata, context['inputs'], context['location_types']
@@ -719,7 +719,7 @@ def _compile_output_step(outputs):
                                       u'one field with the @output directive.')
 
     output_fields = {}
-    for output_name, output_context in outputs.iteritems():
+    for output_name, output_context in outputs.items():
         location = output_context['location']
         optional = output_context['optional']
         graphql_type = output_context['type']

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Kensho Technologies, Inc.
 from graphql import GraphQLList, GraphQLNonNull
 
-from ..compat import basestring, unicode
+from ..compat import basestring, unicode  # pylint: disable=redefined-builtin
 from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .helpers import (CompilerEntity, Location, ensure_unicode_string, is_graphql_type,

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -5,6 +5,7 @@ from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .helpers import (CompilerEntity, Location, ensure_unicode_string, is_graphql_type,
                       safe_quoted_string, strip_non_null_from_type, validate_safe_string)
+import ..compat.py
 
 
 # Since MATCH uses $-prefixed keywords to indicate special values,

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -5,7 +5,7 @@ from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .helpers import (CompilerEntity, Location, ensure_unicode_string, is_graphql_type,
                       safe_quoted_string, strip_non_null_from_type, validate_safe_string)
-import ..compat.py
+import ..compat
 
 
 # Since MATCH uses $-prefixed keywords to indicate special values,

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -1,11 +1,11 @@
 # Copyright 2017 Kensho Technologies, Inc.
 from graphql import GraphQLList, GraphQLNonNull
 
+from ..compat import basestring, unicode
 from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .helpers import (CompilerEntity, Location, ensure_unicode_string, is_graphql_type,
                       safe_quoted_string, strip_non_null_from_type, validate_safe_string)
-import ..compat
 
 
 # Since MATCH uses $-prefixed keywords to indicate special values,

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -5,6 +5,7 @@ import string
 from graphql import GraphQLEnumType, GraphQLNonNull, GraphQLScalarType, GraphQLString, is_type
 
 from ..exceptions import GraphQLCompilationError
+import ..compat.py
 
 
 VARIABLE_ALLOWED_CHARS = frozenset(unicode(string.ascii_letters + string.digits + '_'))

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -4,7 +4,7 @@ import string
 
 from graphql import GraphQLEnumType, GraphQLNonNull, GraphQLScalarType, GraphQLString, is_type
 
-from ..compat import basestring, unicode
+from ..compat import basestring, unicode  # pylint: disable=redefined-builtin
 from ..exceptions import GraphQLCompilationError
 
 

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -4,8 +4,8 @@ import string
 
 from graphql import GraphQLEnumType, GraphQLNonNull, GraphQLScalarType, GraphQLString, is_type
 
+from ..compat import basestring, unicode
 from ..exceptions import GraphQLCompilationError
-import ..compat.py
 
 
 VARIABLE_ALLOWED_CHARS = frozenset(unicode(string.ascii_letters + string.digits + '_'))

--- a/graphql_compiler/compiler/ir_lowering_gremlin.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin.py
@@ -28,7 +28,7 @@ def lower_coerce_type_block_type_data(ir_blocks, type_equivalence_hints):
     allowed_value_type_spec = GraphQLUnionType
 
     # Validate that the type_equivalence_hints parameter has correct types.
-    for key, value in type_equivalence_hints.iteritems():
+    for key, value in type_equivalence_hints.items():
         if (not isinstance(key, allowed_key_type_spec) or
                 not isinstance(value, allowed_value_type_spec)):
             msg = (u'Invalid type equivalence hints received! Hint {} ({}) -> {} ({}) '
@@ -43,7 +43,7 @@ def lower_coerce_type_block_type_data(ir_blocks, type_equivalence_hints):
     # a dict of type name -> set of names of equivalent types, which can be used more readily.
     equivalent_type_names = {
         key.name: {x.name for x in value.types}
-        for key, value in type_equivalence_hints.iteritems()
+        for key, value in type_equivalence_hints.items()
     }
 
     new_ir_blocks = []

--- a/graphql_compiler/compiler/ir_lowering_match.py
+++ b/graphql_compiler/compiler/ir_lowering_match.py
@@ -261,7 +261,7 @@ def _flatten_location_translations(location_translations):
         location_translations: dict of Location -> Location, where the key translates to the value.
                                Mutated in place for efficiency and simplicity of implementation.
     """
-    sources_to_process = set(location_translations.iterkeys())
+    sources_to_process = set(location_translations)
 
     def _update_translation(source):
         """Return the proper (fully-flattened) translation for the given location."""

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Kensho Technologies, Inc.
 import re
-import .compat.py
+from .compat import xrange
 
 
 def remove_custom_formatting(query):

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Kensho Technologies, Inc.
-import re
 from .compat import xrange  # pylint: disable=redefined-builtin
+import re
 
 
 def remove_custom_formatting(query):

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Kensho Technologies, Inc.
-import re
 from .compat import xrange
+import re
 
 
 def remove_custom_formatting(query):

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -1,5 +1,6 @@
 # Copyright 2017 Kensho Technologies, Inc.
 import re
+import .compat.py
 
 
 def remove_custom_formatting(query):

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Kensho Technologies, Inc.
-from .compat import xrange  # pylint: disable=redefined-builtin
 import re
+
+from .compat import xrange  # pylint: disable=redefined-builtin
 
 
 def remove_custom_formatting(query):

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Kensho Technologies, Inc.
-from .compat import xrange
 import re
+from .compat import xrange
 
 
 def remove_custom_formatting(query):

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Kensho Technologies, Inc.
 import re
-from .compat import xrange
+from .compat import xrange  # pylint: disable=redefined-builtin
 
 
 def remove_custom_formatting(query):

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -10,8 +10,8 @@ def _ensure_arguments_are_provided(expected_types, arguments):
     """Ensure that all arguments expected by the query were actually provided."""
     # This function only checks that the arguments were specified,
     # and does not check types. Type checking is done as part of the actual formatting step.
-    expected_arg_names = set(expected_types.iterkeys())
-    provided_arg_names = set(arguments.iterkeys())
+    expected_arg_names = set(expected_types.keys())
+    provided_arg_names = set(arguments.keys())
 
     if expected_arg_names != provided_arg_names:
         missing_args = expected_arg_names - provided_arg_names

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -12,6 +12,7 @@ from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .representations import represent_float_as_str, type_check_and_str
+import ..compat.py
 
 
 def _safe_gremlin_string(value):

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -7,8 +7,8 @@ from string import Template
 import arrow
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 
+from ..compat import basestring, unicode  # pylint: disable=redefined-builtin
 from ..compiler import GREMLIN_LANGUAGE
-from ..compat import basestring, unicode
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -8,11 +8,11 @@ import arrow
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 
 from ..compiler import GREMLIN_LANGUAGE
+from ..compat import basestring, unicode
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .representations import represent_float_as_str, type_check_and_str
-import ..compat.py
 
 
 def _safe_gremlin_string(value):

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -144,7 +144,7 @@ def insert_arguments_into_gremlin_query(compilation_result, arguments):
     # The arguments are assumed to have already been validated against the query.
     sanitized_arguments = {
         key: _safe_gremlin_argument(argument_types[key], value)
-        for key, value in arguments.iteritems()
+        for key, value in arguments.items()
     }
 
     return Template(base_query).substitute(sanitized_arguments)

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -6,7 +6,7 @@ import json
 import arrow
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 
-from ..compat import basestring, unicode
+from ..compat import basestring, unicode  # pylint: disable=redefined-builtin
 from ..compiler import MATCH_LANGUAGE
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -6,12 +6,12 @@ import json
 import arrow
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 
+from ..compat import basestring, unicode
 from ..compiler import MATCH_LANGUAGE
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .representations import represent_float_as_str, type_check_and_str
-import ..compat.py
 
 
 def _safe_match_string(value):

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -11,6 +11,7 @@ from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .representations import represent_float_as_str, type_check_and_str
+import ..compat.py
 
 
 def _safe_match_string(value):

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -122,7 +122,7 @@ def insert_arguments_into_match_query(compilation_result, arguments):
     # The arguments are assumed to have already been validated against the query.
     sanitized_arguments = {
         key: _safe_match_argument(argument_types[key], value)
-        for key, value in arguments.iteritems()
+        for key, value in arguments.items()
     }
 
     return base_query.format(**sanitized_arguments)

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -25,7 +25,7 @@ def check_test_data(test_case, graphql_input, expected_match, expected_gremlin,
         schema_based_type_equivalence_hints = {}
         name_format = 'temp_union_{}'
         name_counter = 0
-        for key, value in type_equivalence_hints.iteritems():
+        for key, value in type_equivalence_hints.items():
             new_key = test_case.schema.get_type(key)
 
             new_value_name = name_format.format(name_counter)

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -7,7 +7,6 @@ from graphql import parse
 from graphql.utils.build_ast_schema import build_ast_schema
 
 from ..debugging_utils import pretty_print_gremlin, pretty_print_match
-import ..compat.py
 
 
 # The strings which we will be comparing have newlines and spaces we'd like to get rid of,
@@ -35,8 +34,7 @@ def compare_ir_blocks(test_case, expected_blocks, received_blocks):
         test_case.fail(u'Not the same number of blocks:\n\n'
                        u'{}'.format(mismatch_message))
 
-    for i in xrange(len(expected_blocks)):
-        expected = expected_blocks[i]
+    for i, expected in enumerate(expected_blocks):
         received = received_blocks[i]
         test_case.assertEquals(expected, received,
                                msg=u'Blocks at position {} were different: {} vs {}\n\n'
@@ -65,7 +63,7 @@ def compare_input_metadata(test_case, expected, received):
     test_case.assertEquals(set(expected.iterkeys()), set(received.iterkeys()))
 
     # Then, compare the values for each key in both dicts.
-    for key in expected.iterkeys():
+    for key in expected:
         expected_value = expected[key]
         received_value = received[key]
 

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -7,6 +7,7 @@ from graphql import parse
 from graphql.utils.build_ast_schema import build_ast_schema
 
 from ..debugging_utils import pretty_print_gremlin, pretty_print_match
+import ..compat.py
 
 
 # The strings which we will be comparing have newlines and spaces we'd like to get rid of,

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -60,7 +60,7 @@ def compare_gremlin(test_case, expected, received):
 def compare_input_metadata(test_case, expected, received):
     """Compare two dicts of input metadata, using proper GraphQL type comparison operators."""
     # First, assert that the sets of keys in both dicts are equal.
-    test_case.assertEquals(set(expected.iterkeys()), set(received.iterkeys()))
+    test_case.assertEquals(set(expected.keys()), set(received.keys()))
 
     # Then, compare the values for each key in both dicts.
     for key in expected:
@@ -195,5 +195,5 @@ def construct_location_types(location_types_as_strings):
 
     return {
         location: schema.get_type(type_name)
-        for location, type_name in location_types_as_strings.iteritems()
+        for location, type_name in location_types_as_strings.items()
     }

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -5,6 +5,7 @@ import unittest
 from ..compiler.compiler_frontend import graphql_to_ir
 from ..exceptions import GraphQLCompilationError, GraphQLParsingError, GraphQLValidationError
 from .test_helpers import get_schema
+import ..compat.py
 
 
 class IrGenerationErrorTests(unittest.TestCase):

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -5,7 +5,6 @@ import unittest
 from ..compiler.compiler_frontend import graphql_to_ir
 from ..exceptions import GraphQLCompilationError, GraphQLParsingError, GraphQLValidationError
 from .test_helpers import get_schema
-import ..compat.py
 
 
 class IrGenerationErrorTests(unittest.TestCase):
@@ -439,7 +438,7 @@ class IrGenerationErrorTests(unittest.TestCase):
             if num_args >= len(variable_names):
                 raise AssertionError('Invalid test data, too many variables to represent.')
 
-            args = (variable_names[i] for i in xrange(num_args))
+            args = (variable_names[i] for i in range(num_args))
             array_contents = u','.join(u'"${}"'.format(x) for x in args)
             return u'[{}]'.format(array_contents)
 

--- a/graphql_compiler/tests/test_safe_match_and_gremlin.py
+++ b/graphql_compiler/tests/test_safe_match_and_gremlin.py
@@ -59,7 +59,7 @@ class SafeMatchFormattingTests(unittest.TestCase):
             u'injection: ${ -> (2 + 2 == 4)}': u'"injection: ${ -> (2 + 2 == 4)}"',
         }
 
-        for input_data, expected_value in test_data.iteritems():
+        for input_data, expected_value in test_data.items():
             unicode_string = input_data
             bytes_string = input_data.encode('utf-8')
 
@@ -72,8 +72,8 @@ class SafeMatchFormattingTests(unittest.TestCase):
             self.assertEquals(expected_value, _safe_match_argument(GraphQLID, bytes_string))
 
     def test_incorrect_graphql_type_causes_errors(self):
-        for correct_graphql_type, value in REPRESENTATIVE_DATA_FOR_EACH_TYPE.iteritems():
-            for other_graphql_type in REPRESENTATIVE_DATA_FOR_EACH_TYPE.iterkeys():
+        for correct_graphql_type, value in REPRESENTATIVE_DATA_FOR_EACH_TYPE.items():
+            for other_graphql_type in REPRESENTATIVE_DATA_FOR_EACH_TYPE:
                 if correct_graphql_type.is_same_type(other_graphql_type):
                     # No error -- GraphQL type is correct.
                     _safe_match_argument(correct_graphql_type, value)
@@ -115,7 +115,7 @@ class SafeGremlinFormattingTests(unittest.TestCase):
             u'injection: ${ -> (2 + 2 == 4)}': u"'injection: ${ -> (2 + 2 == 4)}'",  # noqa
         }
 
-        for input_data, expected_value in test_data.iteritems():
+        for input_data, expected_value in test_data.items():
             unicode_string = input_data
             bytes_string = input_data.encode('utf-8')
 
@@ -128,8 +128,8 @@ class SafeGremlinFormattingTests(unittest.TestCase):
             self.assertEquals(expected_value, _safe_gremlin_argument(GraphQLID, bytes_string))
 
     def test_incorrect_graphql_type_causes_errors(self):
-        for correct_graphql_type, value in REPRESENTATIVE_DATA_FOR_EACH_TYPE.iteritems():
-            for other_graphql_type in REPRESENTATIVE_DATA_FOR_EACH_TYPE.iterkeys():
+        for correct_graphql_type, value in REPRESENTATIVE_DATA_FOR_EACH_TYPE.items():
+            for other_graphql_type in REPRESENTATIVE_DATA_FOR_EACH_TYPE:
                 if correct_graphql_type.is_same_type(other_graphql_type):
                     # No error -- GraphQL type is correct.
                     _safe_gremlin_argument(correct_graphql_type, value)

--- a/graphql_compiler/tests/test_schema.py
+++ b/graphql_compiler/tests/test_schema.py
@@ -44,7 +44,7 @@ class SchemaTests(unittest.TestCase):
             '1991-12-31': date(1991, 12, 31),
         }
 
-        for iso_date, date_obj in test_data.iteritems():
+        for iso_date, date_obj in test_data.items():
             self.assertEquals(iso_date, schema.GraphQLDate.serialize(date_obj))
             self.assertEquals(date_obj, schema.GraphQLDate.parse_value(iso_date))
 
@@ -71,6 +71,6 @@ class SchemaTests(unittest.TestCase):
         self.assertEquals(datetime(2017, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
                           schema.GraphQLDateTime.parse_value('2017-01-01T00:00:00Z'))
 
-        for iso_datetime, datetime_obj in test_data.iteritems():
+        for iso_datetime, datetime_obj in test_data.items():
             self.assertEquals(iso_datetime, schema.GraphQLDateTime.serialize(datetime_obj))
             self.assertEquals(datetime_obj, schema.GraphQLDateTime.parse_value(iso_datetime))

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(name=package_name,
           'Programming Language :: Python :: 2.7',
       ],
       keywords='graphql database compiler orientdb',
-      python_requires='>=2.7, <3',
+      python_requires='>=2.7, <3.7',
       )

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(name=package_name,
           'Programming Language :: Python :: 2.7',
       ],
       keywords='graphql database compiler orientdb',
-      python_requires='>=2.7, <3.7',
+      python_requires='>=2.7',
       )


### PR DESCRIPTION
Fixes for 30 flake8 errors on Python 3...

flake8 testing of https://github.com/kensho-technologies/graphql-compiler on Python 3.6.2

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

```
./graphql_compiler/debugging_utils.py:19:18: F821 undefined name 'xrange'
        for i in xrange(0, len(too_many_parts) - 1, 2)
                 ^

./graphql_compiler/debugging_utils.py:24:14: F821 undefined name 'xrange'
    for i in xrange(1, len(parts)):
             ^

./graphql_compiler/debugging_utils.py:87:26: F821 undefined name 'xrange'
                for i in xrange(1, len(separate_keywords) - 1, 2):
                         ^

./graphql_compiler/compiler/blocks.py:55:35: F821 undefined name 'basestring'
                all(isinstance(x, basestring) for x in self.start_class)):
                                  ^

./graphql_compiler/compiler/blocks.py:98:35: F821 undefined name 'basestring'
                all(isinstance(x, basestring) for x in self.target_class)):
                                  ^

./graphql_compiler/compiler/blocks.py:256:43: F821 undefined name 'basestring'
        if not isinstance(self.direction, basestring):
                                          ^

./graphql_compiler/compiler/blocks.py:320:43: F821 undefined name 'basestring'
        if not isinstance(self.direction, basestring):
                                          ^

./graphql_compiler/compiler/blocks.py:347:22: F821 undefined name 'xrange'
            for i in xrange(self.depth + 1)
                     ^

./graphql_compiler/compiler/expressions.py:78:35: F821 undefined name 'basestring'
        if isinstance(self.value, basestring):
                                  ^

./graphql_compiler/compiler/expressions.py:102:37: F821 undefined name 'basestring'
        elif isinstance(self.value, basestring):
                                    ^

./graphql_compiler/compiler/expressions.py:107:36: F821 undefined name 'basestring'
            elif all(isinstance(x, basestring) for x in self.value):
                                   ^

./graphql_compiler/compiler/expressions.py:182:41: F821 undefined name 'unicode'
        match_variable_name = '{%s}' % (unicode(variable_with_no_dollar_sign),)
                                        ^

./graphql_compiler/compiler/expressions.py:206:20: F821 undefined name 'unicode'
            return unicode(self.variable_name)
                   ^

./graphql_compiler/compiler/expressions.py:237:16: F821 undefined name 'unicode'
        return unicode(self.field_name)
               ^

./graphql_compiler/compiler/expressions.py:619:42: F821 undefined name 'unicode'
        if not isinstance(self.operator, unicode):
                                         ^

./graphql_compiler/compiler/helpers.py:10:36: F821 undefined name 'unicode'
VARIABLE_ALLOWED_CHARS = frozenset(unicode(string.ascii_letters + string.digits + '_'))
                                   ^

./graphql_compiler/compiler/helpers.py:60:30: F821 undefined name 'basestring'
    if not isinstance(value, basestring):
                             ^

./graphql_compiler/compiler/helpers.py:62:12: F821 undefined name 'unicode'
    return unicode(value)
           ^

./graphql_compiler/compiler/helpers.py:100:30: F821 undefined name 'basestring'
    if not isinstance(value, basestring):
                             ^

./graphql_compiler/compiler/helpers.py:158:44: F821 undefined name 'basestring'
        if field and not isinstance(field, basestring):
                                           ^

./graphql_compiler/compiler/helpers.py:185:34: F821 undefined name 'basestring'
        if not isinstance(child, basestring):
                                 ^

./graphql_compiler/compiler/helpers.py:199:60: F821 undefined name 'unicode'
        mark_name = u'__'.join(self.query_path) + u'___' + unicode(self.visit_counter)
                                                           ^

./graphql_compiler/query_formatting/gremlin_formatting.py:19:30: F821 undefined name 'basestring'
    if not isinstance(value, basestring):
                             ^

./graphql_compiler/query_formatting/gremlin_formatting.py:89:43: F821 undefined name 'basestring'
        if not isinstance(argument_value, basestring):
                                          ^

./graphql_compiler/query_formatting/gremlin_formatting.py:90:30: F821 undefined name 'unicode'
            argument_value = unicode(argument_value)
                             ^

./graphql_compiler/query_formatting/match_formatting.py:18:30: F821 undefined name 'basestring'
    if not isinstance(value, basestring):
                             ^

./graphql_compiler/query_formatting/match_formatting.py:75:43: F821 undefined name 'basestring'
        if not isinstance(argument_value, basestring):
                                          ^

./graphql_compiler/query_formatting/match_formatting.py:76:30: F821 undefined name 'unicode'
            argument_value = unicode(argument_value)
                             ^

./graphql_compiler/tests/test_helpers.py:37:14: F821 undefined name 'xrange'
    for i in xrange(len(expected_blocks)):
             ^

./graphql_compiler/tests/test_ir_generation_errors.py:441:48: F821 undefined name 'xrange'
            args = (variable_names[i] for i in xrange(num_args))
                                               ^
```