### PR TITLE
Allow multiple filters on the same field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Current development version
+
+- Allow having multiple `@filter` directives on the same field
+
 ## v1.1.0
 
 - Add support for Python 3 [#31](https://github.com/kensho-technologies/graphql-compiler/pull/31)

--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ for details on the various types of filtering that the compiler currently suppor
 These operations are currently hardcoded in the compiler; in the future,
 we may enable the addition of custom filtering operations via compiler plugins.
 
+Multiple `@filter` directives may be applied to the same field at once. Conceptually,
+it is as if the different `@filter` directives were joined by SQL `AND` keywords.
+
 #### Passing Parameters
 
 The `@filter` directive accepts two types of parameters: runtime parameters and tagged parameters.

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -116,11 +116,6 @@ def _get_directives(ast):
 
     return result
 
-    try:
-        return get_uniquely_named_objects_by_name(ast.directives)
-    except ValueError as e:
-        raise GraphQLCompilationError(e)
-
 
 def _is_vertex_field_name(field_name):
     """Return True if the field name denotes a vertex field, or False if it's a property field."""


### PR DESCRIPTION
Multiple `@filter` directives behave as if joined by `AND` operators. There's no equivalent notation for `OR` at the moment, we can revisit this in the future if needed, though it may be difficult to add.

I updated the documentation as well as the code. 