### PR TITLE
Fold/Unfold blocks emitted by the front-end and processed by the back-end

### DIFF
--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -1,52 +1,11 @@
 # Copyright 2017 Kensho Technologies, Inc.
 """Definitions of the basic blocks of the compiler."""
 
-from abc import ABCMeta
-
 import six
 
-from .expressions import Expression
-from .helpers import (CompilerEntity, Location, ensure_unicode_string, safe_quoted_string,
+from .compiler_entities import BasicBlock, Expression, MarkerBlock
+from .helpers import (FoldScopeLocation, ensure_unicode_string, safe_quoted_string,
                       validate_edge_direction, validate_marked_location, validate_safe_string)
-
-
-@six.add_metaclass(ABCMeta)
-class BasicBlock(CompilerEntity):
-    """A basic operation block of the GraphQL compiler."""
-
-    def visit_and_update_expressions(self, visitor_fn):
-        """Create an updated version (if needed) of the BasicBlock via the visitor pattern.
-
-        Args:
-            visitor_fn: function that takes an Expression argument, and returns an Expression.
-                        This function is recursively called on all child Expressions that may
-                        exist within this BasicBlock. If the visitor_fn does not return the
-                        exact same object that was passed in, this is interpreted as an update
-                        request, and the visit_and_update() method will return a new BasicBlock
-                        with the given update applied. No Expressions or BasicBlocks are
-                        mutated in-place.
-
-        Returns:
-            - If the visitor_fn does not request any updates (by always returning the exact same
-              object it was called with), this method returns 'self'.
-            - Otherwise, this method returns a new BasicBlock object that reflects the updates
-              requested by the visitor_fn.
-        """
-        # Most BasicBlocks do not contain expressions, and immediately return 'self'.
-        # Any BasicBlocks that contain Expressions will override this method.
-        return self
-
-
-@six.add_metaclass(ABCMeta)
-class MarkerBlock(BasicBlock):
-    """A block that is used to mark that a context-affecting operation with no output happened."""
-
-    def to_gremlin(self):
-        """Return the Gremlin representation of the block, which should almost always be empty.
-
-        The effect of MarkerBlocks is applied during optimization and code generation steps.
-        """
-        return u''
 
 
 class QueryRoot(BasicBlock):
@@ -419,28 +378,17 @@ class OutputSource(MarkerBlock):
 class Fold(MarkerBlock):
     """A marker for the start of a @fold context."""
 
-    def __init__(self, root_location, relative_position):
+    def __init__(self, fold_scope_location):
         """Create a new Fold block rooted at the given location."""
-        super(Fold, self).__init__(root_location, relative_position)
-        self.root_location = root_location
-        # If we ever allow folds deeper than a single level,
-        # relative_position might need rethinking.
-        self.relative_position = relative_position
+        super(Fold, self).__init__(fold_scope_location)
+        self.fold_scope_location = fold_scope_location
         self.validate()
 
     def validate(self):
         """Ensure the Fold block is valid."""
-        if not isinstance(self.root_location, Location):
-            raise TypeError(u'Expected a Location for root_location, got: '
-                            u'{} {}'.format(type(self.root_location), self.root_location))
-
-        if not isinstance(self.relative_position, tuple) or not len(self.relative_position) == 2:
-            raise TypeError(u'Expected relative_position to be a tuple of two elements, got: '
-                            u'{} {}'.format(type(self.relative_position), self.relative_position))
-
-        edge_direction, edge_name = self.relative_position
-        validate_edge_direction(edge_direction)
-        validate_safe_string(edge_name)
+        if not isinstance(self.fold_scope_location, FoldScopeLocation):
+            raise TypeError(u'Expected a FoldScopeLocation for fold_scope_location, got: {} '
+                            u'{}'.format(type(self.fold_scope_location), self.fold_scope_location))
 
 
 class Unfold(MarkerBlock):

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -438,7 +438,7 @@ class Fold(MarkerBlock):
         """Ensure the Fold block is valid."""
         if not isinstance(self.root_location, Location):
             raise ValueError(u'Expected a Location for root_location, got: '
-                             u'{}'.format(self.root_location))
+                             u'{} {}'.format(type(self.root_location), self.root_location))
 
 
 class Unfold(MarkerBlock):

