### PR TITLE
Allow no-op type coercions within @fold scopes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ It's modeled after Python's `json.tool`, reading from stdin and writing to stdou
   * [Meta fields](#meta-fields)
   * [The GraphQL schema](#the-graphql-schema)
   * [Execution model](#execution-model)
+  * [Miscellaneous](#miscellaneous)
   * [License](#license)
 
 ## FAQ
@@ -854,6 +855,39 @@ the opposite order:
     }
 }
 ```
+
+## Miscellaneous
+
+### The optional `type_equivalence_hints` parameter
+
+This compilation parameter is a workaround for the limitations of the GraphQL and Gremlin
+type systems:
+- GraphQL does not allow `type` to inherit from another `type`, only to implement an `interface`.
+- Gremlin does not have first-class support for inheritance at all.
+
+Assume the following GraphQL schema:
+```
+type Animal {
+    name: String
+}
+
+type Cat {
+    name: String
+}
+
+type Dog {
+    name: String
+}
+
+union AnimalCatDog = Animal | Cat | Dog
+```
+
+An appropriate `type_equivalence_hints` value here would be `{ Animal: AnimalCatDog }`.
+This lets the compiler know that the `AnimalCatDog` union type is implicitly equivalent to
+the `Animal` type, as there are no other types that inherit from `Animal` in the database schema.
+This allows the compiler to perform accurate type coercions in Gremlin, as well as optimize away
+type coercions across edges of union type if the coercion is coercing to the
+union's equivalent type.
 
 ## License
 

--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -13,43 +13,24 @@ from .schema import DIRECTIVES  # noqa
 from .schema import GraphQLDate, GraphQLDateTime  # noqa
 
 
-def graphql_to_match(schema, graphql_query, parameters):
+def graphql_to_match(schema, graphql_query, parameters, type_equivalence_hints=None):
     """Compile the GraphQL input using the schema into a MATCH query and associated metadata.
 
     Args:
         schema: GraphQL schema object describing the schema of the graph to be queried
         graphql_string: the GraphQL query to compile to MATCH, as a string
         parameters: dict, mapping argument name to its value, for every parameter the query expects.
-
-    Returns:
-        a CompilationResult object, containing:
-            - query: string, the resulting compiled and parameterized query string
-            - language: string, specifying the language to which the query was compiled
-            - output_metadata: dict, output name -> OutputMetadata namedtuple object
-            - input_metadata: dict, name of input variables -> inferred GraphQL type, based on use
-    """
-    compilation_result = compile_graphql_to_match(schema, graphql_query)
-    return compilation_result._replace(
-        query=insert_arguments_into_query(compilation_result, parameters))
-
-
-def graphql_to_gremlin(schema, graphql_query, parameters, type_equivalence_hints=None):
-    """Compile the GraphQL input using the schema into a Gremlin query and associated metadata.
-
-    Args:
-        schema: GraphQL schema object describing the schema of the graph to be queried
-        graphql_string: the GraphQL query to compile to Gremlin, as a string
-        parameters: dict, mapping argument name to its value, for every parameter the query expects.
         type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
-                                Used as a workaround for Gremlin's lack of inheritance-awareness.
-                                When this parameter is not specified or is empty, type coercion
-                                coerces to the *exact* type being coerced to without regard for
-                                subclasses of that type. This parameter allows the user to
-                                manually specify which GraphQL interfaces and types are
-                                superclasses of which other types, and emits Gremlin code
-                                that performs type coercion with this information in mind.
-                                No recursive expansion of type equivalence hints will be performed,
-                                and only type-level correctness of the hints is enforced.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
                                 *****
                                 Be very careful with this option, as bad input here will
                                 lead to incorrect output queries being generated.
@@ -62,6 +43,43 @@ def graphql_to_gremlin(schema, graphql_query, parameters, type_equivalence_hints
             - output_metadata: dict, output name -> OutputMetadata namedtuple object
             - input_metadata: dict, name of input variables -> inferred GraphQL type, based on use
     """
-    compilation_result = compile_graphql_to_gremlin(schema, graphql_query)
+    compilation_result = compile_graphql_to_match(
+        schema, graphql_query, type_equivalence_hints=type_equivalence_hints)
+    return compilation_result._replace(
+        query=insert_arguments_into_query(compilation_result, parameters))
+
+
+def graphql_to_gremlin(schema, graphql_query, parameters, type_equivalence_hints=None):
+    """Compile the GraphQL input using the schema into a Gremlin query and associated metadata.
+
+    Args:
+        schema: GraphQL schema object describing the schema of the graph to be queried
+        graphql_string: the GraphQL query to compile to Gremlin, as a string
+        parameters: dict, mapping argument name to its value, for every parameter the query expects.
+        type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
+                                *****
+                                Be very careful with this option, as bad input here will
+                                lead to incorrect output queries being generated.
+                                *****
+
+    Returns:
+        a CompilationResult object, containing:
+            - query: string, the resulting compiled and parameterized query string
+            - language: string, specifying the language to which the query was compiled
+            - output_metadata: dict, output name -> OutputMetadata namedtuple object
+            - input_metadata: dict, name of input variables -> inferred GraphQL type, based on use
+    """
+    compilation_result = compile_graphql_to_gremlin(
+        schema, graphql_query, type_equivalence_hints=type_equivalence_hints)
     return compilation_result._replace(
         query=insert_arguments_into_query(compilation_result, parameters))

--- a/graphql_compiler/compiler/common.py
+++ b/graphql_compiler/compiler/common.py
@@ -43,7 +43,7 @@ def compile_graphql_to_match(schema, graphql_string, type_equivalence_hints=None
         a CompilationResult object
     """
     ir_blocks, output_metadata, input_metadata, location_types = \
-        graphql_to_ir(schema, graphql_string)
+        graphql_to_ir(schema, graphql_string, type_equivalence_hints=type_equivalence_hints)
 
     lowered_ir_blocks = ir_lowering_match.lower_ir(ir_blocks, location_types,
                                                    type_equivalence_hints=type_equivalence_hints)
@@ -83,7 +83,7 @@ def compile_graphql_to_gremlin(schema, graphql_string, type_equivalence_hints=No
         a CompilationResult object
     """
     ir_blocks, output_metadata, input_metadata, location_types = \
-        graphql_to_ir(schema, graphql_string)
+        graphql_to_ir(schema, graphql_string, type_equivalence_hints=type_equivalence_hints)
 
     lowered_ir_blocks = ir_lowering_gremlin.lower_ir(ir_blocks, location_types,
                                                      type_equivalence_hints=type_equivalence_hints)

--- a/graphql_compiler/compiler/common.py
+++ b/graphql_compiler/compiler/common.py
@@ -17,12 +17,27 @@ MATCH_LANGUAGE = 'MATCH'
 GREMLIN_LANGUAGE = 'Gremlin'
 
 
-def compile_graphql_to_match(schema, graphql_string):
+def compile_graphql_to_match(schema, graphql_string, type_equivalence_hints=None):
     """Compile the GraphQL input using the schema into a MATCH query and associated metadata.
 
     Args:
         schema: GraphQL schema object describing the schema of the graph to be queried
         graphql_string: the GraphQL query to compile to MATCH, as a string
+        type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
+                                *****
+                                Be very careful with this option, as bad input here will
+                                lead to incorrect output queries being generated.
+                                *****
 
     Returns:
         a CompilationResult object
@@ -30,7 +45,8 @@ def compile_graphql_to_match(schema, graphql_string):
     ir_blocks, output_metadata, input_metadata, location_types = \
         graphql_to_ir(schema, graphql_string)
 
-    lowered_ir_blocks = ir_lowering_match.lower_ir(ir_blocks, location_types)
+    lowered_ir_blocks = ir_lowering_match.lower_ir(ir_blocks, location_types,
+                                                   type_equivalence_hints=type_equivalence_hints)
 
     query = emit_match.emit_code_from_ir(lowered_ir_blocks)
 
@@ -48,15 +64,16 @@ def compile_graphql_to_gremlin(schema, graphql_string, type_equivalence_hints=No
         schema: GraphQL schema object describing the schema of the graph to be queried
         graphql_string: the GraphQL query to compile to Gremlin, as a string
         type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
-                                Used as a workaround for Gremlin's lack of inheritance-awareness.
-                                When this parameter is not specified or is empty, type coercion
-                                coerces to the *exact* type being coerced to without regard for
-                                subclasses of that type. This parameter allows the user to
-                                manually specify which GraphQL interfaces and types are
-                                superclasses of which other types, and emits Gremlin code
-                                that performs type coercion with this information in mind.
-                                No recursive expansion of type equivalence hints will be performed,
-                                and only type-level correctness of the hints is enforced.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
                                 *****
                                 Be very careful with this option, as bad input here will
                                 lead to incorrect output queries being generated.

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -419,6 +419,9 @@ def process_filter_directive(schema, current_schema_type, ast, context, directiv
     Returns:
         a Filter basic block that performs the requested filtering operation
     """
+    if 'fold' in context:
+        raise GraphQLCompilationError(u'Filtering within a @fold scope is not allowed!')
+
     args = get_uniquely_named_objects_by_name(directive.arguments)
     if 'op_name' not in args:
         raise AssertionError(u'op_name not found in filter directive arguments!'

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -420,7 +420,8 @@ def process_filter_directive(schema, current_schema_type, ast, context, directiv
         a Filter basic block that performs the requested filtering operation
     """
     if 'fold' in context:
-        raise GraphQLCompilationError(u'Filtering within a @fold scope is not allowed!')
+        raise AssertionError(u'Filtering within a @fold scope is not allowed, '
+                             u'and should have been caught earlier!')
 
     args = get_uniquely_named_objects_by_name(directive.arguments)
     if 'op_name' not in args:

--- a/graphql_compiler/compiler/ir_lowering_gremlin.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin.py
@@ -133,15 +133,16 @@ def lower_ir(ir_blocks, location_types, type_equivalence_hints=None):
         ir_blocks: list of IR blocks to lower into Gremlin-compatible form
         location_types: a dict of location objects -> GraphQL type objects at that location
         type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
-                                Used as a workaround for Gremlin's lack of inheritance-awareness
-                                When this parameter is not specified or is empty, type coercion
-                                coerces to the *exact* type being coerced to without regard for
-                                subclasses of that type. This parameter allows the user to
-                                manually specify which GraphQL interfaces and types are
-                                superclasses of which other types, and emits Gremlin code
-                                that performs type coercion with this information in mind.
-                                No recursive expansion of type equivalence hints will be performed,
-                                and only type-level correctness of the hints is enforced.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
                                 *****
                                 Be very careful with this option, as bad input here will
                                 lead to incorrect output queries being generated.

--- a/graphql_compiler/compiler/ir_lowering_match.py
+++ b/graphql_compiler/compiler/ir_lowering_match.py
@@ -347,12 +347,27 @@ def _translate_equivalent_locations(match_query, location_translations):
 # Public API #
 ##############
 
-def lower_ir(ir_blocks, location_types):
+def lower_ir(ir_blocks, location_types, type_equivalence_hints=None):
     """Lower the IR into an IR form that can be represented in MATCH queries.
 
     Args:
         ir_blocks: list of IR blocks to lower into MATCH-compatible form
         location_types: a dict of location objects -> GraphQL type objects at that location
+        type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
+                                *****
+                                Be very careful with this option, as bad input here will
+                                lead to incorrect output queries being generated.
+                                *****
 
     Returns:
         MatchQuery object containing the IR blocks organized in a MATCH-like structure

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -126,6 +126,7 @@ def get_schema():
             out_Animal_OfSpecies: [Species]
             out_Animal_FedAt: [Event]
             out_Animal_BornAt: [BirthEvent]
+            out_Animal_ImportantEvent: [EventOrBirthEvent]
             in_Entity_Related: [Entity]
             out_Entity_Related: [Entity]
         }
@@ -161,6 +162,7 @@ def get_schema():
             uuid: ID
             event_date: DateTime
             in_Animal_FedAt: [Animal]
+            in_Animal_ImportantEvent: [Animal]
             in_Entity_Related: [Entity]
             out_Entity_Related: [Entity]
         }
@@ -173,9 +175,13 @@ def get_schema():
             event_date: DateTime
             in_Animal_FedAt: [Animal]
             in_Animal_BornAt: [Animal]
+            in_Animal_ImportantEvent: [Animal]
             in_Entity_Related: [Entity]
             out_Entity_Related: [Entity]
         }
+
+        # Because of the above, the base type for this union is Event.
+        union EventOrBirthEvent = Event | BirthEvent
 
         type RootSchemaQuery {
             Animal: Animal


### PR DESCRIPTION
Using `@fold` on vertex fields of union type was practically impossible, since the union type requires a type coercion, and type coercions are disallowed within `@fold` scopes. This PR extends the use of the `type_equivalence_hints` optional compilation parameter, allowing the compiler to detect "no-op" coercions (e.g. from the union type to the type that a superclass of all other types in the union) and allow them inside `@fold` scopes.

See the updated test cases for examples.