### PR TITLE
Print directive arguments in the order that they are defined. 

### DIFF
--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -17,14 +17,13 @@ def pretty_print_graphql(query, spaces=4):
     # opposed to copying the entire class.
     import graphql
 
-    def _indent_override(spaces):
-        def indent(maybe_str):
-            if maybe_str:
-                return maybe_str.replace('\n', '\n' + ' ' * spaces)
-            return maybe_str
-        return indent
-    graphql.language.printer.indent = _indent_override(spaces)
-    
+    def indent_override(maybe_str):
+        if maybe_str:
+            return maybe_str.replace('\n', '\n' + ' ' * spaces)
+        return maybe_str
+
+    graphql.language.printer.indent = indent_override
+
     output = visit(parse(query), CustomPrintingVisitor())
     return output
 

--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -1,5 +1,4 @@
 # Copyright 2017 Kensho Technologies, Inc.
-import graphql
 from graphql import parse
 from graphql.language.printer import PrintingVisitor, wrap, join
 from graphql.language.visitor import visit
@@ -8,53 +7,55 @@ from ..schema import DIRECTIVES
 
 def pretty_print_graphql(query, spaces=4):
     """Take a GraphQL query, pretty print it, and return it."""
-    # Use four spaces for indentation, to make it easier up to edit in Python
-    # source files.
-    old_indent = graphql.language.printer.indent
+    # The graphql-core printer module has an indent function outside of the
+    # PrintingVisitor class which has two spaces hard coded. Ideally, it would
+    # be a member of the class and we could simply override it in our custom
+    # printer. To work around this we can set the function inside the module
+    # forcefully. This is undesireable as it has a global effect and relies on
+    # the implementation details of the print_ast() function, but has the
+    # advantage of only modifying the leave_Directive() method on the class as
+    # opposed to copying the entire class.
+    import graphql
+
+    def _indent_override(spaces):
+        def indent(maybe_str):
+            if maybe_str:
+                return maybe_str.replace('\n', '\n' + ' ' * spaces)
+            return maybe_str
+        return indent
     graphql.language.printer.indent = _indent_override(spaces)
-
-    output = visit(parse(query), CustomPrinter(spaces))
-
-    graphql.language.printer.indent = old_indent
-
+    
+    output = visit(parse(query), CustomPrintingVisitor())
     return output
 
 
-def _indent_override(spaces):
-    def indent(maybe_str):
-        if maybe_str:
-            return maybe_str.replace('\n', '\n' + ' ' * spaces)
-        return maybe_str
-    return indent
-
-
-class CustomPrinter(PrintingVisitor):
-    def __init__(self, spaces=2):
-        self._spaces = spaces
-
-    # @filter directives are much easier to read if the operation comes before
-    # the values. The default AST printer outputs the values
-    # before the operation, so the filtering operation ends up written in
-    # postfix order.
+class CustomPrintingVisitor(PrintingVisitor):
+    # Directives are easier to read if they are in the order in which we defined
+    # them in the schema. For example, @filter directives are much easier to
+    # read if the operation comes before the values. The arguments of the
+    # directives specified in the schema are defined as OrderedDicts which
+    # allows us to sort the provided arguments to match.
     def leave_Directive(self, node, *args):
         args = node.arguments
 
-        def _arg_order(arg, directive):
+        def _arg_index(arg, directive):
             defined_arg_names = directive.args.keys()
             # Taking [0] is ok here because the graphql parser checks for the
             # existence of ':' in directive arguments
-            arg_name = arg.split(':')[0]
+            arg_name = arg.split(':', 1)[0]
             try:
                 return defined_arg_names.index(arg_name)
             except ValueError:
                 # This argument name isn't defined in our schema but we should
-                # still pretty print it
+                # still pretty print it anyway
                 return -1
 
         try:
             directive = next(d for d in DIRECTIVES if d.name == node.name)
-            args = list(sorted(args, key=lambda a: _arg_order(a, directive)))
+            args = list(sorted(args, key=lambda a: _arg_index(a, directive)))
         except StopIteration:
+            # The directive wasn't defined in our schema, use whatever order
+            # the args appeared in within the query
             pass
 
         return '@' + node.name + wrap('(', join(args, ', '), ')')