--- a/graphql_compiler/compiler/compiler_entities.py
+++ b/graphql_compiler/compiler/compiler_entities.py
@@ -1,0 +1,121 @@
+# Copyright 2017 Kensho Technologies, Inc.
+"""Base classes for compiler entity objects like basic blocks and expressions."""
+
+from abc import ABCMeta, abstractmethod
+
+import six
+
+
+@six.python_2_unicode_compatible
+@six.add_metaclass(ABCMeta)
+class CompilerEntity(object):
+    """An abstract compiler entity. Can represent things like basic blocks and expressions."""
+
+    def __init__(self, *args, **kwargs):
+        """Construct a new CompilerEntity."""
+        self._print_args = args
+        self._print_kwargs = kwargs
+
+    @abstractmethod
+    def validate(self):
+        """Ensure that the CompilerEntity is valid."""
+        raise NotImplementedError()
+
+    def __str__(self):
+        """Return a human-readable unicode representation of this CompilerEntity."""
+        printed_args = []
+        if self._print_args:
+            printed_args.append('{args}')
+        if self._print_kwargs:
+            printed_args.append('{kwargs}')
+
+        template = u'{cls_name}(' + u', '.join(printed_args) + u')'
+        return template.format(cls_name=type(self).__name__,
+                               args=self._print_args,
+                               kwargs=self._print_kwargs)
+
+    def __repr__(self):
+        """Return a human-readable str representation of the CompilerEntity object."""
+        return self.__str__()
+
+    # pylint: disable=protected-access
+    def __eq__(self, other):
+        """Return True if the CompilerEntity objects are equal, and False otherwise."""
+        return (type(self) == type(other) and
+                self._print_args == other._print_args and
+                self._print_kwargs == other._print_kwargs)
+    # pylint: enable=protected-access
+
+    def __ne__(self, other):
+        """Check another object for non-equality against this one."""
+        return not self.__eq__(other)
+
+    @abstractmethod
+    def to_gremlin(self):
+        """Return the Gremlin unicode string representation of this object."""
+        raise NotImplementedError()
+
+
+@six.add_metaclass(ABCMeta)
+class Expression(CompilerEntity):
+    """An expression that produces a value in the GraphQL compiler."""
+
+    def visit_and_update(self, visitor_fn):
+        """Create an updated version (if needed) of the Expression via the visitor pattern.
+
+        Args:
+            visitor_fn: function that takes an Expression argument, and returns an Expression.
+                        This function is recursively called on all child Expressions that may
+                        exist within this expression. If the visitor_fn does not return the
+                        exact same object that was passed in, this is interpreted as an update
+                        request, and the visit_and_update() method will return a new Expression
+                        with the given update applied. No Expressions are mutated in-place.
+
+        Returns:
+            - If the visitor_fn does not request any updates (by always returning the exact same
+              object it was called with), this method returns 'self'.
+            - Otherwise, this method returns a new Expression object that reflects the updates
+              requested by the visitor_fn.
+        """
+        # Most Expressions simply visit themselves.
+        # Any Expressions that contain Expressions will override this method.
+        return visitor_fn(self)
+
+
+@six.add_metaclass(ABCMeta)
+class BasicBlock(CompilerEntity):
+    """A basic operation block of the GraphQL compiler."""
+
+    def visit_and_update_expressions(self, visitor_fn):
+        """Create an updated version (if needed) of the BasicBlock via the visitor pattern.
+
+        Args:
+            visitor_fn: function that takes an Expression argument, and returns an Expression.
+                        This function is recursively called on all child Expressions that may
+                        exist within this BasicBlock. If the visitor_fn does not return the
+                        exact same object that was passed in, this is interpreted as an update
+                        request, and the visit_and_update() method will return a new BasicBlock
+                        with the given update applied. No Expressions or BasicBlocks are
+                        mutated in-place.
+
+        Returns:
+            - If the visitor_fn does not request any updates (by always returning the exact same
+              object it was called with), this method returns 'self'.
+            - Otherwise, this method returns a new BasicBlock object that reflects the updates
+              requested by the visitor_fn.
+        """
+        # Most BasicBlocks do not contain expressions, and immediately return 'self'.
+        # Any BasicBlocks that contain Expressions will override this method.
+        return self
+
+
+@six.add_metaclass(ABCMeta)
+class MarkerBlock(BasicBlock):
+    """A block that is used to mark that a context-affecting operation with no output happened."""
+
+    def to_gremlin(self):
+        """Return the Gremlin representation of the block, which should almost always be empty.
+
+        The effect of MarkerBlocks is applied during optimization and code generation steps.
+        """
+        return u''

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -293,6 +293,21 @@ def _validate_recurse_directive_types(current_schema_type, field_schema_type):
                                       u'{}'.format(current_schema_type, field_schema_type))
 
 
