### PR TITLE
Update versions of dev-dependency packages.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 bandit==1.4.0
-coveralls==1.1
-flake8==3.3.0
-isort==4.2.15
-pydocstyle==2.0.0
-pylint==1.7.1
-pytest==3.2.1
-pytest-cov==2.4.0
+coveralls==1.2.0
+flake8==3.5.0
+isort==4.3.4
+pydocstyle==2.1.1
+pylint==1.8.2
+pytest==3.4.1
+pytest-cov==2.5.1


### PR DESCRIPTION
The `pylint` package had a bug that generated false-positive errors when analyzing with Python 3. Upgrading to the newest version avoids the bug.

Upgraded all other dev tools as well, while I was at it.