### PR TITLE
Workaround for OrientDB type inconsistency when filtering lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current development version
 
+- Add workaround for [OrientDB type inconsistency when filtering lists](https://github.com/orientechnologies/orientdb/issues/7811)
+
 ## v1.2.0
 
 - **BREAKING**: Requires OrientDB 2.2.28+, since it depends on two OrientDB bugs being fixed: [bug 1](https://github.com/orientechnologies/orientdb/issues/7225) [bug 2](https://github.com/orientechnologies/orientdb/issues/7754)

--- a/graphql_compiler/compiler/emit_match.py
+++ b/graphql_compiler/compiler/emit_match.py
@@ -128,6 +128,10 @@ def _represent_fold(fold_location, fold_ir_blocks):
                                  u'{}'.format(type(block), block, fold_ir_blocks))
         final_string += u'[' + block.predicate.to_match() + u']'
 
+    # Workaround for OrientDB's inconsistent return type when filtering a list.
+    # https://github.com/orientechnologies/orientdb/issues/7811
+    final_string += '.asList()'
+
     return final_string
 
 

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -1907,7 +1907,7 @@ FROM (
                 RETURN $matches
             ) LET
                 $Animal___1___out_Animal_ParentOf =
-                    Animal___1.out("Animal_ParentOf")
+                    Animal___1.out("Animal_ParentOf").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -1958,7 +1958,7 @@ FROM (
                 RETURN $matches
             ) LET
                 $Animal__in_Animal_ParentOf___1___out_Animal_ParentOf =
-                    Animal__in_Animal_ParentOf___1.out("Animal_ParentOf")
+                    Animal__in_Animal_ParentOf___1.out("Animal_ParentOf").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2011,7 +2011,7 @@ FROM (
                 }}
                 RETURN $matches
             ) LET
-                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf")
+                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2070,8 +2070,8 @@ FROM (
                 }}
                 RETURN $matches
             ) LET
-                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf"),
-                $Animal___1___in_Animal_ParentOf = Animal___1.in("Animal_ParentOf")
+                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf").asList(),
+                $Animal___1___in_Animal_ParentOf = Animal___1.in("Animal_ParentOf").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2140,8 +2140,8 @@ FROM (
                 }}
                 RETURN $matches
             ) LET
-                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf"),
-                $Animal___1___out_Animal_FedAt = Animal___1.out("Animal_FedAt")
+                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf").asList(),
+                $Animal___1___out_Animal_FedAt = Animal___1.out("Animal_FedAt").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2204,7 +2204,8 @@ FROM (
                 }}
                 RETURN $matches
             ) LET
-                $Animal___1___out_Animal_ImportantEvent = Animal___1.out("Animal_ImportantEvent")
+                $Animal___1___out_Animal_ImportantEvent =
+                    Animal___1.out("Animal_ImportantEvent").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2255,7 +2256,7 @@ FROM (
                 }}
                 RETURN $matches
             ) LET
-                $Animal___1___out_Entity_Related = Animal___1.out("Entity_Related")
+                $Animal___1___out_Entity_Related = Animal___1.out("Entity_Related").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2305,7 +2306,7 @@ FROM (
                 RETURN $matches
             ) LET
                 $Animal___1___out_Animal_ParentOf =
-                    Animal___1.out("Animal_ParentOf")[(name = {desired})]
+                    Animal___1.out("Animal_ParentOf")[(name = {desired})].asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2369,7 +2370,7 @@ FROM (
             ) LET
                 $Animal___1___out_Animal_ParentOf =
                     Animal___1.out("Animal_ParentOf")[((name = {desired})
-                                                      OR (alias CONTAINS {desired}))]
+                                                      OR (alias CONTAINS {desired}))].asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2424,7 +2425,7 @@ FROM (
                 RETURN $matches
             ) LET
                 $Animal___1___out_Entity_Related =
-                    Animal___1.out("Entity_Related")[(@this INSTANCEOF 'Animal')]
+                    Animal___1.out("Entity_Related")[(@this INSTANCEOF 'Animal')].asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2476,7 +2477,7 @@ FROM (
                 RETURN $matches
             ) LET
                 $Animal___1___out_Animal_ImportantEvent =
-                    Animal___1.out("Animal_ImportantEvent")[(@this INSTANCEOF 'BirthEvent')]
+                   Animal___1.out("Animal_ImportantEvent")[(@this INSTANCEOF 'BirthEvent')].asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2535,7 +2536,7 @@ FROM (
             Animal___1.out("Entity_Related")[(
                 (@this INSTANCEOF 'Animal') AND
                 ((name LIKE ('%' + ({substring} + '%'))) AND
-                (birthday <= date({latest}, "yyyy-MM-dd"))))]
+                (birthday <= date({latest}, "yyyy-MM-dd"))))].asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')


### PR DESCRIPTION
Applies the workaround suggested by the OrientDB team: https://github.com/orientechnologies/orientdb/issues/7811

Since we apply the workaround on the `LET` clause itself, this has minimal cost and is independent on the number of output columns in any fold scope.