+def _get_edge_direction_and_name(vertex_field_name):
+    """Get the edge direction and name from a non-root vertex field name."""
+    edge_direction = None
+    edge_name = None
+    if vertex_field_name.startswith('out_'):
+        edge_direction = 'out'
+        edge_name = vertex_field_name[4:]
+    elif vertex_field_name.startswith('in_'):
+        edge_direction = 'in'
+        edge_name = vertex_field_name[3:]
+    else:
+        raise AssertionError(u'Unreachable condition reached:', vertex_field_name)
+    return edge_direction, edge_name
+
+
 def _compile_vertex_ast(schema, current_schema_type, ast,
                         location, context, local_directives, fields):
     """Return a list of basic blocks corresponding to the vertex AST node.
@@ -382,16 +397,7 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
                 context['optional'] = inner_location
                 in_topmost_optional_block = True
 
-        edge_direction = None
-        edge_name = None
-        if field_name.startswith('out_'):
-            edge_direction = 'out'
-            edge_name = field_name[4:]
-        elif field_name.startswith('in_'):
-            edge_direction = 'in'
-            edge_name = field_name[3:]
-        else:
-            raise AssertionError(u'Unreachable condition reached:', field_name)
+        edge_direction, edge_name = _get_edge_direction_and_name(field_name)
 
         if fold_directive:
             fold_block = blocks.Fold(location, (edge_direction, edge_name))

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -70,7 +70,7 @@ from .directive_helpers import (get_directives, validate_property_directives,
                                 validate_root_vertex_directives, validate_vertex_directives,
                                 validate_vertex_field_directive_interactions)
 from .filters import process_filter_directive
-from .helpers import (Location, get_ast_field_name, get_field_type_from_schema,
+from .helpers import (FoldScopeLocation, Location, get_ast_field_name, get_field_type_from_schema,
                       get_uniquely_named_objects_by_name, strip_non_null_from_type,
                       validate_safe_string)
 
@@ -400,9 +400,10 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
         edge_direction, edge_name = _get_edge_direction_and_name(field_name)
 
         if fold_directive:
-            fold_block = blocks.Fold(location, (edge_direction, edge_name))
+            fold_scope_location = FoldScopeLocation(location, (edge_direction, edge_name))
+            fold_block = blocks.Fold(fold_scope_location)
             basic_blocks.append(fold_block)
-            context['fold'] = fold_block
+            context['fold'] = fold_scope_location
         elif recurse_directive:
             recurse_depth = _get_recurse_directive_depth(field_name, inner_directives)
             _validate_recurse_directive_types(current_schema_type, field_schema_type)
@@ -444,17 +445,17 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
     return basic_blocks
 
 
-def _validate_fold_has_outputs(fold_data, outputs):
+def _validate_fold_has_outputs(fold_scope_location, outputs):
     """Ensure the @fold scope has at least one output."""
-    # At least one output in the outputs list must point to the fold_data,
-    # or the scope corresponding to fold_data had no @outputs and is illegal.
+    # At least one output in the outputs list must point to the fold_scope_location,
+    # or the scope corresponding to fold_scope_location had no @outputs and is illegal.
     for output in six.itervalues(outputs):
-        if output['fold'] is fold_data:
+        if output['fold'] == fold_scope_location:
             return True
 
     raise GraphQLCompilationError(u'Each @fold scope must contain at least one field '
                                   u'marked @output. Encountered a @fold with no outputs: '
-                                  u'{}'.format(fold_data))
+                                  u'{}'.format(fold_scope_location))
 
 
 def _compile_fragment_ast(schema, current_schema_type, ast, location, context):
@@ -682,18 +683,17 @@ def _compile_output_step(outputs):
         location = output_context['location']
         optional = output_context['optional']
         graphql_type = output_context['type']
-        fold_data = output_context['fold']
+        fold_scope_location = output_context['fold']
 
         expression = None
-        if fold_data:
+        if fold_scope_location:
             if optional:
                 raise AssertionError(u'Unreachable state reached, optional in fold: '
                                      u'{}'.format(output_context))
 
             _, field_name = location.get_location_name()
             expression = expressions.FoldedOutputContextField(
-                fold_data.root_location, fold_data.relative_position,
-                field_name, graphql_type)
+                fold_scope_location, field_name, graphql_type)
         else:
             expression = expressions.OutputContextField(location, graphql_type)
 

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -427,7 +427,7 @@ class FoldedOutputContextField(Expression):
         self.validate()
         edge_direction, edge_name = self.fold_scope_location.relative_position
 
-        mark_name, _ = self.fold_scope_location.root_location.get_location_name()
+        mark_name, _ = self.fold_scope_location.base_location.get_location_name()
         validate_safe_string(mark_name)
 
         template = u'%(mark_name)s.%(direction)s("%(edge_name)s").%(field_name)s'
@@ -460,7 +460,7 @@ class FoldedOutputContextField(Expression):
         }
         inverse_direction = inverse_direction_table[edge_direction]
 
-        mark_name, _ = self.fold_scope_location.root_location.get_location_name()
+        mark_name, _ = self.fold_scope_location.base_location.get_location_name()
         validate_safe_string(mark_name)
 
         # This template generates code like:

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -4,7 +4,8 @@ import six
 
 from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
-from .helpers import (CompilerEntity, Location, ensure_unicode_string, is_graphql_type,
+from .compiler_entities import Expression
+from .helpers import (FoldScopeLocation, Location, ensure_unicode_string, is_graphql_type,
                       safe_quoted_string, strip_non_null_from_type, validate_safe_string)
 
 
@@ -25,31 +26,6 @@ RESERVED_MATCH_KEYWORDS = frozenset({
 # These are the Java (OrientDB) representations of the ISO-8601 standard date and datetime formats.
 STANDARD_DATE_FORMAT = 'yyyy-MM-dd'
 STANDARD_DATETIME_FORMAT = 'yyyy-MM-dd\'T\'HH:mm:ssX'
-
-
-class Expression(CompilerEntity):
-    """An expression that produces a value in the GraphQL compiler."""
-
-    def visit_and_update(self, visitor_fn):
-        """Create an updated version (if needed) of the Expression via the visitor pattern.
-
-        Args:
-            visitor_fn: function that takes an Expression argument, and returns an Expression.
-                        This function is recursively called on all child Expressions that may
-                        exist within this expression. If the visitor_fn does not return the
-                        exact same object that was passed in, this is interpreted as an update
-                        request, and the visit_and_update() method will return a new Expression
-                        with the given update applied. No Expressions are mutated in-place.
-
-        Returns:
-            - If the visitor_fn does not request any updates (by always returning the exact same
-              object it was called with), this method returns 'self'.
-            - Otherwise, this method returns a new Expression object that reflects the updates
-              requested by the visitor_fn.
-        """
-        # Most Expressions simply visit themselves.
-        # Any Expressions that contain Expressions will override this method.
-        return visitor_fn(self)
 
 
 class Literal(Expression):
@@ -409,13 +385,12 @@ class OutputContextField(Expression):
 class FoldedOutputContextField(Expression):
     """An expression used to output data captured in a @fold scope."""
 
-    def __init__(self, root_location, relative_position, field_name, field_type):
+    def __init__(self, fold_scope_location, field_name, field_type):
         """Construct a new FoldedOutputContextField object for this folded field.
 
         Args:
-            root_location: Location, specifying where the @fold was applied.
-            relative_position: tuple of (edge_direction, edge_name) specifying the field's
-                               enclosing vertex field, relative to the root_location.
+            fold_scope_location: FoldScopeLocation specifying the start of the @fold scope
+                                 where this output context field was captured.
             field_name: string, the name of the field being output.
             field_type: GraphQL type object, specifying the type of the field being output.
                         Since the field is folded, this must be a GraphQLList of some kind.
@@ -423,35 +398,17 @@ class FoldedOutputContextField(Expression):
         Returns:
             new FoldedOutputContextField object
         """
-        super(FoldedOutputContextField, self).__init__(root_location, relative_position,
-                                                       field_name, field_type)
-        self.root_location = root_location
-        self.relative_position = relative_position
+        super(FoldedOutputContextField, self).__init__(fold_scope_location, field_name, field_type)
+        self.fold_scope_location = fold_scope_location
         self.field_name = field_name
         self.field_type = field_type
         self.validate()
 
     def validate(self):
         """Validate that the FoldedOutputContextField is correctly representable."""
-        if not isinstance(self.root_location, Location):
-            raise TypeError(u'Expected Location root_location, got: {} {}'.format(
-                type(self.root_location).__name__, self.root_location))
-
-        if self.root_location.field:
-            raise ValueError(u'Expected Location object that points to a vertex, got: '
-                             u'{}'.format(self.root_location))
-
-        if not isinstance(self.relative_position, tuple) or len(self.relative_position) != 2:
-            raise ValueError(u'Expected relative_position to be a tuple '
-                             u'(edge_direction, edge_name) but got: '
-                             u'{}'.format(self.relative_position))
-
-        edge_direction, edge_name = self.relative_position
-        validate_safe_string(edge_direction)
-        validate_safe_string(edge_name)
-        if edge_direction not in {'out', 'in'}:
-            raise ValueError(u'Expected relative_position[0] to be "in" or "out", '
-                             u'but got: {}'.format(edge_direction))
+        if not isinstance(self.fold_scope_location, FoldScopeLocation):
+            raise TypeError(u'Expected FoldScopeLocation fold_scope_location, got: {} {}'.format(
+                type(self.fold_scope_location), self.fold_scope_location))
 
         validate_safe_string(self.field_name)
 
@@ -468,9 +425,9 @@ class FoldedOutputContextField(Expression):
     def to_match(self):
         """Return a unicode object with the MATCH representation of this expression."""
         self.validate()
-        edge_direction, edge_name = self.relative_position
+        edge_direction, edge_name = self.fold_scope_location.relative_position
 
-        mark_name, _ = self.root_location.get_location_name()
+        mark_name, _ = self.fold_scope_location.root_location.get_location_name()
         validate_safe_string(mark_name)
 
         template = u'%(mark_name)s.%(direction)s("%(edge_name)s").%(field_name)s'
@@ -496,14 +453,14 @@ class FoldedOutputContextField(Expression):
     def to_gremlin(self):
         """Return a unicode object with the Gremlin representation of this expression."""
         self.validate()
-        edge_direction, edge_name = self.relative_position
+        edge_direction, edge_name = self.fold_scope_location.relative_position
         inverse_direction_table = {
             'out': 'in',
             'in': 'out',
         }
         inverse_direction = inverse_direction_table[edge_direction]
 
-        mark_name, _ = self.root_location.get_location_name()
+        mark_name, _ = self.fold_scope_location.root_location.get_location_name()
         validate_safe_string(mark_name)
 
         # This template generates code like:
@@ -543,8 +500,7 @@ class FoldedOutputContextField(Expression):
         # Since this object has a GraphQL type as a variable, which doesn't implement
         # the equality operator, we have to override equality and call is_same_type() here.
         return (type(self) == type(other) and
-                self.root_location == other.root_location and
-                self.relative_position == other.relative_position and
+                self.fold_scope_location == other.fold_scope_location and
                 self.field_name == other.field_name and
                 self.field_type.is_same_type(other.field_type))
 

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -115,6 +115,16 @@ def validate_safe_string(value):
         raise GraphQLCompilationError(u'Encountered illegal characters in string: {}'.format(value))
 
 
+def validate_edge_direction(edge_direction):
+    """Ensure the provided edge direction is either "in" or "out"."""
+    if not isinstance(edge_direction, six.string_types):
+        raise TypeError(u'Expected string edge_direction, got: {} {}'.format(
+                        type(edge_direction), edge_direction))
+
+    if edge_direction not in {u'in', u'out'}:
+        raise ValueError(u'Unrecognized edge direction: {}'.format(edge_direction))
+
+
 def validate_marked_location(location):
     """Validate that a Location object is safe for marking, and not at a field."""
     if not isinstance(location, Location):

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -238,25 +238,25 @@ class Location(object):
 
 @six.python_2_unicode_compatible
 class FoldScopeLocation(object):
-    def __init__(self, root_location, relative_position):
+    def __init__(self, base_location, relative_position):
         """Create a new FoldScopeLocation object. Used to represent the locations of @fold scopes.
 
         Args:
