### PR TITLE
Add a GraphQL pretty-printer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ pip install graphql-compiler
 For a more detailed overview and getting started guide, please see
 [our blog post](https://blog.kensho.com/compiled-graphql-as-a-database-query-language-72e106844282).
 
+To pretty-print GraphQL queries, use the included pretty-printer:
+```
+python -m graphql_compiler.tool <input_file.graphql >output_file.graphql
+```
+It's modeled after Python's `json.tool`, reading from stdin and writing to stdout.
+
 ## Table of contents
   * [FAQ](#faq)
   * [Definitions](#definitions)
@@ -572,7 +578,7 @@ containing the `Animal`'s name and color in columns named `animal_name` and `col
     }
 }
 ```
-This returns one row for every `Animal` whose name contains the value supplied 
+This returns one row for every `Animal` whose name contains the value supplied
 for the `$substring` parameter. Each row contains the matching `Animal`’s name
 in a column named `animal_name`.
 

--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -3,6 +3,7 @@
 from .compiler import CompilationResult, OutputMetadata  # noqa
 from .compiler import compile_graphql_to_gremlin, compile_graphql_to_match  # noqa
 from .query_formatting import insert_arguments_into_query  # noqa
+from .query_formatting.graphql_formatting import pretty_print_graphql  # noqa
 
 from .exceptions import GraphQLError  # noqa
 from .exceptions import GraphQLParsingError, GraphQLCompilationError  # noqa

--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -1,0 +1,63 @@
+# Copyright 2017 Kensho Technologies, Inc.
+import re
+
+from graphql import parse, print_ast
+
+
+def fix_indentation_depth(query):
+    """Make indentation use 4 spaces, rather than the 2 spaces GraphQL normally uses."""
+    lines = query.split('\n')
+    final_lines = []
+
+    for line in lines:
+        consecutive_spaces = 0
+        for char in line:
+            if char == ' ':
+                consecutive_spaces += 1
+            else:
+                break
+
+        if consecutive_spaces % 2 != 0:
+            raise AssertionError(u'Indentation was not a multiple of two: '
+                                 u'{}'.format(consecutive_spaces))
+
+        final_lines.append(('  ' * consecutive_spaces) + line[consecutive_spaces:])
+
+    return '\n'.join(final_lines)
+
+
+def fix_filter_directive_order(query):
+    """Reverse the order of filter arguments. GraphQL insists on printing them backwards."""
+    filter_directive_pattern = (
+        r'@filter\('
+        r'value: \['
+        r'("[$%][a-zA-Z0-9_]+"'         # start of capture group 1 at start of this line
+        r'(?:, "[$%][a-zA-Z0-9_]+")*)'  # end of capture group 1 at end of this line
+        r'\], '
+        r'op_name: '
+        r'("[^"]+")'                    # capture group 2 on this line
+        r'\)'
+    )
+
+    replacement_pattern = (
+        r'@filter(op_name: \2, value: [\1])'
+    )
+
+    return re.sub(filter_directive_pattern, replacement_pattern, query)
+
+
+def pretty_print_graphql(query, use_four_spaces=True):
+    """Take a GraphQL query, pretty print it, and return it."""
+    # Use the built-in AST printer to get the canonical representation.
+    output = print_ast(parse(query))
+
+    # Use four spaces for indentation, to make it easier up to edit in Python source files.
+    if use_four_spaces:
+        output = fix_indentation_depth(output)
+
+    # @filter directives are much easier to read if the operation comes before the values.
+    # The default AST printer seems to like outputting the values before the operation, so
+    # the filtering operation ends up written in postfix order. Use regex to correct that.
+    output = fix_filter_directive_order(output)
+
+    return output

--- a/graphql_compiler/tests/test_graphql_pretty_print.py
+++ b/graphql_compiler/tests/test_graphql_pretty_print.py
@@ -1,0 +1,58 @@
+# Copyright 2017 Kensho Technologies, Inc.
+import unittest
+
+from ..query_formatting.graphql_formatting import pretty_print_graphql
+
+
+class GraphQLPrettyPrintTests(unittest.TestCase):
+    def test_graphql_pretty_print_indentation(self):
+        bad_query = '''{
+          Animal {
+                  name @output(out_name: "name")
+            }
+        }'''
+
+        # indentation starts at 0
+        four_space_output = '''{
+    Animal {
+        name @output(out_name: "name")
+    }
+}
+'''
+
+        two_space_output = '''{
+  Animal {
+    name @output(out_name: "name")
+  }
+}
+'''
+        self.assertEquals(four_space_output, pretty_print_graphql(bad_query))
+        self.assertEquals(two_space_output, pretty_print_graphql(bad_query, use_four_spaces=False))
+
+    def test_filter_directive_order(self):
+        bad_query = '''{
+            Animal @filter(value: ["$name"], op_name: "name_or_alias"){
+                uuid @filter(value: ["$max_uuid"], op_name: "<=")
+
+
+                out_Entity_Related {
+                  ...on Species{
+                      name @output(out_name: "related_species")
+                    }
+                }
+            }
+        }'''
+
+        expected_output = '''{
+    Animal @filter(op_name: "name_or_alias", value: ["$name"]) {
+        uuid @filter(op_name: "<=", value: ["$max_uuid"])
+        out_Entity_Related {
+            ... on Species {
+                name @output(out_name: "related_species")
+            }
+        }
+    }
+}
+'''
+
+        self.assertEquals(expected_output, pretty_print_graphql(bad_query))

--- a/graphql_compiler/tool.py
+++ b/graphql_compiler/tool.py
@@ -1,0 +1,19 @@
+# Copyright 2017 Kensho Technologies, Inc.
+"""Utility modeled after json.tool, pretty-prints GraphQL read from stdin and outputs to stdout.
+
+Used as: python -m graphql_compiler.tool
+"""
+import sys
+
+from . import pretty_print_graphql
+
+
+def main():
+    """Read a GraphQL query from standard input, and output it pretty-printed to standard output."""
+    query = ' '.join(sys.stdin.readlines())
+
+    print pretty_print_graphql(query)  # noqa
+
+
+if __name__ == '__main__':
+    main()

--- a/graphql_compiler/tool.py
+++ b/graphql_compiler/tool.py
@@ -12,7 +12,7 @@ def main():
     """Read a GraphQL query from standard input, and output it pretty-printed to standard output."""
     query = ' '.join(sys.stdin.readlines())
 
-    print pretty_print_graphql(query)  # noqa
+    sys.stdout.write(pretty_print_graphql(query))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The default GraphQL formatted is a bit human-unfriendly:
- It uses 2-space indents, which makes it difficult to work with in a 4-space Python environment.
- Since directives have no required parameter order, `@filter` gets its parameters printed backwards. That makes the operator the last parameter, and means that `@filter` is in hard-to-read postfix notation.

This fixes both those complaints.