### PR TITLE
Move common test input/output data to a common place.

### DIFF
--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -9,6 +9,7 @@ from . import test_input_data
 from ..compiler import OutputMetadata, compile_graphql_to_gremlin, compile_graphql_to_match
 from .test_helpers import compare_gremlin, compare_input_metadata, compare_match, get_schema
 
+
 def check_test_data(test_case, test_data, expected_match, expected_gremlin):
     """Assert that the GraphQL input generates all expected MATCH and Gremlin data."""
     if test_data.type_equivalence_hints:
@@ -32,6 +33,7 @@ def check_test_data(test_case, test_data, expected_match, expected_gremlin):
     compare_gremlin(test_case, expected_gremlin, result.query)
     test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
     compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
+
 
 class CompilerTests(unittest.TestCase):
     def setUp(self):

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -9,6 +9,7 @@ from ..compiler import OutputMetadata, compile_graphql_to_gremlin, compile_graph
 from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .test_helpers import compare_gremlin, compare_input_metadata, compare_match, get_schema
+from . import test_input_data
 
 
 def check_test_data(test_case, graphql_input, expected_match, expected_gremlin,
@@ -44,11 +45,7 @@ class CompilerTests(unittest.TestCase):
         self.schema = get_schema()
 
     def test_immediate_output(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-            }
-        }'''
+        test_data = test_input_data.immediate_output()
 
         expected_match = '''
             SELECT Animal___1.name AS `animal_name` FROM (
@@ -66,13 +63,9 @@ class CompilerTests(unittest.TestCase):
                 animal_name: m.Animal___1.name
             ])}
         '''
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
 
-        check_test_data(self, graphql_input, expected_match, expected_gremlin,
-                        expected_output_metadata, expected_input_metadata)
+        check_test_data(self, test_data.graphql_input, expected_match, expected_gremlin,
+                        test_data.expected_output_metadata, test_data.expected_input_metadata)
 
     def test_immediate_filter_and_output(self):
         # Ensure that all basic comparison operators output correct code in this simple case.

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2,13 +2,12 @@
 """End-to-end tests of the GraphQL compiler."""
 import unittest
 
-from graphql import GraphQLID, GraphQLInt, GraphQLList, GraphQLString
+from graphql import GraphQLID, GraphQLString
 import six
 
+from . import test_input_data
 from ..compiler import OutputMetadata, compile_graphql_to_gremlin, compile_graphql_to_match
 from .test_helpers import compare_gremlin, compare_input_metadata, compare_match, get_schema
-from . import test_input_data
-
 
 def check_test_data(test_case, test_data, expected_match, expected_gremlin):
     """Assert that the GraphQL input generates all expected MATCH and Gremlin data."""
@@ -33,7 +32,6 @@ def check_test_data(test_case, test_data, expected_match, expected_gremlin):
     compare_gremlin(test_case, expected_gremlin, result.query)
     test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
     compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
-
 
 class CompilerTests(unittest.TestCase):
     def setUp(self):
@@ -1650,7 +1648,6 @@ FROM (
             ])}
         '''
 
-
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
     def test_fold_after_traverse(self):
@@ -1691,7 +1688,6 @@ FROM (
             ])}
         '''
 
-
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
     def test_multiple_outputs_in_same_fold(self):
@@ -1728,7 +1724,6 @@ FROM (
                 )
             ])}
         '''
-
 
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
@@ -1780,7 +1775,6 @@ FROM (
             ])}
         '''
 
-
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
     def test_fold_date_and_datetime_fields(self):
@@ -1825,17 +1819,12 @@ FROM (
             ])}
         '''
 
-
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
     def test_coercion_to_union_base_type_inside_fold(self):
         # Given type_equivalence_hints = { Event: EventOrBirthEvent },
         # the coercion should be optimized away as a no-op.
         test_data = test_input_data.coercion_to_union_base_type_inside_fold()
-
-        type_equivalence_hints = {
-            'Event': 'EventOrBirthEvent'
-        }
 
         expected_match = '''
             SELECT
@@ -1865,7 +1854,6 @@ FROM (
                 )
             ])}
         '''
-
 
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
@@ -1900,7 +1888,6 @@ FROM (
                 )
             ])}
         '''
-
 
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
@@ -1946,7 +1933,6 @@ FROM (
             ])}
         '''
 
-
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
     def test_filter_on_fold_scope(self):
@@ -1984,7 +1970,6 @@ FROM (
             ])}
         '''
 
-
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
     def test_coercion_on_interface_within_fold_scope(self):
@@ -2020,7 +2005,6 @@ FROM (
             ])}
         '''
 
-
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
     def test_coercion_on_union_within_fold_scope(self):
@@ -2055,7 +2039,6 @@ FROM (
                 name: m.Animal___1.name
             ])}
         '''
-
 
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
@@ -2109,6 +2092,5 @@ FROM (
                 )
             ])}
         '''
-
 
         check_test_data(self, test_data, expected_match, expected_gremlin)

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -1,0 +1,30 @@
+# Copyright 2017 Kensho Technologies, Inc.
+"""Common GraphQL test inputs and expected outputs."""
+
+from collections import namedtuple
+
+from graphql import GraphQLString
+
+from ..compiler.compiler_frontend import OutputMetadata
+
+
+CommonTestData = namedtuple(
+    'CommonTestData',
+    ('graphql_input', 'expected_output_metadata', 'expected_input_metadata'))
+
+
+def immediate_output():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata)

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -3,14 +3,20 @@
 
 from collections import namedtuple
 
-from graphql import GraphQLString
+from graphql import GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 
 from ..compiler.compiler_frontend import OutputMetadata
+from ..schema import GraphQLDate, GraphQLDateTime
 
 
 CommonTestData = namedtuple(
     'CommonTestData',
-    ('graphql_input', 'expected_output_metadata', 'expected_input_metadata'))
+    (
+        'graphql_input',
+        'expected_output_metadata',
+        'expected_input_metadata',
+        'type_equivalence_hints',
+    ))
 
 
 def immediate_output():
