### PR TITLE
Make LET clause order deterministic. Remove unnecessary workarounds.

### DIFF
--- a/graphql_compiler/compiler/emit_match.py
+++ b/graphql_compiler/compiler/emit_match.py
@@ -173,10 +173,11 @@ def emit_code_from_ir(match_query):
     query_data.append(u'RETURN $matches)')  # Finish the MATCH query and the wrapping ().
 
     # Represent and add the LET clauses for any @fold scopes that might be part of the query.
-    fold_data = [
+    # Sort for deterministic order of clauses.
+    fold_data = sorted([
         _represent_fold(fold_location, fold_ir_blocks)
         for fold_location, fold_ir_blocks in six.iteritems(match_query.folds)
-    ]
+    ])
     if fold_data:
         query_data.append(u' LET ')
         query_data.append(fold_data[0])

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -2,8 +2,8 @@
 from functools import partial, wraps
 
 from graphql import GraphQLList, GraphQLScalarType, GraphQLString, GraphQLUnionType
-from graphql.type.definition import is_leaf_type
 from graphql.language.ast import ListValue
+from graphql.type.definition import is_leaf_type
 
 from . import blocks, expressions
 from ..exceptions import GraphQLCompilationError, GraphQLValidationError

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -1,13 +1,13 @@
 # Copyright 2017 Kensho Technologies, Inc.
 from functools import partial, wraps
 
-from graphql import (GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLScalarType,
-                     GraphQLString)
+from graphql import GraphQLList, GraphQLScalarType, GraphQLString, GraphQLUnionType
+from graphql.type.definition import is_leaf_type
 from graphql.language.ast import ListValue
 
 from . import blocks, expressions
 from ..exceptions import GraphQLCompilationError, GraphQLValidationError
-from .helpers import (get_ast_field_name, get_uniquely_named_objects_by_name, is_real_leaf_type,
+from .helpers import (get_ast_field_name, get_uniquely_named_objects_by_name, is_vertex_field_type,
                       strip_non_null_from_type, validate_safe_string)
 
 
@@ -25,8 +25,33 @@ def scalar_leaf_only(operator):
                 # Because "operator" is from an enclosing scope, it is immutable in Python 2.x.
                 current_operator = operator
 
-            if not is_real_leaf_type(current_schema_type):
+            if not is_leaf_type(current_schema_type):
                 raise GraphQLCompilationError(u'Cannot apply "{}" filter to non-leaf type'
+                                              u'{}'.format(current_operator, current_schema_type))
+            return f(schema, current_schema_type, ast, context,
+                     directive, parameters, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def vertex_field_only(operator):
+    """Ensure the filter function is only applied to vertex field types."""
+    def decorator(f):
+        """Decorate the supplied function with the "vertex_field_only" logic."""
+        @wraps(f)
+        def wrapper(schema, current_schema_type, ast, context,
+                    directive, parameters, *args, **kwargs):
+            """Check that the type on which the operator operates is a vertex field type."""
+            if 'operator' in kwargs:
+                current_operator = kwargs['operator']
+            else:
+                # Because "operator" is from an enclosing scope, it is immutable in Python 2.x.
+                current_operator = operator
+
+            if not is_vertex_field_type(current_schema_type):
+                raise GraphQLCompilationError(u'Cannot apply "{}" filter to non-vertex field:'
                                               u'{}'.format(current_operator, current_schema_type))
             return f(schema, current_schema_type, ast, context,
                      directive, parameters, *args, **kwargs)
@@ -172,6 +197,7 @@ def _process_comparison_filter_directive(schema, current_schema_type, ast,
     return blocks.Filter(final_expression)
 
 
+@vertex_field_only(u'name_or_alias')
 @takes_parameters(1)
 def _process_name_or_alias_filter_directive(schema, current_schema_type, ast,
                                             context, directive, parameters):
@@ -190,10 +216,9 @@ def _process_name_or_alias_filter_directive(schema, current_schema_type, ast,
     Returns:
         a Filter basic block that performs the check against the name or alias
     """
-    if not isinstance(current_schema_type, (GraphQLInterfaceType, GraphQLObjectType)):
-        raise GraphQLCompilationError(u'Cannot apply "name_or_alias" to non-object, '
-                                      u'non-interface type {} '
-                                      u'{}'.format(current_schema_type, type(current_schema_type)))
+    if isinstance(current_schema_type, GraphQLUnionType):
+        raise GraphQLCompilationError(u'Cannot apply "name_or_alias" to union type '
+                                      u'{}'.format(current_schema_type))
 
     current_type_fields = current_schema_type.fields
     name_field = current_type_fields.get('name', None)

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -3,7 +3,8 @@
 
 import string
 
-from graphql import GraphQLEnumType, GraphQLNonNull, GraphQLScalarType, GraphQLString, is_type
+from graphql import GraphQLNonNull, GraphQLString, is_type
+from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType, GraphQLUnionType
 import six
 
 from ..exceptions import GraphQLCompilationError
@@ -47,12 +48,11 @@ def strip_non_null_from_type(graphql_type):
     return graphql_type
 
 
-def is_real_leaf_type(graphql_type):
-    """Return True if the argument is a leaf type, and False otherwise."""
-    # HACK(predrag): Workaround for graphql-core issue:
-    #                https://github.com/graphql-python/graphql-core/issues/105
-    return isinstance(strip_non_null_from_type(graphql_type),
-                      (GraphQLScalarType, GraphQLEnumType))
+def is_vertex_field_type(graphql_type):
+    """Return True if the argument is a vertex field type, and False otherwise."""
+    # This will need to change if we ever support complex embedded types or edge field types.
+    underlying_type = strip_non_null_from_type(graphql_type)
+    return isinstance(underlying_type, (GraphQLInterfaceType, GraphQLObjectType, GraphQLUnionType))
 
 
 def is_graphql_type(graphql_type):

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2070,8 +2070,8 @@ FROM (
                 }}
                 RETURN $matches
             ) LET
-                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf").asList(),
-                $Animal___1___in_Animal_ParentOf = Animal___1.in("Animal_ParentOf").asList()
+                $Animal___1___in_Animal_ParentOf = Animal___1.in("Animal_ParentOf").asList(),
+                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')
@@ -2140,8 +2140,8 @@ FROM (
                 }}
                 RETURN $matches
             ) LET
-                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf").asList(),
-                $Animal___1___out_Animal_FedAt = Animal___1.out("Animal_FedAt").asList()
+                $Animal___1___out_Animal_FedAt = Animal___1.out("Animal_FedAt").asList(),
+                $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf").asList()
         '''
         expected_gremlin = '''
             g.V('@class', 'Animal')


### PR DESCRIPTION
We upgraded the underlying graphql-core library to 1.1 some time ago. Some of the workarounds we had in the code to compensate for pre-1.1 bugs are no longer necessary, and I am removing them.

I'm also adding a `vertex_field_only` helper which will be useful for the upcoming `has_degree` filtering operation, and making the order of LET clauses deterministic to make tests not be flaky.