### PR TITLE
Allow "name_or_alias" filtering operation on interface types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current development version
 
-- Allow having multiple `@filter` directives on the same field
+- Allow having multiple `@filter` directives on the same field [#33](https://github.com/kensho-technologies/graphql-compiler/pull/33)
+- Allow using the `name_or_alias` filtering operation on interface types
 
 ## v1.1.0
 

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -1,7 +1,8 @@
 # Copyright 2017 Kensho Technologies, Inc.
 from functools import partial, wraps
 
-from graphql import GraphQLList, GraphQLObjectType, GraphQLScalarType, GraphQLString
+from graphql import (GraphQLInterfaceType, GraphQLList, GraphQLObjectType,
+                     GraphQLScalarType, GraphQLString)
 from graphql.language.ast import ListValue
 
 from . import blocks, expressions
@@ -190,9 +191,10 @@ def _process_name_or_alias_filter_directive(schema, current_schema_type, ast,
     Returns:
         a Filter basic block that performs the check against the name or alias
     """
-    if not isinstance(current_schema_type, GraphQLObjectType):
-        raise GraphQLCompilationError(u'Cannot apply "name_or_alias" to non-object '
-                                      u'type {}'.format(current_schema_type))
+    if not isinstance(current_schema_type, (GraphQLInterfaceType, GraphQLObjectType)):
+        raise GraphQLCompilationError(u'Cannot apply "name_or_alias" to non-object, '
+                                      u'non-interface type {} '
+                                      u'{}'.format(current_schema_type, type(current_schema_type)))
 
     current_type_fields = current_schema_type.fields
     name_field = current_type_fields.get('name', None)

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -1,8 +1,8 @@
 # Copyright 2017 Kensho Technologies, Inc.
 from functools import partial, wraps
 
-from graphql import (GraphQLInterfaceType, GraphQLList, GraphQLObjectType,
-                     GraphQLScalarType, GraphQLString)
+from graphql import (GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLScalarType,
+                     GraphQLString)
 from graphql.language.ast import ListValue
 
 from . import blocks, expressions

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -108,6 +108,7 @@ def get_schema():
 
         interface Entity {
             name: String
+            alias: [String]
             description: String
             uuid: ID
             in_Entity_Related: [Entity]
@@ -129,6 +130,13 @@ def get_schema():
             out_Animal_ImportantEvent: [EventOrBirthEvent]
             in_Entity_Related: [Entity]
             out_Entity_Related: [Entity]
+            out_Animal_LivesIn: [Location]
+        }
+
+        type Location {
+            name: String
+            uuid: ID
+            in_Animal_LivesIn: [Animal]
         }
 
         type Species implements Entity {
@@ -158,6 +166,7 @@ def get_schema():
 
         type Event implements Entity {
             name: String
+            alias: [String]
             description: String
             uuid: ID
             event_date: DateTime
@@ -170,6 +179,7 @@ def get_schema():
         # Assume that in the database, the below type is actually a subclass of Event.
         type BirthEvent implements Entity {
             name: String
+            alias: [String]
             description: String
             uuid: ID
             event_date: DateTime
@@ -190,6 +200,7 @@ def get_schema():
             Event: Event
             Food: Food
             Species: Species
+            Location: Location
         }
     '''
 

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -430,7 +430,7 @@ class IrGenerationErrorTests(unittest.TestCase):
                 }
             }''',
             '''{
-                Event @filter(op_name: "name_or_alias", value: ["$foo"]) {
+                Location @filter(op_name: "name_or_alias", value: ["$foo"]) {
                     name @output(out_name: "name")
                 }
             }''',


### PR DESCRIPTION
The compiler was unnecessarily strict with checking the validity of `name_or_alias` targets, and ended up disallowing its use on interface types that contained the necessary fields. This PR relaxes that restriction and updates the schema and tests to reflect that.