@@ -27,4 +33,1207 @@ def immediate_output():
     return CommonTestData(
         graphql_input=graphql_input,
         expected_output_metadata=expected_output_metadata,
-        expected_input_metadata=expected_input_metadata)
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def multiple_filters():
+    graphql_input = '''{
+        Animal {
+            name @filter(op_name: ">=", value: ["$lower_bound"])
+                 @filter(op_name: "<", value: ["$upper_bound"])
+                 @output(out_name: "animal_name")
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'lower_bound': GraphQLString,
+        'upper_bound': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def traverse_and_output():
+    graphql_input = '''{
+        Animal {
+            out_Animal_ParentOf {
+                name @output(out_name: "parent_name")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'parent_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def optional_traverse_after_mandatory_traverse():
+    graphql_input = '''{
+        Animal {
+            out_Animal_OfSpecies {
+                name @output(out_name: "species_name")
+            }
+            out_Animal_ParentOf @optional {
+                name @output(out_name: "child_name")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'species_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_name': OutputMetadata(type=GraphQLString, optional=True),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def traverse_filter_and_output():
+    graphql_input = '''{
+        Animal {
+            out_Animal_ParentOf @filter(op_name: "name_or_alias", value: ["$wanted"]) {
+                name @output(out_name: "parent_name")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'parent_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'wanted': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def name_or_alias_filter_on_interface_type():
+    graphql_input = '''{
+        Animal {
+            out_Entity_Related @filter(op_name: "name_or_alias", value: ["$wanted"]) {
+                name @output(out_name: "related_entity")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'related_entity': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'wanted': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def output_source_and_complex_output():
+    graphql_input = '''{
+        Animal {
+            name @filter(op_name: "=", value: ["$wanted"]) @output(out_name: "animal_name")
+            out_Animal_ParentOf @output_source {
+                name @output(out_name: "parent_name")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'parent_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'wanted': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def filter_on_optional_variable_equality():
+    # The operand in the @filter directive originates from an optional block.
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ParentOf {
+                out_Animal_FedAt @optional {
+                    name @tag(tag_name: "child_fed_at_event")
+                }
+            }
+            out_Animal_FedAt @output_source {
+                name @filter(op_name: "=", value: ["%child_fed_at_event"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def filter_on_optional_variable_name_or_alias():
+    # The operand in the @filter directive originates from an optional block.
+    graphql_input = '''{
+        Animal {
+            in_Animal_ParentOf @optional {
+                name @tag(tag_name: "parent_name")
+            }
+            out_Animal_ParentOf @filter(op_name: "name_or_alias", value: ["%parent_name"])
+                                @output_source {
+                name @output(out_name: "animal_name")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def filter_in_optional_block():
+    graphql_input = '''{
+        Animal {
+            out_Animal_FedAt @optional {
+                name @filter(op_name: "=", value: ["$name"])
+                uuid @output(out_name: "uuid")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'uuid': OutputMetadata(type=GraphQLID, optional=True),
+    }
+    expected_input_metadata = {
+        'name': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def between_filter_on_simple_scalar():
+    # The "between" filter emits different output depending on what the compared types are.
+    # This test checks for correct code generation when the type is a simple scalar (a String).
+    graphql_input = '''{
+        Animal {
+            name @filter(op_name: "between", value: ["$lower", "$upper"])
+                 @output(out_name: "name")
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'lower': GraphQLString,
+        'upper': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def between_filter_on_date():
+    # The "between" filter emits different output depending on what the compared types are.
+    # This test checks for correct code generation when the type is a custom scalar (Date).
+    graphql_input = '''{
+        Animal {
+            birthday @filter(op_name: "between", value: ["$lower", "$upper"])
+                     @output(out_name: "birthday")
+        }
+    }'''
+    expected_output_metadata = {
+        'birthday': OutputMetadata(type=GraphQLDate, optional=False),
+    }
+    expected_input_metadata = {
+        'lower': GraphQLDate,
+        'upper': GraphQLDate,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def between_filter_on_datetime():
+    # The "between" filter emits different output depending on what the compared types are.
+    # This test checks for correct code generation when the type is a custom scalar (DateTime).
+    graphql_input = '''{
+        Event {
+            event_date @filter(op_name: "between", value: ["$lower", "$upper"])
+                       @output(out_name: "event_date")
+        }
+    }'''
+    expected_output_metadata = {
+        'event_date': OutputMetadata(type=GraphQLDateTime, optional=False),
+    }
+    expected_input_metadata = {
+        'lower': GraphQLDateTime,
+        'upper': GraphQLDateTime,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def complex_optional_variables():
+    # The operands in the @filter directives originate from an optional block.
+    graphql_input = '''{
+        Animal {
+            name @filter(op_name: "=", value: ["$animal_name"])
+            out_Animal_ParentOf {
+                out_Animal_FedAt @optional {
+                    name @tag(tag_name: "child_fed_at_event")
+                    event_date @tag(tag_name: "child_fed_at")
+                               @output(out_name: "child_fed_at")
+                }
+                in_Animal_ParentOf {
+                    out_Animal_FedAt @optional {
+                        event_date @tag(tag_name: "other_parent_fed_at")
+                                   @output(out_name: "other_parent_fed_at")
+                    }
+                }
+            }
+            in_Animal_ParentOf {
+                out_Animal_FedAt {
+                    name @filter(op_name: "=", value: ["%child_fed_at_event"])
+                    event_date @output(out_name: "grandparent_fed_at")
+                               @filter(op_name: "between",
+                                       value: ["%other_parent_fed_at", "%child_fed_at"])
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'child_fed_at': OutputMetadata(type=GraphQLDateTime, optional=True),
+        'other_parent_fed_at': OutputMetadata(type=GraphQLDateTime, optional=True),
+        'grandparent_fed_at': OutputMetadata(type=GraphQLDateTime, optional=False),
+    }
+    expected_input_metadata = {
+        'animal_name': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def simple_fragment():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Entity_Related {
+                ... on Animal {
+                    name @output(out_name: "related_animal_name")
+                    out_Animal_OfSpecies {
+                        name @output(out_name: "related_animal_species")
+                    }
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'related_animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'related_animal_species': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def simple_union():
+    graphql_input = '''{
+        Species {
+            name @output(out_name: "species_name")
+            out_Species_Eats {
+                ... on Food {
+                    name @output(out_name: "food_name")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'species_name': OutputMetadata(type=GraphQLString, optional=False),
+        'food_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def filter_on_fragment_in_union():
+    graphql_input = '''{
+        Species {
+            name @output(out_name: "species_name")
+            out_Species_Eats {
+                ... on Food @filter(op_name: "name_or_alias", value: ["$wanted"]) {
+                    name @output(out_name: "food_name")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'species_name': OutputMetadata(type=GraphQLString, optional=False),
+        'food_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'wanted': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def optional_on_union():
+    graphql_input = '''{
+        Species {
+            name @output(out_name: "species_name")
+            out_Species_Eats @optional {
+                ... on Food {
+                    name @output(out_name: "food_name")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'species_name': OutputMetadata(type=GraphQLString, optional=False),
+        'food_name': OutputMetadata(type=GraphQLString, optional=True),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def typename_output():
+    graphql_input = '''{
+        Animal {
+            __typename @output(out_name: "base_cls")
+            out_Animal_OfSpecies {
+                __typename @output(out_name: "child_cls")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'base_cls': OutputMetadata(type=GraphQLString, optional=False),
+        'child_cls': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def typename_filter():
+    graphql_input = '''{
+        Entity {
+            __typename @filter(op_name: "=", value: ["$base_cls"])
+            name @output(out_name: "entity_name")
+        }
+    }'''
+    expected_output_metadata = {
+        'entity_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'base_cls': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def simple_recurse():
+    graphql_input = '''{
+        Animal {
+            out_Animal_ParentOf @recurse(depth: 1) {
+                name @output(out_name: "relation_name")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'relation_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def recurse_within_fragment():
+    graphql_input = '''{
+        Food {
+            name @output(out_name: "food_name")
+            in_Entity_Related {
+                ... on Animal {
+                    name @output(out_name: "animal_name")
+                    out_Animal_ParentOf @recurse(depth: 3) {
+                        name @output(out_name: "relation_name")
+                    }
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'food_name': OutputMetadata(type=GraphQLString, optional=False),
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'relation_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def filter_within_recurse():
+    graphql_input = '''{
+        Animal {
+            out_Animal_ParentOf @recurse(depth: 3) {
+                name @output(out_name: "relation_name")
+                color @filter(op_name: "=", value: ["$wanted"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'relation_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'wanted': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def recurse_with_immediate_type_coercion():
+    graphql_input = '''{
+        Animal {
+            in_Entity_Related @recurse(depth: 4) {
+                ... on Animal {
+                    name @output(out_name: "name")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def recurse_with_immediate_type_coercion_and_filter():
+    graphql_input = '''{
+        Animal {
+            in_Entity_Related @recurse(depth: 4) {
+                ... on Animal {
+                    name @output(out_name: "name")
+                    color @filter(op_name: "=", value: ["$color"])
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'color': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def in_collection_op_filter_with_variable():
+    graphql_input = '''{
+        Animal {
+            name @filter(op_name: "in_collection", value: ["$wanted"])
+                 @output(out_name: "animal_name")
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'wanted': GraphQLList(GraphQLString)
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def in_collection_op_filter_with_tag():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            alias @tag(tag_name: "aliases")
+            out_Animal_ParentOf {
+                name @filter(op_name: "in_collection", value: ["%aliases"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def in_collection_op_filter_with_optional_tag():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            in_Animal_ParentOf @optional {
+                alias @tag(tag_name: "parent_aliases")
+            }
+            out_Animal_ParentOf {
+                name @filter(op_name: "in_collection", value: ["%parent_aliases"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def contains_op_filter_with_variable():
+    graphql_input = '''{
+        Animal {
+            alias @filter(op_name: "contains", value: ["$wanted"])
+            name @output(out_name: "animal_name")
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'wanted': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def contains_op_filter_with_tag():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name") @tag(tag_name: "name")
+            out_Animal_ParentOf {
+                alias @filter(op_name: "contains", value: ["%name"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def contains_op_filter_with_optional_tag():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            in_Animal_ParentOf @optional {
+                name @tag(tag_name: "parent_name")
+            }
+            out_Animal_ParentOf {
+                alias @filter(op_name: "contains", value: ["%parent_name"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def has_substring_op_filter():
+    graphql_input = '''{
+        Animal {
+            name @filter(op_name: "has_substring", value: ["$wanted"])
+                 @output(out_name: "animal_name")
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'wanted': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def has_substring_op_filter_with_optional_tag():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            in_Animal_ParentOf @optional {
+                name @tag(tag_name: "parent_name")
+            }
+            out_Animal_ParentOf {
+                name @filter(op_name: "has_substring", value: ["%parent_name"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def has_edge_degree_op_filter():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ParentOf @filter(op_name: "has_edge_degree", value: ["$child_count"])
+                                @output_source {
+                name @output(out_name: "child_name")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'child_count': GraphQLInt,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def has_edge_degree_op_filter_with_optional():
+    graphql_input = '''{
+        Species {
+            name @output(out_name: "species_name")
+
+            in_Animal_OfSpecies {
+                name @output(out_name: "parent_name")
+
+                out_Animal_ParentOf @filter(op_name: "has_edge_degree", value: ["$child_count"])
+                                    @optional {
+                    name @output(out_name: "child_name")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'species_name': OutputMetadata(type=GraphQLString, optional=False),
+        'parent_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_name': OutputMetadata(type=GraphQLString, optional=True),
+    }
+    expected_input_metadata = {
+        'child_count': GraphQLInt,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def has_edge_degree_op_filter_with_fold():
+    graphql_input = '''{
+        Species {
+            name @output(out_name: "species_name")
+
+            in_Animal_OfSpecies {
+                name @output(out_name: "parent_name")
+
+                out_Animal_ParentOf @filter(op_name: "has_edge_degree", value: ["$child_count"])
+                                    @fold {
+                    name @output(out_name: "child_names")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'species_name': OutputMetadata(type=GraphQLString, optional=False),
+        'parent_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_names': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {
+        'child_count': GraphQLInt,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def optional_traversal_edge_case():
+    # Both Animal and out_Animal_ParentOf have an out_Animal_FedAt field,
+    # ensure the correct such field is picked out.
+    graphql_input = '''{
+        Animal {
+            out_Animal_ParentOf @optional {
+                out_Animal_FedAt {
+                    name @output(out_name: "name")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=True),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def fold_on_output_variable():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ParentOf @fold {
+                name @output(out_name: "child_names_list")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def fold_after_traverse():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            in_Animal_ParentOf {
+                out_Animal_ParentOf @fold {
+                    name @output(out_name: "sibling_and_self_names_list")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'sibling_and_self_names_list': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def multiple_outputs_in_same_fold():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ParentOf @fold {
+                name @output(out_name: "child_names_list")
+                uuid @output(out_name: "child_uuids_list")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
+        'child_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def multiple_folds():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ParentOf @fold {
+                name @output(out_name: "child_names_list")
+                uuid @output(out_name: "child_uuids_list")
+            }
+            in_Animal_ParentOf @fold {
+                name @output(out_name: "parent_names_list")
+                uuid @output(out_name: "parent_uuids_list")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
+        'child_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
+        'parent_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
+        'parent_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def fold_date_and_datetime_fields():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ParentOf @fold {
+                birthday @output(out_name: "child_birthdays_list")
+            }
+            out_Animal_FedAt @fold {
+                event_date @output(out_name: "fed_at_datetimes_list")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_birthdays_list': OutputMetadata(type=GraphQLList(GraphQLDate), optional=False),
+        'fed_at_datetimes_list': OutputMetadata(
+            type=GraphQLList(GraphQLDateTime), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def coercion_to_union_base_type_inside_fold():
+    # Given type_equivalence_hints = { Event: EventOrBirthEvent },
+    # the coercion should be optimized away as a no-op.
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ImportantEvent @fold {
+                ... on Event {
+                    name @output(out_name: "important_events")
+                }
+            }
+        }
+    }'''
+    type_equivalence_hints = {
+        'Event': 'EventOrBirthEvent'
+    }
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'important_events': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=type_equivalence_hints)
+
+
+def no_op_coercion_inside_fold():
+    # The type where the coercion is applied is already Entity, so the coercion is a no-op.
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Entity_Related @fold {
+                ... on Entity {
+                    name @output(out_name: "related_entities")
+                }
+            }
+        }
+    }'''
+    type_equivalence_hints = {
+        'Event': 'EventOrBirthEvent'
+    }
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'related_entities': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=type_equivalence_hints)
+
+
+def filter_within_fold_scope():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "name")
+            out_Animal_ParentOf @fold {
+                name @filter(op_name: "=", value: ["$desired"]) @output(out_name: "child_list")
+                description @output(out_name: "child_descriptions")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_list': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+        'child_descriptions': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {
+        'desired': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def filter_on_fold_scope():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "name")
+            out_Animal_ParentOf @fold
+                                @filter(op_name: "name_or_alias", value: ["$desired"]) {
+                name @output(out_name: "child_list")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_list': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {
+        'desired': GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def coercion_on_interface_within_fold_scope():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "name")
+            out_Entity_Related @fold {
+                ... on Animal {
+                    name @output(out_name: "related_animals")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=False),
+        'related_animals': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def coercion_on_union_within_fold_scope():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "name")
+            out_Animal_ImportantEvent @fold {
+                ... on BirthEvent {
+                    name @output(out_name: "birth_events")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=False),
+        'birth_events': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def coercion_filters_and_multiple_outputs_within_fold_scope():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "name")
+            out_Entity_Related @fold {
+                ... on Animal {
+                    name @filter(op_name: "has_substring", value: ["$substring"])
+                         @output(out_name: "related_animals")
+                    birthday @filter(op_name: "<=", value: ["$latest"])
+                             @output(out_name: "related_birthdays")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'name': OutputMetadata(type=GraphQLString, optional=False),
+        'related_animals': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+        'related_birthdays': OutputMetadata(
+            type=GraphQLList(GraphQLDate), optional=False),
+    }
+    expected_input_metadata = {
+        'substring': GraphQLString,
+        'latest': GraphQLDate,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -2,7 +2,6 @@
 import unittest
 
 from graphql import GraphQLID, GraphQLInt, GraphQLList, GraphQLString
-import pytest
 import six
 
 from ..compiler import blocks, expressions, helpers
@@ -12,27 +11,25 @@ from .test_helpers import compare_input_metadata, compare_ir_blocks, get_schema
 from . import test_input_data
 
 
-def check_test_data(test_case, graphql_input, expected_blocks,
-                    expected_output_metadata, expected_input_metadata, expected_location_types,
-                    type_equivalence_hints=None):
+def check_test_data(test_case, test_data, expected_blocks, expected_location_types):
     """Assert that the GraphQL input generates all expected IR data."""
-    if type_equivalence_hints:
+    if test_data.type_equivalence_hints:
         # For test convenience, we accept the type equivalence hints in string form.
         # Here, we convert them to the required GraphQL types.
         schema_based_type_equivalence_hints = {
             test_case.schema.get_type(key): test_case.schema.get_type(value)
-            for key, value in six.iteritems(type_equivalence_hints)
+            for key, value in six.iteritems(test_data.type_equivalence_hints)
         }
     else:
         schema_based_type_equivalence_hints = None
 
-    compilation_results = graphql_to_ir(test_case.schema, graphql_input,
+    compilation_results = graphql_to_ir(test_case.schema, test_data.graphql_input,
                                         type_equivalence_hints=schema_based_type_equivalence_hints)
     received_blocks, output_metadata, input_metadata, location_types = compilation_results
 
     compare_ir_blocks(test_case, expected_blocks, received_blocks)
-    test_case.assertEqual(expected_output_metadata, output_metadata)
-    compare_input_metadata(test_case, expected_input_metadata, input_metadata)
+    test_case.assertEqual(test_data.expected_output_metadata, output_metadata)
+    compare_input_metadata(test_case, test_data.expected_input_metadata, input_metadata)
     test_case.assertEqual(expected_location_types, comparable_location_types(location_types))
 
 
@@ -69,9 +66,7 @@ class IrGenerationTests(unittest.TestCase):
             base_location: 'Animal',
         }
 
-        check_test_data(self, test_data.graphql_input, expected_blocks,
-                        test_data.expected_output_metadata, test_data.expected_input_metadata,
-                        expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_immediate_filter_and_output(self):
         # Ensure that all basic comparison operators output correct code in this simple case.
@@ -97,28 +92,26 @@ class IrGenerationTests(unittest.TestCase):
                         base_location.navigate_to_field('name'), GraphQLString)
                 }),
             ]
+            expected_location_types = {
+                base_location: 'Animal',
+            }
             expected_output_metadata = {
                 'animal_name': OutputMetadata(type=GraphQLString, optional=False),
             }
             expected_input_metadata = {
                 'wanted': GraphQLString,
             }
-            expected_location_types = {
-                base_location: 'Animal',
-            }
 
-            check_test_data(self, graphql_input, expected_blocks,
-                            expected_output_metadata, expected_input_metadata,
-                            expected_location_types)
+            test_data = test_input_data.CommonTestData(
+                graphql_input=graphql_input,
+                expected_output_metadata=expected_output_metadata,
+                expected_input_metadata=expected_input_metadata,
+                type_equivalence_hints=None)
+
+            check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_multiple_filters(self):
-        graphql_input = '''{
-            Animal {
-                name @filter(op_name: ">=", value: ["$lower_bound"])
-                     @filter(op_name: "<", value: ["$upper_bound"])
-                     @output(out_name: "animal_name")
-            }
-        }'''
+        test_data = test_input_data.multiple_filters()
 
         base_location = helpers.Location(('Animal',))
 
@@ -136,29 +129,14 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString)
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'lower_bound': GraphQLString,
-            'upper_bound': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata,
-                        expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_traverse_and_output(self):
-        graphql_input = '''{
-            Animal {
-                out_Animal_ParentOf {
-                    name @output(out_name: "parent_name")
-                }
-            }
-        }'''
+        test_data = test_input_data.traverse_and_output()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -174,29 +152,15 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString)
             }),
         ]
-        expected_output_metadata = {
-            'parent_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_optional_traverse_after_mandatory_traverse(self):
-        graphql_input = '''{
-            Animal {
-                out_Animal_OfSpecies {
-                    name @output(out_name: "species_name")
-                }
-                out_Animal_ParentOf @optional {
-                    name @output(out_name: "child_name")
-                }
-            }
-        }'''
+        test_data = test_input_data.optional_traverse_after_mandatory_traverse()
 
         base_location = helpers.Location(('Animal',))
         revisited_base_location = base_location.revisit()
@@ -225,11 +189,6 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral),
             }),
         ]
-        expected_output_metadata = {
-            'species_name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_name': OutputMetadata(type=GraphQLString, optional=True),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             species_location: 'Species',
@@ -238,17 +197,10 @@ class IrGenerationTests(unittest.TestCase):
             twice_revisited_base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_traverse_filter_and_output(self):
-        graphql_input = '''{
-            Animal {
-                out_Animal_ParentOf @filter(op_name: "name_or_alias", value: ["$wanted"]) {
-                    name @output(out_name: "parent_name")
-                }
-            }
-        }'''
+        test_data = test_input_data.traverse_filter_and_output()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -278,28 +230,15 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'parent_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'wanted': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_name_or_alias_filter_on_interface_type(self):
-        graphql_input = '''{
-            Animal {
-                out_Entity_Related @filter(op_name: "name_or_alias", value: ["$wanted"]) {
-                    name @output(out_name: "related_entity")
-                }
-            }
-        }'''
+        test_data = test_input_data.name_or_alias_filter_on_interface_type()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Entity_Related')
@@ -329,29 +268,15 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'related_entity': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'wanted': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Entity',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_output_source_and_complex_output(self):
-        graphql_input = '''{
-            Animal {
-                name @filter(op_name: "=", value: ["$wanted"]) @output(out_name: "animal_name")
-                out_Animal_ParentOf @output_source {
-                    name @output(out_name: "parent_name")
-                }
-            }
-        }'''
+        test_data = test_input_data.output_source_and_complex_output()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -376,37 +301,17 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'parent_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'wanted': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_filter_on_optional_variable_equality(self):
-        # The operand in the @filter directive originates from an optional block.
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Animal_ParentOf {
-                    out_Animal_FedAt @optional {
-                        name @tag(tag_name: "child_fed_at_event")
-                    }
-                }
-                out_Animal_FedAt @output_source {
-                    name @filter(op_name: "=", value: ["%child_fed_at_event"])
-                }
-            }
-        }'''
+        test_data = test_input_data.filter_on_optional_variable_equality()
 
+        # The operand in the @filter directive originates from an optional block.
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         child_fed_at_location = child_location.navigate_to_subpath('out_Animal_FedAt')
@@ -446,10 +351,6 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
@@ -458,23 +359,12 @@ class IrGenerationTests(unittest.TestCase):
             animal_fed_at_location: 'Event',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_filter_on_optional_variable_name_or_alias(self):
-        # The operand in the @filter directive originates from an optional block.
-        graphql_input = '''{
-            Animal {
-                in_Animal_ParentOf @optional {
-                    name @tag(tag_name: "parent_name")
-                }
-                out_Animal_ParentOf @filter(op_name: "name_or_alias", value: ["%parent_name"])
-                                    @output_source {
-                    name @output(out_name: "animal_name")
-                }
-            }
-        }'''
+        test_data = test_input_data.filter_on_optional_variable_name_or_alias()
 
+        # The operand in the @filter directive originates from an optional block.
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -518,10 +408,6 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             parent_location: 'Animal',
@@ -529,18 +415,10 @@ class IrGenerationTests(unittest.TestCase):
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_filter_in_optional_block(self):
-        graphql_input = '''{
-            Animal {
-                out_Animal_FedAt @optional {
-                    name @filter(op_name: "=", value: ["$name"])
-                    uuid @output(out_name: "uuid")
-                }
-            }
-        }'''
+        test_data = test_input_data.filter_in_optional_block()
 
         base_location = helpers.Location(('Animal',))
         animal_fed_at_location = base_location.navigate_to_subpath('out_Animal_FedAt')
@@ -569,31 +447,19 @@ class IrGenerationTests(unittest.TestCase):
                 )
             }),
         ]
-        expected_output_metadata = {
-            'uuid': OutputMetadata(type=GraphQLID, optional=True),
-        }
-        expected_input_metadata = {
-            'name': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
             animal_fed_at_location: 'Event',
             revisited_base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_between_filter_on_simple_scalar(self):
+        test_data = test_input_data.between_filter_on_simple_scalar()
+
         # The "between" filter emits different output depending on what the compared types are.
         # This test checks for correct code generation when the type is a simple scalar (a String).
-        graphql_input = '''{
-            Animal {
-                name @filter(op_name: "between", value: ["$lower", "$upper"])
-                     @output(out_name: "name")
-            }
-        }'''
-
         base_location = helpers.Location(('Animal',))
 
         expected_blocks = [
@@ -619,30 +485,17 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString)
             }),
         ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'lower': GraphQLString,
-            'upper': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_between_filter_on_date(self):
+        test_data = test_input_data.between_filter_on_date()
+
         # The "between" filter emits different output depending on what the compared types are.
         # This test checks for correct code generation when the type is a custom scalar (Date).
-        graphql_input = '''{
-            Animal {
-                birthday @filter(op_name: "between", value: ["$lower", "$upper"])
-                         @output(out_name: "birthday")
-            }
-        }'''
-
         base_location = helpers.Location(('Animal',))
 
         expected_blocks = [
@@ -668,30 +521,17 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('birthday'), GraphQLDate)
             }),
         ]
-        expected_output_metadata = {
-            'birthday': OutputMetadata(type=GraphQLDate, optional=False),
-        }
-        expected_input_metadata = {
-            'lower': GraphQLDate,
-            'upper': GraphQLDate,
-        }
         expected_location_types = {
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_between_filter_on_datetime(self):
+        test_data = test_input_data.between_filter_on_datetime()
+
         # The "between" filter emits different output depending on what the compared types are.
         # This test checks for correct code generation when the type is a custom scalar (DateTime).
-        graphql_input = '''{
-            Event {
-                event_date @filter(op_name: "between", value: ["$lower", "$upper"])
-                           @output(out_name: "event_date")
-            }
-        }'''
-
         base_location = helpers.Location(('Event',))
 
         expected_blocks = [
@@ -717,49 +557,16 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('event_date'), GraphQLDateTime)
             }),
         ]
-        expected_output_metadata = {
-            'event_date': OutputMetadata(type=GraphQLDateTime, optional=False),
-        }
-        expected_input_metadata = {
-            'lower': GraphQLDateTime,
-            'upper': GraphQLDateTime,
-        }
         expected_location_types = {
             base_location: 'Event',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_complex_optional_variables(self):
-        # The operands in the @filter directives originate from an optional block.
-        graphql_input = '''{
-            Animal {
-                name @filter(op_name: "=", value: ["$animal_name"])
-                out_Animal_ParentOf {
-                    out_Animal_FedAt @optional {
-                        name @tag(tag_name: "child_fed_at_event")
-                        event_date @tag(tag_name: "child_fed_at")
-                                   @output(out_name: "child_fed_at")
-                    }
-                    in_Animal_ParentOf {
-                        out_Animal_FedAt @optional {
-                            event_date @tag(tag_name: "other_parent_fed_at")
-                                       @output(out_name: "other_parent_fed_at")
-                        }
-                    }
-                }
-                in_Animal_ParentOf {
-                    out_Animal_FedAt {
-                        name @filter(op_name: "=", value: ["%child_fed_at_event"])
-                        event_date @output(out_name: "grandparent_fed_at")
-                                   @filter(op_name: "between",
-                                           value: ["%other_parent_fed_at", "%child_fed_at"])
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.complex_optional_variables()
 
+        # The operands in the @filter directives originate from an optional block.
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         child_fed_at_location = child_location.navigate_to_subpath('out_Animal_FedAt')
@@ -877,14 +684,6 @@ class IrGenerationTests(unittest.TestCase):
                     grandparent_fed_at_output, GraphQLDateTime),
             }),
         ]
-        expected_output_metadata = {
-            'child_fed_at': OutputMetadata(type=GraphQLDateTime, optional=True),
-            'other_parent_fed_at': OutputMetadata(type=GraphQLDateTime, optional=True),
-            'grandparent_fed_at': OutputMetadata(type=GraphQLDateTime, optional=False),
-        }
-        expected_input_metadata = {
-            'animal_name': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
@@ -897,23 +696,10 @@ class IrGenerationTests(unittest.TestCase):
             grandparent_fed_at_location: 'Event',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_simple_fragment(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Entity_Related {
-                    ... on Animal {
-                        name @output(out_name: "related_animal_name")
-                        out_Animal_OfSpecies {
-                            name @output(out_name: "related_animal_species")
-                        }
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.simple_fragment()
 
         base_location = helpers.Location(('Animal',))
         related_location = base_location.navigate_to_subpath('out_Entity_Related')
@@ -938,32 +724,16 @@ class IrGenerationTests(unittest.TestCase):
                     related_species_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'related_animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'related_animal_species': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             related_location: 'Animal',
             related_species_location: 'Species',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_simple_union(self):
-        graphql_input = '''{
-            Species {
-                name @output(out_name: "species_name")
-                out_Species_Eats {
-                    ... on Food {
-                        name @output(out_name: "food_name")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.simple_union()
 
         base_location = helpers.Location(('Species',))
         food_location = base_location.navigate_to_subpath('out_Species_Eats')
@@ -982,30 +752,15 @@ class IrGenerationTests(unittest.TestCase):
                     food_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'species_name': OutputMetadata(type=GraphQLString, optional=False),
-            'food_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Species',
             food_location: 'Food',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_filter_on_fragment_in_union(self):
-        graphql_input = '''{
-            Species {
-                name @output(out_name: "species_name")
-                out_Species_Eats {
-                    ... on Food @filter(op_name: "name_or_alias", value: ["$wanted"]) {
-                        name @output(out_name: "food_name")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.filter_on_fragment_in_union()
 
         base_location = helpers.Location(('Species',))
         food_location = base_location.navigate_to_subpath('out_Species_Eats')
@@ -1036,32 +791,15 @@ class IrGenerationTests(unittest.TestCase):
                     food_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'species_name': OutputMetadata(type=GraphQLString, optional=False),
-            'food_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'wanted': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Species',
             food_location: 'Food',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_optional_on_union(self):
-        graphql_input = '''{
-            Species {
-                name @output(out_name: "species_name")
-                out_Species_Eats @optional {
-                    ... on Food {
-                        name @output(out_name: "food_name")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.optional_on_union()
 
         base_location = helpers.Location(('Species',))
         food_location = base_location.navigate_to_subpath('out_Species_Eats')
@@ -1086,29 +824,16 @@ class IrGenerationTests(unittest.TestCase):
                 ),
             }),
         ]
-        expected_output_metadata = {
-            'species_name': OutputMetadata(type=GraphQLString, optional=False),
-            'food_name': OutputMetadata(type=GraphQLString, optional=True),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Species',
             food_location: 'Food',
             revisited_base_location: 'Species',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_typename_output(self):
-        graphql_input = '''{
-            Animal {
-                __typename @output(out_name: "base_cls")
-                out_Animal_OfSpecies {
-                    __typename @output(out_name: "child_cls")
-                }
-            }
-        }'''
+        test_data = test_input_data.typename_output()
 
         base_location = helpers.Location(('Animal',))
         species_location = base_location.navigate_to_subpath('out_Animal_OfSpecies')
@@ -1126,26 +851,15 @@ class IrGenerationTests(unittest.TestCase):
                     species_location.navigate_to_field('@class'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'base_cls': OutputMetadata(type=GraphQLString, optional=False),
-            'child_cls': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             species_location: 'Species',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_typename_filter(self):
-        graphql_input = '''{
-            Entity {
-                __typename @filter(op_name: "=", value: ["$base_cls"])
-                name @output(out_name: "entity_name")
-            }
-        }'''
+        test_data = test_input_data.typename_filter()
 
         base_location = helpers.Location(('Entity',))
 
@@ -1164,27 +878,14 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'entity_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'base_cls': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Entity',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_simple_recurse(self):
-        graphql_input = '''{
-            Animal {
-                out_Animal_ParentOf @recurse(depth: 1) {
-                    name @output(out_name: "relation_name")
-                }
-            }
-        }'''
+        test_data = test_input_data.simple_recurse()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -1200,32 +901,15 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'relation_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_recurse_within_fragment(self):
-        graphql_input = '''{
-            Food {
-                name @output(out_name: "food_name")
-                in_Entity_Related {
-                    ... on Animal {
-                        name @output(out_name: "animal_name")
-                        out_Animal_ParentOf @recurse(depth: 3) {
-                            name @output(out_name: "relation_name")
-                        }
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.recurse_within_fragment()
 
         base_location = helpers.Location(('Food',))
         related_location = base_location.navigate_to_subpath('in_Entity_Related')
@@ -1250,30 +934,16 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'food_name': OutputMetadata(type=GraphQLString, optional=False),
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'relation_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Food',
             related_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_filter_within_recurse(self):
-        graphql_input = '''{
-            Animal {
-                out_Animal_ParentOf @recurse(depth: 3) {
-                    name @output(out_name: "relation_name")
-                    color @filter(op_name: "=", value: ["$wanted"])
-                }
-            }
-        }'''
+        test_data = test_input_data.filter_within_recurse()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -1296,30 +966,15 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'relation_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'wanted': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_recurse_with_immediate_type_coercion(self):
-        graphql_input = '''{
-            Animal {
-                in_Entity_Related @recurse(depth: 4) {
-                    ... on Animal {
-                        name @output(out_name: "name")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.recurse_with_immediate_type_coercion()
 
         base_location = helpers.Location(('Animal',))
         related_location = base_location.navigate_to_subpath('in_Entity_Related')
@@ -1336,29 +991,15 @@ class IrGenerationTests(unittest.TestCase):
                     related_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             related_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_recurse_with_immediate_type_coercion_and_filter(self):
-        graphql_input = '''{
-            Animal {
-                in_Entity_Related @recurse(depth: 4) {
-                    ... on Animal {
-                        name @output(out_name: "name")
-                        color @filter(op_name: "=", value: ["$color"])
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.recurse_with_immediate_type_coercion_and_filter()
 
         base_location = helpers.Location(('Animal',))
         related_location = base_location.navigate_to_subpath('in_Entity_Related')
@@ -1382,27 +1023,15 @@ class IrGenerationTests(unittest.TestCase):
                     related_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'color': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
             related_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_in_collection_op_filter_with_variable(self):
-        graphql_input = '''{
-            Animal {
-                name @filter(op_name: "in_collection", value: ["$wanted"])
-                     @output(out_name: "animal_name")
-            }
-        }'''
+        test_data = test_input_data.in_collection_op_filter_with_variable()
 
         base_location = helpers.Location(('Animal',))
 
@@ -1421,29 +1050,14 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'wanted': GraphQLList(GraphQLString)
-        }
         expected_location_types = {
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_in_collection_op_filter_with_tag(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                alias @tag(tag_name: "aliases")
-                out_Animal_ParentOf {
-                    name @filter(op_name: "in_collection", value: ["%aliases"])
-                }
-            }
-        }'''
+        test_data = test_input_data.in_collection_op_filter_with_tag()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -1466,30 +1080,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_in_collection_op_filter_with_optional_tag(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                in_Animal_ParentOf @optional {
-                    alias @tag(tag_name: "parent_aliases")
-                }
-                out_Animal_ParentOf {
-                    name @filter(op_name: "in_collection", value: ["%parent_aliases"])
-                }
-            }
-        }'''
+        test_data = test_input_data.in_collection_op_filter_with_optional_tag()
 
         base_location = helpers.Location(('Animal',))
         revisited_base_location = base_location.revisit()
@@ -1528,10 +1127,6 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             revisited_base_location: 'Animal',
@@ -1539,16 +1134,10 @@ class IrGenerationTests(unittest.TestCase):
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_contains_op_filter_with_variable(self):
-        graphql_input = '''{
-            Animal {
-                alias @filter(op_name: "contains", value: ["$wanted"])
-                name @output(out_name: "animal_name")
-            }
-        }'''
+        test_data = test_input_data.contains_op_filter_with_variable()
 
         base_location = helpers.Location(('Animal',))
 
@@ -1567,28 +1156,14 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'wanted': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_contains_op_filter_with_tag(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name") @tag(tag_name: "name")
-                out_Animal_ParentOf {
-                    alias @filter(op_name: "contains", value: ["%name"])
-                }
-            }
-        }'''
+        test_data = test_input_data.contains_op_filter_with_tag()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -1611,30 +1186,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_contains_op_filter_with_optional_tag(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                in_Animal_ParentOf @optional {
-                    name @tag(tag_name: "parent_name")
-                }
-                out_Animal_ParentOf {
-                    alias @filter(op_name: "contains", value: ["%parent_name"])
-                }
-            }
-        }'''
+        test_data = test_input_data.contains_op_filter_with_optional_tag()
 
         base_location = helpers.Location(('Animal',))
         revisited_base_location = base_location.revisit()
@@ -1673,10 +1233,6 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             revisited_base_location: 'Animal',
@@ -1684,16 +1240,10 @@ class IrGenerationTests(unittest.TestCase):
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_has_substring_op_filter(self):
-        graphql_input = '''{
-            Animal {
-                name @filter(op_name: "has_substring", value: ["$wanted"])
-                     @output(out_name: "animal_name")
-            }
-        }'''
+        test_data = test_input_data.has_substring_op_filter()
 
         base_location = helpers.Location(('Animal',))
 
@@ -1712,31 +1262,14 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'wanted': GraphQLString,
-        }
         expected_location_types = {
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_has_substring_op_filter_with_optional_tag(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                in_Animal_ParentOf @optional {
-                    name @tag(tag_name: "parent_name")
-                }
-                out_Animal_ParentOf {
-                    name @filter(op_name: "has_substring", value: ["%parent_name"])
-                }
-            }
-        }'''
+        test_data = test_input_data.has_substring_op_filter_with_optional_tag()
 
         base_location = helpers.Location(('Animal',))
         revisited_base_location = base_location.revisit()
@@ -1775,10 +1308,6 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
             revisited_base_location: 'Animal',
@@ -1786,19 +1315,10 @@ class IrGenerationTests(unittest.TestCase):
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_has_edge_degree_op_filter(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Animal_ParentOf @filter(op_name: "has_edge_degree", value: ["$child_count"])
-                                    @output_source {
-                    name @output(out_name: "child_name")
-                }
-            }
-        }'''
+        test_data = test_input_data.has_edge_degree_op_filter()
 
         base_location = helpers.Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
@@ -1850,36 +1370,15 @@ class IrGenerationTests(unittest.TestCase):
                     child_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {
-            'child_count': GraphQLInt,
-        }
         expected_location_types = {
             base_location: 'Animal',
             child_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_has_edge_degree_op_filter_with_optional(self):
-        graphql_input = '''{
-            Species {
-                name @output(out_name: "species_name")
-
-                in_Animal_OfSpecies {
-                    name @output(out_name: "parent_name")
-
-                    out_Animal_ParentOf @filter(op_name: "has_edge_degree", value: ["$child_count"])
-                                        @optional {
-                        name @output(out_name: "child_name")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.has_edge_degree_op_filter_with_optional()
 
         base_location = helpers.Location(('Species',))
         animal_location = base_location.navigate_to_subpath('in_Animal_OfSpecies')
@@ -1942,14 +1441,6 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral),
             }),
         ]
-        expected_output_metadata = {
-            'species_name': OutputMetadata(type=GraphQLString, optional=False),
-            'parent_name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_name': OutputMetadata(type=GraphQLString, optional=True),
-        }
-        expected_input_metadata = {
-            'child_count': GraphQLInt,
-        }
         expected_location_types = {
             base_location: 'Species',
             animal_location: 'Animal',
@@ -1957,24 +1448,10 @@ class IrGenerationTests(unittest.TestCase):
             revisited_animal_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_has_edge_degree_op_filter_with_fold(self):
-        graphql_input = '''{
-            Species {
-                name @output(out_name: "species_name")
-
-                in_Animal_OfSpecies {
-                    name @output(out_name: "parent_name")
-
-                    out_Animal_ParentOf @filter(op_name: "has_edge_degree", value: ["$child_count"])
-                                        @fold {
-                        name @output(out_name: "child_names")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.has_edge_degree_op_filter_with_fold()
 
         base_location = helpers.Location(('Species',))
         animal_location = base_location.navigate_to_subpath('in_Animal_OfSpecies')
@@ -2031,111 +1508,15 @@ class IrGenerationTests(unittest.TestCase):
                     animal_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'species_name': OutputMetadata(type=GraphQLString, optional=False),
-            'parent_name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_names': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {
-            'child_count': GraphQLInt,
-        }
         expected_location_types = {
             base_location: 'Species',
             animal_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
-
-    # Disabled until OrientDB fixes the limitation against traversing from an optional vertex.
-    # For details, see https://github.com/orientechnologies/orientdb/issues/6788
-    @pytest.mark.skip(reason='traversing from an optional node is not currently supported in MATCH')
-    def test_optional_traversal_edge_case(self):
-        # Both Animal and out_Animal_ParentOf have an out_Animal_FedAt field,
-        # ensure the correct such field is picked out.
-        graphql_input = '''{
-            Animal {
-                out_Animal_ParentOf @optional {
-                    out_Animal_FedAt {
-                        name @output(out_name: "name")
-                    }
-                }
-            }
-        }'''
-
-        # Disabled until OrientDB fixes the limitation against traversing from an optional vertex.
-        # Rather than compiling correctly, this raises an exception until the OrientDB limitation
-        # is lifted.
-        # For details, see https://github.com/orientechnologies/orientdb/issues/6788
-        base_location = helpers.Location(('Animal',))
-        child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
-        child_fed_at_location = child_location.navigate_to_subpath('out_Animal_FedAt')
-        revisited_base_location = base_location.revisit()
-
-        expected_blocks = [
-            blocks.QueryRoot({'Animal'}),
-            blocks.MarkLocation(base_location),
-
-            blocks.Traverse('out', 'Animal_ParentOf', optional=True),
-            blocks.MarkLocation(child_location),
-
-            blocks.Traverse('out', 'Animal_FedAt'),
-            blocks.MarkLocation(child_fed_at_location),
-            blocks.Backtrack(child_location),
-
-            blocks.Backtrack(base_location, optional=True),
-            blocks.MarkLocation(revisited_base_location),
-
-            blocks.ConstructResult({
-                'name': expressions.TernaryConditional(
-                    expressions.ContextFieldExistence(child_fed_at_location),
-                    expressions.OutputContextField(
-                        child_fed_at_location.navigate_to_field('name'), GraphQLString),
-                    expressions.NullLiteral
-                ),
-            })
-        ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=True),
-        }
-        expected_input_metadata = {}
-        expected_location_types = {
-            base_location: 'Animal',
-            child_location: 'Animal',
-            child_fed_at_location: 'Event',
-            revisited_base_location: 'Animal',
-        }
-
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
-
-    def test_no_traversing_from_optional_scope(self):
-        # Until OrientDB fixes the limitation against traversing from an optional vertex,
-        # attempting to do so will raise GraphQLCompilationError.
-        # For details, see https://github.com/orientechnologies/orientdb/issues/6788
-
-        graphql_input = '''{
-            Animal {
-                out_Animal_ParentOf @optional {
-                    out_Animal_FedAt {
-                        name @output(out_name: "name")
-                    }
-                }
-            }
-        }'''
-
-        with self.assertRaises(helpers.GraphQLCompilationError):
-            graphql_to_ir(self.schema, graphql_input)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_fold_on_output_variable(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Animal_ParentOf @fold {
-                    name @output(out_name: "child_names_list")
-                }
-            }
-        }'''
+        test_data = test_input_data.fold_on_output_variable()
 
         base_location = helpers.Location(('Animal',))
         base_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
@@ -2152,30 +1533,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_fold_after_traverse(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                in_Animal_ParentOf {
-                    out_Animal_ParentOf @fold {
-                        name @output(out_name: "sibling_and_self_names_list")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.fold_after_traverse()
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
@@ -2196,31 +1562,16 @@ class IrGenerationTests(unittest.TestCase):
                     parent_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'sibling_and_self_names_list': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
             parent_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_multiple_outputs_in_same_fold(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Animal_ParentOf @fold {
-                    name @output(out_name: "child_names_list")
-                    uuid @output(out_name: "child_uuids_list")
-                }
-            }
-        }'''
+        test_data = test_input_data.multiple_outputs_in_same_fold()
 
         base_location = helpers.Location(('Animal',))
         base_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
@@ -2239,34 +1590,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_fold, 'uuid', GraphQLList(GraphQLID)),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
-            'child_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_multiple_folds(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Animal_ParentOf @fold {
-                    name @output(out_name: "child_names_list")
-                    uuid @output(out_name: "child_uuids_list")
-                }
-                in_Animal_ParentOf @fold {
-                    name @output(out_name: "parent_names_list")
-                    uuid @output(out_name: "parent_uuids_list")
-                }
-            }
-        }'''
+        test_data = test_input_data.multiple_folds()
 
         base_location = helpers.Location(('Animal',))
         base_out_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
@@ -2292,34 +1624,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_in_fold, 'uuid', GraphQLList(GraphQLID)),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
-            'child_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
-            'parent_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
-            'parent_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_fold_date_and_datetime_fields(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Animal_ParentOf @fold {
-                    birthday @output(out_name: "child_birthdays_list")
-                }
-                out_Animal_FedAt @fold {
-                    event_date @output(out_name: "fed_at_datetimes_list")
-                }
-            }
-        }'''
+        test_data = test_input_data.fold_date_and_datetime_fields()
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
@@ -2341,37 +1654,17 @@ class IrGenerationTests(unittest.TestCase):
                     base_fed_at_fold, 'event_date', GraphQLList(GraphQLDateTime)),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_birthdays_list': OutputMetadata(type=GraphQLList(GraphQLDate), optional=False),
-            'fed_at_datetimes_list': OutputMetadata(
-                type=GraphQLList(GraphQLDateTime), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_coercion_to_union_base_type_inside_fold(self):
         # Given type_equivalence_hints = { Event: EventOrBirthEvent },
         # the coercion should be optimized away as a no-op.
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Animal_ImportantEvent @fold {
-                    ... on Event {
-                        name @output(out_name: "important_events")
-                    }
-                }
-            }
-        }'''
-        type_equivalence_hints = {
-            'Event': 'EventOrBirthEvent'
-        }
+        test_data = test_input_data.coercion_to_union_base_type_inside_fold()
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(
@@ -2389,36 +1682,16 @@ class IrGenerationTests(unittest.TestCase):
                     base_parent_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'important_events': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types,
-                        type_equivalence_hints=type_equivalence_hints)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_no_op_coercion_inside_fold(self):
         # The type where the coercion is applied is already Entity, so the coercion is a no-op.
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-                out_Entity_Related @fold {
-                    ... on Entity {
-                        name @output(out_name: "related_entities")
-                    }
-                }
-            }
-        }'''
-        type_equivalence_hints = {
-            'Event': 'EventOrBirthEvent'
-        }
+        test_data = test_input_data.no_op_coercion_inside_fold()
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(
@@ -2436,31 +1709,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_parent_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-            'related_entities': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types,
-                        type_equivalence_hints=type_equivalence_hints)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_filter_within_fold_scope(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "name")
-                out_Animal_ParentOf @fold {
-                    name @filter(op_name: "=", value: ["$desired"]) @output(out_name: "child_list")
-                    description @output(out_name: "child_descriptions")
-                }
-            }
-        }'''
+        test_data = test_input_data.filter_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
@@ -2486,34 +1743,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_parent_fold, 'description', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_list': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-            'child_descriptions': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {
-            'desired': GraphQLString,
-        }
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_filter_on_fold_scope(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "name")
-                out_Animal_ParentOf @fold
-                                    @filter(op_name: "name_or_alias", value: ["$desired"]) {
-                    name @output(out_name: "child_list")
-                }
-            }
-        }'''
+        test_data = test_input_data.filter_on_fold_scope()
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
@@ -2545,33 +1783,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_parent_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=False),
-            'child_list': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {
-            'desired': GraphQLString,
-        }
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_coercion_on_interface_within_fold_scope(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "name")
-                out_Entity_Related @fold {
-                    ... on Animal {
-                        name @output(out_name: "related_animals")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.coercion_on_interface_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Entity_Related'))
@@ -2589,31 +1809,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_parent_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=False),
-            'related_animals': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_coercion_on_union_within_fold_scope(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "name")
-                out_Animal_ImportantEvent @fold {
-                    ... on BirthEvent {
-                        name @output(out_name: "birth_events")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.coercion_on_union_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(
@@ -2632,34 +1836,15 @@ class IrGenerationTests(unittest.TestCase):
                     base_parent_fold, 'name', GraphQLList(GraphQLString)),
             }),
         ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=False),
-            'birth_events': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
 
     def test_coercion_filters_and_multiple_outputs_within_fold_scope(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "name")
-                out_Entity_Related @fold {
-                    ... on Animal {
-                        name @filter(op_name: "has_substring", value: ["$substring"])
-                             @output(out_name: "related_animals")
-                        birthday @filter(op_name: "<=", value: ["$latest"])
-                                 @output(out_name: "related_birthdays")
-                    }
-                }
-            }
-        }'''
+        test_data = test_input_data.coercion_filters_and_multiple_outputs_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Entity_Related'))
@@ -2693,21 +1878,9 @@ class IrGenerationTests(unittest.TestCase):
                     base_parent_fold, 'birthday', GraphQLList(GraphQLDate)),
             }),
         ]
-        expected_output_metadata = {
-            'name': OutputMetadata(type=GraphQLString, optional=False),
-            'related_animals': OutputMetadata(
-                type=GraphQLList(GraphQLString), optional=False),
-            'related_birthdays': OutputMetadata(
-                type=GraphQLList(GraphQLDate), optional=False),
-        }
-        expected_input_metadata = {
-            'substring': GraphQLString,
-            'latest': GraphQLDate,
-        }
         expected_location_types = {
             # The folded location was never traversed to, so it does not appear here.
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data, expected_blocks, expected_location_types)

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -4,11 +4,11 @@ import unittest
 from graphql import GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 import six
 
+from . import test_input_data
 from ..compiler import blocks, expressions, helpers
 from ..compiler.compiler_frontend import OutputMetadata, graphql_to_ir
 from ..schema import GraphQLDate, GraphQLDateTime
 from .test_helpers import compare_input_metadata, compare_ir_blocks, get_schema
-from . import test_input_data
 
 
 def check_test_data(test_case, test_data, expected_blocks, expected_location_types):

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -9,6 +9,7 @@ from ..compiler import blocks, expressions, helpers
 from ..compiler.compiler_frontend import OutputMetadata, graphql_to_ir
 from ..schema import GraphQLDate, GraphQLDateTime
 from .test_helpers import compare_input_metadata, compare_ir_blocks, get_schema
+from . import test_input_data
 
 
 def check_test_data(test_case, graphql_input, expected_blocks,
@@ -52,11 +53,7 @@ class IrGenerationTests(unittest.TestCase):
         self.schema = get_schema()
 
     def test_immediate_output(self):
-        graphql_input = '''{
-            Animal {
-                name @output(out_name: "animal_name")
-            }
-        }'''
+        test_data = test_input_data.immediate_output()
 
         base_location = helpers.Location(('Animal',))
 
@@ -68,16 +65,13 @@ class IrGenerationTests(unittest.TestCase):
                     base_location.navigate_to_field('name'), GraphQLString)
             }),
         ]
-        expected_output_metadata = {
-            'animal_name': OutputMetadata(type=GraphQLString, optional=False),
-        }
-        expected_input_metadata = {}
         expected_location_types = {
             base_location: 'Animal',
         }
 
-        check_test_data(self, graphql_input, expected_blocks,
-                        expected_output_metadata, expected_input_metadata, expected_location_types)
+        check_test_data(self, test_data.graphql_input, expected_blocks,
+                        test_data.expected_output_metadata, test_data.expected_input_metadata,
+                        expected_location_types)
 
     def test_immediate_filter_and_output(self):
         # Ensure that all basic comparison operators output correct code in this simple case.

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -17,6 +17,23 @@ class IrGenerationErrorTests(unittest.TestCase):
         self.maxDiff = None
         self.schema = get_schema()
 
+    def test_no_traversing_from_optional_scope(self):
+        # Until OrientDB fixes the limitation against traversing from an optional vertex,
+        # attempting to do so will raise GraphQLCompilationError.
+        # For details, see https://github.com/orientechnologies/orientdb/issues/6788
+        graphql_input = '''{
+            Animal {
+                out_Animal_ParentOf @optional {
+                    out_Animal_FedAt {
+                        name @output(out_name: "name")
+                    }
+                }
+            }
+        }'''
+
+        with self.assertRaises(GraphQLCompilationError):
+            graphql_to_ir(self.schema, graphql_input)
+
     def test_repeated_field_name(self):
         repeated_property_field = '''{
             Animal {


### PR DESCRIPTION
Most of the IR test and compilation tests use the same GraphQL input queries, and output the same metadata. Since I'm about to add a whole lot more metadata, it might be a good idea to put all the common test data in one place. That way, I can add the new metadata once, instead of once per file.

I'm only doing this for one test for now, just to get everyone's input on the idea. If everyone is in favor of this, I would:
- apply it to all tests, and then
- change the `check_test_data` methods to take a `CommonTestData` object instead of unwrapping the data item before passing it in.