### PR TITLE
Verify that the schema contains necessary directives (#9). 

### DIFF
--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -2,6 +2,9 @@
 import string
 import unittest
 
+from graphql import parse
+from graphql.utils.build_ast_schema import build_ast_schema
+
 from ..compiler.compiler_frontend import graphql_to_ir
 from ..exceptions import GraphQLCompilationError, GraphQLParsingError, GraphQLValidationError
 from .test_helpers import get_schema
@@ -885,3 +888,45 @@ class IrGenerationErrorTests(unittest.TestCase):
         for invalid_graphql in invalid_queries:
             with self.assertRaises(GraphQLCompilationError):
                 graphql_to_ir(self.schema, invalid_graphql)
+
+    def test_directives_not_in_schema(self):
+        # The schema should define all directives used in the query.
+        # Ensure we raise an error otherwise.
+        incomplete_schema_text = '''
+            schema {
+                query: RootSchemaQuery
+            }
+
+            directive @recurse(depth: Int!) on FIELD
+
+            directive @filter(op_name: String!, value: [String!]!) on FIELD | INLINE_FRAGMENT
+
+            directive @tag(tag_name: String!) on FIELD
+
+            # The schema should have this directive
+            # directive @output(out_name: String!) on FIELD
+
+            directive @output_source on FIELD
+
+            directive @optional on FIELD
+
+            directive @fold on FIELD
+
+            type Animal {
+                name: String
+            }
+
+            type RootSchemaQuery {
+                Animal: Animal
+            }
+        '''
+        incomplete_schema = build_ast_schema(parse(incomplete_schema_text))
+
+        query = '''{
+            Animal {
+                name @output(out_name: "animal_name")
+            }
+        }'''
+
+        with self.assertRaises(GraphQLValidationError):
+            graphql_to_ir(incomplete_schema, query)


### PR DESCRIPTION
`graphql-core` already validates that the schema contains the directives used in the query via the [`known_directives`](https://github.com/graphql-python/graphql-core/blob/master/graphql/validation/rules/known_directives.py) validation rule. I've added a test to verify this behavior, but I may have misinterpreted the issue (#9): do we wish to verify that the schema contains *all* the directives, or solely the ones used within the query? 