-            root_location: Location object defining where the @fold scope is rooted. In other words,
+            base_location: Location object defining where the @fold scope is rooted. In other words,
                            the location of the tightest scope that fully contains the @fold scope.
             relative_position: (edge_direction, edge_name) tuple, representing where the @fold scope
-                               lies within its root_location scope.
+                               lies within its base_location scope.
 
         Returns:
             a new FoldScopeLocation object
         """
-        if not isinstance(root_location, Location):
-            raise TypeError(u'Expected a Location for root_location, got: '
-                            u'{} {}'.format(type(root_location), root_location))
+        if not isinstance(base_location, Location):
+            raise TypeError(u'Expected a Location for base_location, got: '
+                            u'{} {}'.format(type(base_location), base_location))
 
-        if root_location.field:
+        if base_location.field:
             raise ValueError(u'Expected Location object that points to a vertex, got: '
-                             u'{}'.format(root_location))
+                             u'{}'.format(base_location))
 
         if not isinstance(relative_position, tuple) or not len(relative_position) == 2:
             raise TypeError(u'Expected relative_position to be a tuple of two elements, got: '
@@ -268,12 +268,12 @@ class FoldScopeLocation(object):
         validate_edge_direction(edge_direction)
         validate_safe_string(edge_name)
 
-        self.root_location = root_location
+        self.base_location = base_location
         self.relative_position = relative_position
 
     def __str__(self):
         """Return a human-readable str representation of the FoldScopeLocation object."""
-        return u'FoldScopeLocation({}, {})'.format(self.root_location, self.relative_position)
+        return u'FoldScopeLocation({}, {})'.format(self.base_location, self.relative_position)
 
     def __repr__(self):
         """Return a human-readable str representation of the FoldScopeLocation object."""
@@ -282,7 +282,7 @@ class FoldScopeLocation(object):
     def __eq__(self, other):
         """Return True if the FoldScopeLocations are equal, and False otherwise."""
         return (type(self) == type(other) and
-                self.root_location == other.root_location and
+                self.base_location == other.base_location and
                 self.relative_position == other.relative_position)
 
     def __ne__(self, other):
@@ -291,4 +291,4 @@ class FoldScopeLocation(object):
 
     def __hash__(self):
         """Return the object's hash value."""
