### PR TITLE
Remove assertion code from test coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,16 @@
 [run]
 # We don't want to include the tests themselves in the coverage report
 omit = graphql_compiler/tests/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code
+    def __repr__
+
+    # Don't complain if tests don't hit defensive assertion code
+    raise AssertionError
+    raise NotImplementedError

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -227,6 +227,12 @@ class IrGenerationErrorTests(unittest.TestCase):
             }
         }''')
 
+        output_with_empty_name = (GraphQLCompilationError, '''{
+            Animal @filter(op_name: "name_or_alias", value: ["$animal_name"]) {
+                name @output(out_name: "")
+            }
+        }''')
+
         output_with_duplicated_name = (GraphQLCompilationError, '''{
             Animal @filter(op_name: "name_or_alias", value: ["$animal_name"]) {
                 uuid @output(out_name: "uuid")
@@ -245,7 +251,8 @@ class IrGenerationErrorTests(unittest.TestCase):
         for expected_error, graphql in (output_on_vertex_field,
                                         output_without_name,
                                         output_with_duplicated_name,
-                                        output_with_illegal_name):
+                                        output_with_illegal_name,
+                                        output_with_empty_name,):
             with self.assertRaises(expected_error):
                 graphql_to_ir(self.schema, graphql)
 

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -233,6 +233,12 @@ class IrGenerationErrorTests(unittest.TestCase):
             }
         }''')
 
+        output_with_name_starting_with_digit = (GraphQLCompilationError, '''{
+            Animal @filter(op_name: "name_or_alias", value: ["$animal_name"]) {
+                name @output(out_name: "1uuid")
+            }
+        }''')
+
         output_with_duplicated_name = (GraphQLCompilationError, '''{
             Animal @filter(op_name: "name_or_alias", value: ["$animal_name"]) {
                 uuid @output(out_name: "uuid")
@@ -252,7 +258,8 @@ class IrGenerationErrorTests(unittest.TestCase):
                                         output_without_name,
                                         output_with_duplicated_name,
                                         output_with_illegal_name,
-                                        output_with_empty_name,):
+                                        output_with_empty_name,
+                                        output_with_name_starting_with_digit):
             with self.assertRaises(expected_error):
                 graphql_to_ir(self.schema, graphql)
 


### PR DESCRIPTION
This removes test coverage for `__repr__` methods, `AssertionError` and `NotImplementedError`. More options for the config file can be found [here](https://coverage.readthedocs.io/en/latest/config.html). 

I added a couple tests for the output directive relating to string validation. 