### PR TITLE
Omit __main__ methods from test coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,5 +15,5 @@ exclude_lines =
     raise AssertionError
     raise NotImplementedError
 
+    # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
-

--- a/.coveragerc
+++ b/.coveragerc
@@ -14,3 +14,6 @@ exclude_lines =
     # Don't complain if tests don't hit defensive assertion code
     raise AssertionError
     raise NotImplementedError
+
+    if __name__ == .__main__.:
+


### PR DESCRIPTION
This adresses @ColCarroll's comment in #23 about testing `__main__` methods. 