### PR TITLE
Add UnaryTransformation Expression type, and Literal int values.

### DIFF
--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -518,7 +518,7 @@ class ContextFieldExistence(Expression):
 def _validate_operator_name(operator, supported_operators):
     """Ensure the named operator is valid and supported."""
     if not isinstance(operator, six.text_type):
-        raise TypeError(u'Expected unicode operator, got: {} {}'.format(
+        raise TypeError(u'Expected operator as unicode string, got: {} {}'.format(
             type(operator).__name__, operator))
 
     if operator not in supported_operators:


### PR DESCRIPTION
The new expression type and support for literal integers are necessary to express checks against the number of edges of a given type that exist in a given location.

No tests here -- they are all at the level of testing the new filter type, and implicitly cover this new code as well. This is why I'm opening the PR to a feature branch (`edge_degree_filtering`) -- I'll merge that into `master` when it's completely ready and has acceptable coverage.