-        return hash(self.root_location) ^ hash(self.relative_position)
+        return hash(self.base_location) ^ hash(self.relative_position)

--- a/graphql_compiler/compiler/ir_sanity_checks.py
+++ b/graphql_compiler/compiler/ir_sanity_checks.py
@@ -21,11 +21,24 @@ def sanity_check_ir_blocks_from_frontend(ir_blocks):
     if not ir_blocks:
         raise AssertionError(u'Received no ir_blocks: {}'.format(ir_blocks))
 
+    _sanity_check_fold_scope_locations_are_unique(ir_blocks)
     _sanity_check_no_nested_folds(ir_blocks)
     _sanity_check_query_root_block(ir_blocks)
     _sanity_check_output_source_follower_blocks(ir_blocks)
     _sanity_check_block_pairwise_constraints(ir_blocks)
     _sanity_check_every_location_is_marked(ir_blocks)
+
+
+def _sanity_check_fold_scope_locations_are_unique(ir_blocks):
+    """Assert that every FoldScopeLocation that exists on a Fold block is unique."""
+    observed_locations = dict()
+    for block in ir_blocks:
+        if isinstance(block, Fold):
+            alternate = observed_locations.get(block.fold_scope_location, None)
+            if alternate is not None:
+                raise AssertionError(u'Found two Fold blocks with identical FoldScopeLocations: '
+                                     u'{} {} {}'.format(alternate, block, ir_blocks))
+            observed_locations[block.fold_scope_location] = block
 
 
 def _sanity_check_no_nested_folds(ir_blocks):

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -1823,17 +1823,18 @@ class IrGenerationTests(unittest.TestCase):
         }'''
 
         base_location = helpers.Location(('Animal',))
+        base_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(base_location, ('out', 'Animal_ParentOf')),
+            blocks.Fold(base_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_names_list': expressions.FoldedOutputContextField(
-                    base_location, ('out', 'Animal_ParentOf'), 'name', GraphQLList(GraphQLString)),
+                    base_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
         expected_output_metadata = {
@@ -1863,21 +1864,21 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
+        parent_fold = helpers.FoldScopeLocation(parent_location, ('out', 'Animal_ParentOf'))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
             blocks.Traverse('in', 'Animal_ParentOf'),
             blocks.MarkLocation(parent_location),
-            blocks.Fold(parent_location, ('out', 'Animal_ParentOf')),
+            blocks.Fold(parent_fold),
             blocks.Unfold(),
             blocks.Backtrack(base_location),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'sibling_and_self_names_list': expressions.FoldedOutputContextField(
-                    parent_location, ('out', 'Animal_ParentOf'),
-                    'name', GraphQLList(GraphQLString)),
+                    parent_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
         expected_output_metadata = {
@@ -1907,19 +1908,20 @@ class IrGenerationTests(unittest.TestCase):
         }'''
 
         base_location = helpers.Location(('Animal',))