--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -1,7 +1,8 @@
 # Copyright 2017 Kensho Technologies, Inc.
 from graphql import parse
-from graphql.language.printer import PrintingVisitor, wrap, join
+from graphql.language.printer import PrintingVisitor, join, wrap
 from graphql.language.visitor import visit
+
 from ..schema import DIRECTIVES
 
 

--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -29,11 +29,11 @@ def pretty_print_graphql(query, spaces=4):
 
 
 class CustomPrintingVisitor(PrintingVisitor):
-    # Directives are easier to read if they are in the order in which we defined
-    # them in the schema. For example, @filter directives are much easier to
-    # read if the operation comes before the values. The arguments of the
-    # directives specified in the schema are defined as OrderedDicts which
-    # allows us to sort the provided arguments to match.
+    # Directives are easier to read if their arguments appear in the order in
+    # which we defined them in the schema. For example, @filter directives are
+    # much easier to read if the operation comes before the values. The
+    # arguments of the directives specified in the schema are defined as
+    # OrderedDicts which allows us to sort the provided arguments to match.
     def leave_Directive(self, node, *args):
         args = node.arguments
 

--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -1,16 +1,31 @@
 # Copyright 2017 Kensho Technologies, Inc.
+import graphql
 from graphql import parse
 from graphql.language.printer import PrintingVisitor, wrap, join
 from graphql.language.visitor import visit
+from ..schema import DIRECTIVES
 
 
 def pretty_print_graphql(query, spaces=4):
     """Take a GraphQL query, pretty print it, and return it."""
     # Use four spaces for indentation, to make it easier up to edit in Python
     # source files.
+    old_indent = graphql.language.printer.indent
+    graphql.language.printer.indent = _indent_override(spaces)
+
     output = visit(parse(query), CustomPrinter(spaces))
 
+    graphql.language.printer.indent = old_indent
+
     return output
+
+
+def _indent_override(spaces):
+    def indent(maybe_str):
+        if maybe_str:
+            return maybe_str.replace('\n', '\n' + ' ' * spaces)
+        return maybe_str
+    return indent
 
 
 class CustomPrinter(PrintingVisitor):
@@ -18,52 +33,14 @@ class CustomPrinter(PrintingVisitor):
         self._spaces = spaces
 
     # @filter directives are much easier to read if the operation comes before
-    # the values. The default AST printer seems to like outputting the values
+    # the values. The default AST printer outputs the values
     # before the operation, so the filtering operation ends up written in
-    # postfix order. Use regex to correct that.
+    # postfix order.
     def leave_Directive(self, node, *args):
         args = node.arguments
-        if node.name == 'filter':
-            args = list(reversed(args))
+
+        for directive in DIRECTIVES:
+            if directive.name == node.name:
+                args = list(sorted(args, key=lambda a: directive.args.keys().index(a.split(':')[0])))
+
         return '@' + node.name + wrap('(', join(args, ', '), ')')
-
-    def leave_SelectionSet(self, node, *args):
-        return block(node.selections, self._spaces)
-
-    def leave_SchemaDefinition(self, node, *args):
-        return join([
-            'schema',
-            join(node.directives, ' '),
-            block(node.operation_types, self._spaces),
-            ], ' ')
-
-    def leave_ObjectTypeDefinition(self, node, *args):
-        return join([
-            'type',
-            node.name,
-            wrap('implements ', join(node.interfaces, ', ')),
-            join(node.directives, ' '),
-            block(node.fields, self._spaces)
-        ], ' ')
-
-    def leave_InterfaceTypeDefinition(self, node, *args):
-        return 'interface ' + node.name + wrap(' ', join(node.directives, ' ')) + ' ' + block(node.fields, self._spaces)
-
-    def leave_EnumTypeDefinition(self, node, *args):
-        return 'enum ' + node.name + wrap(' ', join(node.directives, ' ')) + ' ' + block(node.values, self._spaces)
-
-    def leave_InputObjectTypeDefinition(self, node, *args):
-        return 'input ' + node.name + wrap(' ', join(node.directives, ' ')) + ' ' + block(node.fields, self._spaces)
-
-
-def block(_list, spaces):
-    '''Given a list, print each item on its own line, wrapped in an indented "{ }" block.'''
-    if _list:
-        return indent('{\n' + join(_list, '\n'), spaces) + '\n}'
-    return '{}'
-
-
-def indent(maybe_str, spaces):
-    if maybe_str:
-        return maybe_str.replace('\n', '\n' + ' ' * spaces)
-    return maybe_str

