### PR TITLE
Use an explicit namedtuple for the frontend output.

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -92,6 +92,16 @@ class OutputMetadata(namedtuple('OutputMetadata', ('type', 'optional'))):
         return not self.__eq__(other)
 
 
+IrAndMetadata = namedtuple(
+    'IrAndMetadata', (
+        'ir_blocks',
+        'input_metadata',
+        'output_metadata',
+        'location_types',
+    )
+)
+
+
 def _get_fields(ast):
     """Return a list of property fields, and a list of vertex fields, for the given AST node.
 
@@ -570,11 +580,11 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
         type_equivalence_hints: optional dict of GraphQL type to equivalent GraphQL union
 
     Returns:
-        tuple of:
-        - a list of IR basic block objects
-        - a dict of output name (string) -> OutputMetadata object
-        - a dict of expected input parameters (string) -> inferred GraphQL type, based on use
-        - a dict of location objects -> GraphQL type objects at that location
+        IrAndMetadata named tuple, containing fields:
+        - ir_blocks: a list of IR basic block objects
+        - input_metadata: a dict of expected input parameters (string) -> inferred GraphQL type
+        - output_metadata: a dict of output name (string) -> OutputMetadata object
+        - location_types: a dict of location objects -> GraphQL type objects at that location
     """
     if len(ast.selection_set.selections) != 1:
         raise GraphQLCompilationError(u'Cannot process AST with more than one root selection!')
@@ -631,7 +641,11 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
         for name, value in six.iteritems(outputs_context)
     }
 
-    return basic_blocks, output_metadata, context['inputs'], context['location_types']
+    return IrAndMetadata(
+        ir_blocks=basic_blocks,
+        input_metadata=context['inputs'],
+        output_metadata=output_metadata,
+        location_types=context['location_types'])
 
 
 def _compile_output_step(outputs):
@@ -712,11 +726,11 @@ def graphql_to_ir(schema, graphql_string, type_equivalence_hints=None):
                                 *****
 
     Returns:
-        tuple of:
-        - a list of IR basic block objects
-        - a dict of output name (string) -> OutputMetadata object
-        - a dict of expected input parameters (string) -> inferred GraphQL type, based on use
-        - a dict of location objects -> GraphQL type objects at that location
+        IrAndMetadata named tuple, containing fields:
+        - ir_blocks: a list of IR basic block objects
+        - input_metadata: a dict of expected input parameters (string) -> inferred GraphQL type
+        - output_metadata: a dict of output name (string) -> OutputMetadata object
+        - location_types: a dict of location objects -> GraphQL type objects at that location
 
     Raises flavors of GraphQLError in the following cases:
         - if the query is invalid GraphQL (GraphQLParsingError);

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -25,7 +25,10 @@ def check_test_data(test_case, test_data, expected_blocks, expected_location_typ
 
     compilation_results = graphql_to_ir(test_case.schema, test_data.graphql_input,
                                         type_equivalence_hints=schema_based_type_equivalence_hints)
-    received_blocks, output_metadata, input_metadata, location_types = compilation_results
+    received_blocks = compilation_results.ir_blocks
+    input_metadata = compilation_results.input_metadata
+    output_metadata = compilation_results.output_metadata
+    location_types = compilation_results.location_types
 
     compare_ir_blocks(test_case, expected_blocks, received_blocks)
     test_case.assertEqual(test_data.expected_output_metadata, output_metadata)

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -25,15 +25,14 @@ def check_test_data(test_case, test_data, expected_blocks, expected_location_typ
 
     compilation_results = graphql_to_ir(test_case.schema, test_data.graphql_input,
                                         type_equivalence_hints=schema_based_type_equivalence_hints)
-    received_blocks = compilation_results.ir_blocks
-    input_metadata = compilation_results.input_metadata
-    output_metadata = compilation_results.output_metadata
-    location_types = compilation_results.location_types
 
-    compare_ir_blocks(test_case, expected_blocks, received_blocks)
-    test_case.assertEqual(test_data.expected_output_metadata, output_metadata)
-    compare_input_metadata(test_case, test_data.expected_input_metadata, input_metadata)
-    test_case.assertEqual(expected_location_types, comparable_location_types(location_types))
+    compare_ir_blocks(test_case, expected_blocks, compilation_results.ir_blocks)
+    compare_input_metadata(
+        test_case, test_data.expected_input_metadata, compilation_results.input_metadata)
+    test_case.assertEqual(
+        test_data.expected_output_metadata, compilation_results.output_metadata)
+    test_case.assertEqual(
+        expected_location_types, comparable_location_types(compilation_results.location_types))
 
 
 def comparable_location_types(location_types):


### PR DESCRIPTION
This helps us prepare for the additional dependency metadata the frontend will soon generate. We also streamline the compilation process by deduplicating the common GraphQL to compiled query code flow.