+        base_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(base_location, ('out', 'Animal_ParentOf')),
+            blocks.Fold(base_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_names_list': expressions.FoldedOutputContextField(
-                    base_location, ('out', 'Animal_ParentOf'), 'name', GraphQLList(GraphQLString)),
+                    base_fold, 'name', GraphQLList(GraphQLString)),
                 'child_uuids_list': expressions.FoldedOutputContextField(
-                    base_location, ('out', 'Animal_ParentOf'), 'uuid', GraphQLList(GraphQLID)),
+                    base_fold, 'uuid', GraphQLList(GraphQLID)),
             }),
         ]
         expected_output_metadata = {
@@ -1952,25 +1954,27 @@ class IrGenerationTests(unittest.TestCase):
         }'''
 
         base_location = helpers.Location(('Animal',))
+        base_out_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_in_fold = helpers.FoldScopeLocation(base_location, ('in', 'Animal_ParentOf'))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(base_location, ('out', 'Animal_ParentOf')),
+            blocks.Fold(base_out_fold),
             blocks.Unfold(),
-            blocks.Fold(base_location, ('in', 'Animal_ParentOf')),
+            blocks.Fold(base_in_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_names_list': expressions.FoldedOutputContextField(
-                    base_location, ('out', 'Animal_ParentOf'), 'name', GraphQLList(GraphQLString)),
+                    base_out_fold, 'name', GraphQLList(GraphQLString)),
                 'child_uuids_list': expressions.FoldedOutputContextField(
-                    base_location, ('out', 'Animal_ParentOf'), 'uuid', GraphQLList(GraphQLID)),
+                    base_out_fold, 'uuid', GraphQLList(GraphQLID)),
                 'parent_names_list': expressions.FoldedOutputContextField(
-                    base_location, ('in', 'Animal_ParentOf'), 'name', GraphQLList(GraphQLString)),
+                    base_in_fold, 'name', GraphQLList(GraphQLString)),
                 'parent_uuids_list': expressions.FoldedOutputContextField(
-                    base_location, ('in', 'Animal_ParentOf'), 'uuid', GraphQLList(GraphQLID)),
+                    base_in_fold, 'uuid', GraphQLList(GraphQLID)),
             }),
         ]
         expected_output_metadata = {
@@ -2003,23 +2007,23 @@ class IrGenerationTests(unittest.TestCase):
         }'''
 
         base_location = helpers.Location(('Animal',))