--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -51,9 +51,10 @@ class CustomPrinter(PrintingVisitor):
                 # still pretty print it
                 return -1
 
-        for directive in DIRECTIVES:
-            if directive.name == node.name:
-                args = list(sorted(args, key=lambda a, d=directive: _arg_order(a, d)))
-                break
+        try:
+            directive = next(d for d in DIRECTIVES if d.name == node.name)
+            args = list(sorted(args, key=lambda a: _arg_order(a, directive)))
+        except StopIteration:
+            pass
 
         return '@' + node.name + wrap('(', join(args, ', '), ')')

--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -21,11 +21,9 @@ def pretty_print_graphql(query, spaces=4):
         if maybe_str:
             return maybe_str.replace('\n', '\n' + ' ' * spaces)
         return maybe_str
-
     graphql.language.printer.indent = indent_override
 
-    output = visit(parse(query), CustomPrintingVisitor())
-    return output
+    return visit(parse(query), CustomPrintingVisitor())
 
 
 class CustomPrintingVisitor(PrintingVisitor):

--- a/graphql_compiler/query_formatting/graphql_formatting.py
+++ b/graphql_compiler/query_formatting/graphql_formatting.py
@@ -34,6 +34,7 @@ class CustomPrintingVisitor(PrintingVisitor):
     # arguments of the directives specified in the schema are defined as
     # OrderedDicts which allows us to sort the provided arguments to match.
     def leave_Directive(self, node, *args):
+        """Call when exiting a directive node in the ast."""
         args = node.arguments
 
         def _arg_index(arg, directive):

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 import arrow
 from graphql import (DirectiveLocation, GraphQLArgument, GraphQLDirective, GraphQLInt, GraphQLList,
                      GraphQLNonNull, GraphQLScalarType, GraphQLString)
+from collections import OrderedDict
 
 
 # Constraints:
@@ -14,16 +15,16 @@ from graphql import (DirectiveLocation, GraphQLArgument, GraphQLDirective, Graph
 #   to the query at execution time.
 FilterDirective = GraphQLDirective(
     name='filter',
-    args={
-        'op_name': GraphQLArgument(
+    args=OrderedDict([(
+        'op_name', GraphQLArgument(
             type=GraphQLNonNull(GraphQLString),
             description='Name of the filter operation to perform.',
-        ),
-        'value': GraphQLArgument(
+        )),
+        ('value', GraphQLArgument(
             type=GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString))),
             description='List of string operands for the operator.',
-        ),
-    },
+        ))]
+    ),
     locations=[
         DirectiveLocation.FIELD,
         DirectiveLocation.INLINE_FRAGMENT,
@@ -38,12 +39,12 @@ FilterDirective = GraphQLDirective(
 # - cannot be applied to fields within a scope marked @fold.
 TagDirective = GraphQLDirective(
     name='tag',
-    args={
-        'tag_name': GraphQLArgument(
+    args=OrderedDict([
+        ('tag_name', GraphQLArgument(
             type=GraphQLNonNull(GraphQLString),
             description='Name to apply to the given property field.',
-        ),
-    },
+        )),
+    ]),
     locations=[
         DirectiveLocation.FIELD,
     ]
@@ -56,12 +57,12 @@ TagDirective = GraphQLDirective(
 # - can only be applied to property fields.
 OutputDirective = GraphQLDirective(
     name='output',
-    args={
-        'out_name': GraphQLArgument(
+    args=OrderedDict([
+        ('out_name', GraphQLArgument(
             type=GraphQLNonNull(GraphQLString),
             description='What to designate the output field generated from this property field.',
-        ),
-    },
+        )),
+    ]),
     locations=[
         DirectiveLocation.FIELD,
     ]
@@ -173,13 +174,13 @@ FoldDirective = GraphQLDirective(
 #   and its immediate neighbors along the specified edge.
 RecurseDirective = GraphQLDirective(
     name='recurse',
-    args={
-        'depth': GraphQLArgument(
+    args=OrderedDict([
+        ('depth', GraphQLArgument(
             type=GraphQLNonNull(GraphQLInt),
             description='Recurse up to this many times on this edge. A depth of 1 produces '
                         'the current vertex and its immediate neighbors along the given edge.',
-        ),
-    },
+        )),
+    ]),
     locations=[
         DirectiveLocation.FIELD,
     ]

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -1,10 +1,10 @@
 # Copyright 2017 Kensho Technologies, Inc.
+from collections import OrderedDict
 from datetime import date, datetime
 
 import arrow
 from graphql import (DirectiveLocation, GraphQLArgument, GraphQLDirective, GraphQLInt, GraphQLList,
                      GraphQLNonNull, GraphQLScalarType, GraphQLString)
-from collections import OrderedDict
 
 
 # Constraints:

--- a/graphql_compiler/tests/test_graphql_pretty_print.py
+++ b/graphql_compiler/tests/test_graphql_pretty_print.py
@@ -2,6 +2,7 @@
 import unittest
 
 from ..query_formatting.graphql_formatting import pretty_print_graphql
+from textwrap import dedent
 
 
 class GraphQLPrettyPrintTests(unittest.TestCase):
@@ -12,22 +13,23 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
             }
         }'''
 
-        # indentation starts at 0
-        four_space_output = '''{
-    Animal {
-        name @output(out_name: "name")
-    }
-}
-'''
+        four_space_output = dedent('''\
+        {
+            Animal {
+                name @output(out_name: "name")
+            }
+        }
+        ''')
 
-        two_space_output = '''{
-  Animal {
-    name @output(out_name: "name")
-  }
-}
-'''
+        two_space_output = dedent('''\
+        {
+          Animal {
+            name @output(out_name: "name")
+          }
+        }
+        ''')
         self.assertEquals(four_space_output, pretty_print_graphql(bad_query))
-        self.assertEquals(two_space_output, pretty_print_graphql(bad_query, use_four_spaces=False))
+        self.assertEquals(two_space_output, pretty_print_graphql(bad_query, spaces=2))
 
     def test_filter_directive_order(self):
         bad_query = '''{
@@ -43,16 +45,17 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
             }
         }'''
 
-        expected_output = '''{
-    Animal @filter(op_name: "name_or_alias", value: ["$name"]) {
-        uuid @filter(op_name: "<=", value: ["$max_uuid"])
-        out_Entity_Related {
-            ... on Species {
-                name @output(out_name: "related_species")
+        expected_output = dedent('''\
+        {
+            Animal @filter(op_name: "name_or_alias", value: ["$name"]) {
+                uuid @filter(op_name: "<=", value: ["$max_uuid"])
+                out_Entity_Related {
+                    ... on Species {
+                        name @output(out_name: "related_species")
+                    }
+                }
             }
         }
-    }
-}
-'''
+        ''')
 
         self.assertEquals(expected_output, pretty_print_graphql(bad_query))

--- a/graphql_compiler/tests/test_graphql_pretty_print.py
+++ b/graphql_compiler/tests/test_graphql_pretty_print.py
@@ -75,7 +75,7 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
 
         expected_output = dedent('''\
         {
-            Animal @filter(op_name: "name_or_alias", value: ["$name"], unkown_arg: "value") {
+            Animal @filter(op_name: "name_or_alias", value: ["$name"], unknown_arg: "value") {
                 uuid @filter(op_name: "<=", value: ["$max_uuid"])
                 out_Entity_Related {
                     ... on Species {

--- a/graphql_compiler/tests/test_graphql_pretty_print.py
+++ b/graphql_compiler/tests/test_graphql_pretty_print.py
@@ -30,7 +30,7 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
         ''')
         self.assertEquals(four_space_output, pretty_print_graphql(bad_query))
         self.assertEquals(two_space_output,
-                          pretty_print_graphql(bad_query, spaces=2))
+                          pretty_print_graphql(bad_query, use_four_spaces=False))
 
     def test_filter_directive_order(self):
         bad_query = '''{
@@ -62,7 +62,7 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
 
     def test_args_not_in_schema(self):
         bad_query = '''{
-            Animal @filter(value: ["$name"], op_name: "name_or_alias", unkown_arg: "value") {
+            Animal @filter(value: ["$name"], unkown_arg: "value", op_name: "name_or_alias") {
                 uuid @filter(value: ["$max_uuid"], op_name: "<=")
 
                 out_Entity_Related {
@@ -75,7 +75,7 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
 
         expected_output = dedent('''\
         {
-            Animal @filter(unkown_arg: "value", op_name: "name_or_alias", value: ["$name"]) {
+            Animal @filter(op_name: "name_or_alias", value: ["$name"], unkown_arg: "value") {
                 uuid @filter(op_name: "<=", value: ["$max_uuid"])
                 out_Entity_Related {
                     ... on Species {

--- a/graphql_compiler/tests/test_graphql_pretty_print.py
+++ b/graphql_compiler/tests/test_graphql_pretty_print.py
@@ -29,7 +29,8 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
         }
         ''')
         self.assertEquals(four_space_output, pretty_print_graphql(bad_query))
-        self.assertEquals(two_space_output, pretty_print_graphql(bad_query, spaces=2))
+        self.assertEquals(two_space_output,
+                          pretty_print_graphql(bad_query, spaces=2))
 
     def test_filter_directive_order(self):
         bad_query = '''{
@@ -105,6 +106,34 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
             Animal @filter(value: ["$name"]) {
                 uuid @filter(op_name: "<=", value: ["$max_uuid"])
                 out_Entity_Related {
+                    ... on Species {
+                        name @output(out_name: "related_species")
+                    }
+                }
+            }
+        }
+        ''')
+
+        self.assertEquals(expected_output, pretty_print_graphql(bad_query))
+
+    def test_other_directive(self):
+        bad_query = '''{
+            Animal @filter(value: ["$name"]) {
+                uuid @filter(value: ["$max_uuid"], op_name: "<=")
+
+                out_Entity_Related @other(arg1: "val1", arg2: "val2") {
+                  ...on Species{
+                      name @output(out_name: "related_species")
+                    }
+                }
+            }
+        }'''
+
+        expected_output = dedent('''\
+        {
+            Animal @filter(value: ["$name"]) {
+                uuid @filter(op_name: "<=", value: ["$max_uuid"])
+                out_Entity_Related @other(arg1: "val1", arg2: "val2") {
                     ... on Species {
                         name @output(out_name: "related_species")
                     }

--- a/graphql_compiler/tests/test_graphql_pretty_print.py
+++ b/graphql_compiler/tests/test_graphql_pretty_print.py
@@ -62,7 +62,7 @@ class GraphQLPrettyPrintTests(unittest.TestCase):
 
     def test_args_not_in_schema(self):
         bad_query = '''{
-            Animal @filter(value: ["$name"], unkown_arg: "value", op_name: "name_or_alias") {
+            Animal @filter(value: ["$name"], unknown_arg: "value", op_name: "name_or_alias") {
                 uuid @filter(value: ["$max_uuid"], op_name: "<=")
 
                 out_Entity_Related {

--- a/graphql_compiler/tests/test_graphql_pretty_print.py
+++ b/graphql_compiler/tests/test_graphql_pretty_print.py
@@ -1,8 +1,8 @@
 # Copyright 2017 Kensho Technologies, Inc.
+from textwrap import dedent
 import unittest
 
 from ..query_formatting.graphql_formatting import pretty_print_graphql
-from textwrap import dedent
 
 
 class GraphQLPrettyPrintTests(unittest.TestCase):

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -89,7 +89,7 @@ def get_schema():
 
         directive @recurse(depth: Int!) on FIELD
 
-        directive @filter(value: [String!]!, op_name: String!) on FIELD | INLINE_FRAGMENT
+        directive @filter(op_name: String!, value: [String!]!) on FIELD | INLINE_FRAGMENT
 
         directive @tag(tag_name: String!) on FIELD
 


### PR DESCRIPTION
Currently we are using regexs to modify the order in which `@filter` arguments appear. This accomplishes the same goal but is more general by printing directive arguments in the order that they are defined within the schema. Some hackery was required to get the desired indent behavior by forcefully setting a function in the graphql-core printer module, but this also allows a variable number of spaces. 

Using `dedent` on the spacing tests is much more readable. 
Consequentially I had to change the order of the arguments in the test helper `get_schema()` to reflect the `OrderedDict`s.