+        base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_fed_at_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_FedAt'))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(base_location, ('out', 'Animal_ParentOf')),
+            blocks.Fold(base_parent_fold),
             blocks.Unfold(),
-            blocks.Fold(base_location, ('out', 'Animal_FedAt')),
+            blocks.Fold(base_fed_at_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_birthdays_list': expressions.FoldedOutputContextField(
-                    base_location, ('out', 'Animal_ParentOf'),
-                    'birthday', GraphQLList(GraphQLDate)),
+                    base_parent_fold, 'birthday', GraphQLList(GraphQLDate)),
                 'fed_at_datetimes_list': expressions.FoldedOutputContextField(
-                    base_location, ('out', 'Animal_FedAt'),
-                    'event_date', GraphQLList(GraphQLDateTime)),
+                    base_fed_at_fold, 'event_date', GraphQLList(GraphQLDateTime)),
             }),
         ]
         expected_output_metadata = {

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -1827,6 +1827,8 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
+            blocks.Fold(base_location, ('out', 'Animal_ParentOf')),
+            blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
@@ -1867,6 +1869,8 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_location),
             blocks.Traverse('in', 'Animal_ParentOf'),
             blocks.MarkLocation(parent_location),
+            blocks.Fold(parent_location, ('out', 'Animal_ParentOf')),
+            blocks.Unfold(),
             blocks.Backtrack(base_location),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -1907,6 +1911,8 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
+            blocks.Fold(base_location, ('out', 'Animal_ParentOf')),
+            blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
@@ -1950,6 +1956,10 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
+            blocks.Fold(base_location, ('out', 'Animal_ParentOf')),
+            blocks.Unfold(),
+            blocks.Fold(base_location, ('in', 'Animal_ParentOf')),
+            blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
@@ -1997,6 +2007,10 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
+            blocks.Fold(base_location, ('out', 'Animal_ParentOf')),
+            blocks.Unfold(),
+            blocks.Fold(base_location, ('out', 'Animal_FedAt')),
+            blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),


### PR DESCRIPTION
- Move all the base classes for compiler entities into their own file.
- Add a new `FoldScopeLocation` object that uniquely defines where a `@fold` scope is relative to the rest of the query.
- Use the `FoldScopeLocation` to slice out the IR blocks corresponding to the contents of the `@fold` scope. For now, those contents are only the Fold/Unfold blocks, but this is where filtering and type coercions will go.
- Lots of minor refactoring and cleanup.

Left to do:
- Allow filtering and type coercions inside `@fold` scopes.
- Handle back-end query emission appropriately given that outputs may be in a `@fold` scope, based on their `FoldScopeLocation`.
- Lots of tests for filtering and type coercion inside `@fold` scopes.