### PR TITLE
 Allow traversal within a @fold scope (Issue #45) -- Supercedes #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ If a given `Animal` has no children, its `child_names` list is empty.
 #### Constraints and Rules
 - `@fold` can only be applied to vertex fields, except the root vertex field.
 - May not exist at the same vertex field as `@recurse`, `@optional`, or `@output_source`.
-- Only one vertex field may be expanded within a scope marked `@fold`. Note that this applies for all nested scopes within.
+- At most one vertex field may be expanded in a scope within a `@fold` marked scope. Note that this applies for all nested scopes (see example below).
 - `@tag`, `@recurse`, `@optional`, `@output_source` and `@fold` may not be used anywhere within a scope marked `@fold`.
 - Use of type coercions or `@filter` at or within the vertex field marked `@fold` is allowed.
   Only data that satisfies the given type coercions and filters is returned by the `@fold`.
@@ -239,6 +239,34 @@ If a given `Animal` has no children, its `child_names` list is empty.
   it may optimize it away. See the
   [Optional `type_equivalence_hints` compilation parameter](#optional-type_equivalence_hints-parameter)
   section for more details.
+
+#### Example
+```
+    out_Animal_ParentOf @fold {
+        name @output ...
+        in_Animal_ParentOf {
+            in_Animal_PeerOf {
+                ...
+            }
+            out_Animal_RelatedTo {
+                ...
+            }
+        }
+    }
+```
+This fragment is not allowed because two vertex fields are expanded inside `in_Animal_ParentOf`, which is within a `@fold` scope. It is also invalid to `output` at any level except the innermost one.
+```
+    out_Animal_ParentOf @fold {
+        in_Animal_ParentOf {
+            in_Animal_PeerOf {
+                out_Animal_RelatedTo {
+                    name @output ...
+                }
+            }
+        }
+    }
+```
+This is a valid use of `@fold`.
 
 ### @tag
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ If a given `Animal` has no children, its `child_names` list is empty.
 #### Constraints and Rules
 - `@fold` can only be applied to vertex fields, except the root vertex field.
 - May not exist at the same vertex field as `@recurse`, `@optional`, or `@output_source`.
-- Expanding vertex fields is not allowed within a scope marked `@fold`.
-- `@tag` and `@fold` may not be used within a scope marked `@fold`.
+- Only one vertex field may be expanded within a scope marked `@fold`. Note that this applies for all nested scopes within.
+- `@tag`, `@recurse`, `@optional`, `@output_source` and `@fold` may not be used at any level within a scope marked `@fold`.
 - Use of type coercions or `@filter` at or within the vertex field marked `@fold` is allowed.
   Only data that satisfies the given type coercions and filters is returned by the `@fold`.
 - If the compiler is able to prove that the type coercion in the `@fold` scope is actually a no-op,

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ If a given `Animal` has no children, its `child_names` list is empty.
 - `@fold` can only be applied to vertex fields, except the root vertex field.
 - May not exist at the same vertex field as `@recurse`, `@optional`, or `@output_source`.
 - Only one vertex field may be expanded within a scope marked `@fold`. Note that this applies for all nested scopes within.
-- `@tag`, `@recurse`, `@optional`, `@output_source` and `@fold` may not be used at any level within a scope marked `@fold`.
+- `@tag`, `@recurse`, `@optional`, `@output_source` and `@fold` may not be used anywhere within a scope marked `@fold`.
 - Use of type coercions or `@filter` at or within the vertex field marked `@fold` is allowed.
   Only data that satisfies the given type coercions and filters is returned by the `@fold`.
 - If the compiler is able to prove that the type coercion in the `@fold` scope is actually a no-op,

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -420,7 +420,12 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
             _validate_fold_has_outputs(context['fold'], context['outputs'])
             basic_blocks.append(blocks.Unfold())
             del context['fold']
-            del context['fold_last_level']
+            try:
+                del context['fold_last_level']
+            except KeyError:
+                raise GraphQLCompilationError(u'Output inside @fold scope did not add '
+                                              u'"fold_last_level" to context! '
+                                              u'Location: {}'.format(fold_scope_location))
 
         if in_topmost_optional_block:
             del context['optional']

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -255,6 +255,7 @@ def _compile_property_ast(schema, current_schema_type, ast, location,
         graphql_type = strip_non_null_from_type(current_schema_type)
         if is_in_fold_scope(context):
             graphql_type = GraphQLList(graphql_type)
+            # Fold outputs are only allowed at the last level of traversal
             context['fold_last_level'] = None
 
         context['outputs'][output_name] = {

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -69,8 +69,8 @@ from .context_helpers import (has_encountered_output_source, is_in_fold_scope, i
 from .directive_helpers import (get_local_filter_directives, get_unique_directives,
                                 validate_property_directives, validate_root_vertex_directives,
                                 validate_vertex_directives,
-                                validate_vertex_field_directive_interactions,
-                                validate_vertex_field_directive_in_context)
+                                validate_vertex_field_directive_in_context,
+                                validate_vertex_field_directive_interactions)
 from .filters import process_filter_directive
 from .helpers import (FoldScopeLocation, Location, get_ast_field_name, get_field_type_from_schema,
                       get_uniquely_named_objects_by_name, get_vertex_field_type,

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -256,7 +256,7 @@ def _compile_property_ast(schema, current_schema_type, ast, location,
         if is_in_fold_scope(context):
             graphql_type = GraphQLList(graphql_type)
             # Fold outputs are only allowed at the last level of traversal
-            context['fold_last_level'] = None
+            context['fold_innermost_scope'] = None
 
         context['outputs'][output_name] = {
             'location': location,
@@ -421,11 +421,11 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
             _validate_fold_has_outputs(context['fold'], context['outputs'])
             basic_blocks.append(blocks.Unfold())
             del context['fold']
-            try:
-                del context['fold_last_level']
-            except KeyError:
+            if 'fold_innermost_scope' in context:
+                del context['fold_innermost_scope']
+            else:
                 raise GraphQLCompilationError(u'Output inside @fold scope did not add '
-                                              u'"fold_last_level" to context! '
+                                              u'"fold_innermost_scope" to context! '
                                               u'Location: {}'.format(fold_scope_location))
 
         if in_topmost_optional_block:

--- a/graphql_compiler/compiler/context_helpers.py
+++ b/graphql_compiler/compiler/context_helpers.py
@@ -4,6 +4,11 @@
 from ..exceptions import GraphQLCompilationError
 
 
+def is_in_fold_last_level_scope(context):
+    """Return True if the current context is within a scope marked @fold."""
+    return 'fold_last_level' in context
+
+
 def is_in_fold_scope(context):
     """Return True if the current context is within a scope marked @fold."""
     return 'fold' in context
@@ -25,9 +30,9 @@ def validate_context_for_visiting_vertex_field(location, context):
         raise GraphQLCompilationError(u'Traversing inside an optional block is currently not '
                                       u'supported! Location: {}'.format(location))
 
-    if is_in_fold_scope(context):
-        raise GraphQLCompilationError(u'Traversing inside a @fold block is not supported! '
-                                      u'Location: {}'.format(location))
+    if is_in_fold_last_level_scope(context):
+        raise GraphQLCompilationError(u'Traversing inside a @fold block after output is '
+                                      u'not supported! Location: {}'.format(location))
 
     if has_encountered_output_source(context):
         raise GraphQLCompilationError(u'Found vertex field after the vertex marked '

--- a/graphql_compiler/compiler/context_helpers.py
+++ b/graphql_compiler/compiler/context_helpers.py
@@ -4,9 +4,9 @@
 from ..exceptions import GraphQLCompilationError
 
 
-def is_in_fold_last_level_scope(context):
+def is_in_fold_innermost_scope_scope(context):
     """Return True if the current context is within a scope marked @fold."""
-    return 'fold_last_level' in context
+    return 'fold_innermost_scope' in context
 
 
 def is_in_fold_scope(context):
@@ -30,7 +30,7 @@ def validate_context_for_visiting_vertex_field(location, context):
         raise GraphQLCompilationError(u'Traversing inside an optional block is currently not '
                                       u'supported! Location: {}'.format(location))
 
-    if is_in_fold_last_level_scope(context):
+    if is_in_fold_innermost_scope_scope(context):
         raise GraphQLCompilationError(u'Traversing inside a @fold block after output is '
                                       u'not supported! Location: {}'.format(location))
 

--- a/graphql_compiler/compiler/directive_helpers.py
+++ b/graphql_compiler/compiler/directive_helpers.py
@@ -2,6 +2,7 @@
 """Helper functions for dealing with GraphQL directives."""
 
 from graphql.language.ast import InlineFragment
+
 import six
 
 from ..exceptions import GraphQLCompilationError
@@ -182,7 +183,7 @@ def validate_vertex_field_directive_interactions(location, directives):
 
 
 def validate_vertex_field_directive_in_context(location, directives, context):
-    """Ensure that the specified vertex field directives are allowed in the current context"""
+    """Ensure that the specified vertex field directives are allowed in the current context."""
     fold_directive = directives.get('fold', None)
     optional_directive = directives.get('optional', None)
     output_source_directive = directives.get('output_source', None)

--- a/graphql_compiler/compiler/directive_helpers.py
+++ b/graphql_compiler/compiler/directive_helpers.py
@@ -2,7 +2,6 @@
 """Helper functions for dealing with GraphQL directives."""
 
 from graphql.language.ast import InlineFragment
-
 import six
 
 from ..exceptions import GraphQLCompilationError
@@ -190,19 +189,19 @@ def validate_vertex_field_directive_in_context(location, directives, context):
     recurse_directive = directives.get('recurse', None)
 
     fold_context = 'fold' in context
-    optional_context = 'optional' in context
-    output_context = 'output' in context
-    recurse_context = 'recurse' in context
+    # optional_context = 'optional' in context
+    # output_context = 'output' in context
+    # recurse_context = 'recurse' in context
 
     if fold_directive and fold_context:
-        raise GraphQLCompilationError(u'@fold is not allowed within a @fold traversal ! '
+        raise GraphQLCompilationError(u'@fold is not allowed within a @fold traversal! '
                                       u'Location: {}'.format(location))
     if optional_directive and fold_context:
-        raise GraphQLCompilationError(u'@optional is not allowed within a @fold traversal ! '
+        raise GraphQLCompilationError(u'@optional is not allowed within a @fold traversal! '
                                       u'Location: {}'.format(location))
     if output_source_directive and fold_context:
-        raise GraphQLCompilationError(u'@output_source is not allowed within a @fold traversal ! '
+        raise GraphQLCompilationError(u'@output_source is not allowed within a @fold traversal! '
                                       u'Location: {}'.format(location))
     if recurse_directive and fold_context:
-        raise GraphQLCompilationError(u'@recurse is not allowed within a @fold traversal ! '
+        raise GraphQLCompilationError(u'@recurse is not allowed within a @fold traversal! '
                                       u'Location: {}'.format(location))

--- a/graphql_compiler/compiler/directive_helpers.py
+++ b/graphql_compiler/compiler/directive_helpers.py
@@ -194,8 +194,14 @@ def validate_vertex_field_directive_in_context(location, directives, context):
     output_context = 'output' in context
     recurse_context = 'recurse' in context
 
+    if fold_directive and fold_context:
+        raise GraphQLCompilationError(u'@fold is not allowed within a @fold traversal ! '
+                                      u'Location: {}'.format(location))
     if optional_directive and fold_context:
         raise GraphQLCompilationError(u'@optional is not allowed within a @fold traversal ! '
+                                      u'Location: {}'.format(location))
+    if output_source_directive and fold_context:
+        raise GraphQLCompilationError(u'@output_source is not allowed within a @fold traversal ! '
                                       u'Location: {}'.format(location))
     if recurse_directive and fold_context:
         raise GraphQLCompilationError(u'@recurse is not allowed within a @fold traversal ! '

--- a/graphql_compiler/compiler/directive_helpers.py
+++ b/graphql_compiler/compiler/directive_helpers.py
@@ -179,3 +179,23 @@ def validate_vertex_field_directive_interactions(location, directives):
     if optional_directive and recurse_directive:
         raise GraphQLCompilationError(u'@optional and @recurse may not appear at the same '
                                       u'vertex field! Location: {}'.format(location))
+
+
+def validate_vertex_field_directive_in_context(location, directives, context):
+    """Ensure that the specified vertex field directives are allowed in the current context"""
+    fold_directive = directives.get('fold', None)
+    optional_directive = directives.get('optional', None)
+    output_source_directive = directives.get('output_source', None)
+    recurse_directive = directives.get('recurse', None)
+
+    fold_context = 'fold' in context
+    optional_context = 'optional' in context
+    output_context = 'output' in context
+    recurse_context = 'recurse' in context
+
+    if optional_directive and fold_context:
+        raise GraphQLCompilationError(u'@optional is not allowed within a @fold traversal ! '
+                                      u'Location: {}'.format(location))
+    if recurse_directive and fold_context:
+        raise GraphQLCompilationError(u'@recurse is not allowed within a @fold traversal ! '
+                                      u'Location: {}'.format(location))

--- a/graphql_compiler/compiler/directive_helpers.py
+++ b/graphql_compiler/compiler/directive_helpers.py
@@ -189,9 +189,6 @@ def validate_vertex_field_directive_in_context(location, directives, context):
     recurse_directive = directives.get('recurse', None)
 
     fold_context = 'fold' in context
-    # optional_context = 'optional' in context
-    # output_context = 'output' in context
-    # recurse_context = 'recurse' in context
 
     if fold_directive and fold_context:
         raise GraphQLCompilationError(u'@fold is not allowed within a @fold traversal! '

--- a/graphql_compiler/compiler/emit_match.py
+++ b/graphql_compiler/compiler/emit_match.py
@@ -4,7 +4,7 @@ from collections import deque
 
 import six
 
-from .blocks import Backtrack, Filter, QueryRoot, Recurse, Traverse
+from .blocks import Filter, QueryRoot, Recurse, Traverse
 from .helpers import validate_safe_string
 
 

--- a/graphql_compiler/compiler/emit_match.py
+++ b/graphql_compiler/compiler/emit_match.py
@@ -133,7 +133,7 @@ def _represent_fold(fold_location, fold_ir_blocks):
                 'edge_name': block.edge_name,
             }
             final_string += traverse_edge_template % template_data
-        elif not isinstance(block, Backtrack):
+        else:
             raise AssertionError(u'Found a non-Filter/Traverse IR block in the folded IR blocks: '
                                  u'{} {} {}'.format(type(block), block, fold_ir_blocks))
 

--- a/graphql_compiler/compiler/emit_match.py
+++ b/graphql_compiler/compiler/emit_match.py
@@ -133,7 +133,6 @@ def _represent_fold(fold_location, fold_ir_blocks):
                 'edge_name': block.edge_name,
             }
             final_string += traverse_edge_template % template_data
-            pass
         elif not isinstance(block, Backtrack):
             raise AssertionError(u'Found a non-Filter/Traverse IR block in the folded IR blocks: '
                                  u'{} {} {}'.format(type(block), block, fold_ir_blocks))

--- a/graphql_compiler/compiler/ir_lowering_match.py
+++ b/graphql_compiler/compiler/ir_lowering_match.py
@@ -369,6 +369,14 @@ def lower_folded_coerce_types_into_filter_blocks(folded_ir_blocks):
     return new_folded_ir_blocks
 
 
+def remove_backtrack_blocks_from_fold(folded_ir_blocks):
+    new_folded_ir_blocks = []
+    for block in folded_ir_blocks:
+        if not isinstance(block, Backtrack):
+            new_folded_ir_blocks.append(block)
+    return new_folded_ir_blocks
+
+
 ##############
 # Public API #
 ##############
@@ -420,7 +428,10 @@ def lower_ir(ir_blocks, location_types, type_equivalence_hints=None):
     # Optimize and lower the IR blocks inside @fold scopes.
     new_folds = {
         key: merge_consecutive_filter_clauses(
-            lower_folded_coerce_types_into_filter_blocks(folded_ir_blocks))
+            remove_backtrack_blocks_from_fold(
+                lower_folded_coerce_types_into_filter_blocks(folded_ir_blocks)
+            )
+        )
         for key, folded_ir_blocks in six.iteritems(match_query.folds)
     }
     match_query = match_query._replace(folds=new_folds)

--- a/graphql_compiler/compiler/ir_lowering_match.py
+++ b/graphql_compiler/compiler/ir_lowering_match.py
@@ -370,6 +370,7 @@ def lower_folded_coerce_types_into_filter_blocks(folded_ir_blocks):
 
 
 def remove_backtrack_blocks_from_fold(folded_ir_blocks):
+    '''Return a list of IR blocks with all Backtrack blocks removed.'''
     new_folded_ir_blocks = []
     for block in folded_ir_blocks:
         if not isinstance(block, Backtrack):

--- a/graphql_compiler/compiler/ir_lowering_match.py
+++ b/graphql_compiler/compiler/ir_lowering_match.py
@@ -370,7 +370,7 @@ def lower_folded_coerce_types_into_filter_blocks(folded_ir_blocks):
 
 
 def remove_backtrack_blocks_from_fold(folded_ir_blocks):
-    '''Return a list of IR blocks with all Backtrack blocks removed.'''
+    """Return a list of IR blocks with all Backtrack blocks removed."""
     new_folded_ir_blocks = []
     for block in folded_ir_blocks:
         if not isinstance(block, Backtrack):

--- a/graphql_compiler/compiler/ir_sanity_checks.py
+++ b/graphql_compiler/compiler/ir_sanity_checks.py
@@ -133,8 +133,18 @@ def _sanity_check_every_location_is_marked(ir_blocks):
     # Exactly one MarkLocation block is found between a QueryRoot / Traverse / Recurse block,
     # and the first subsequent Traverse, Recurse, Backtrack or ConstructResult block.
     found_start_block = False
+    found_fold_block = False
     mark_location_blocks = 0
+
     for block in ir_blocks:
+        # Don't need to mark locations after a fold block
+        if isinstance(block, Fold):
+            found_fold_block = True
+        if found_fold_block:
+            if isinstance(block, Unfold):
+                found_fold_block = False
+            continue
+
         # Terminate started intervals before opening new ones.
         end_interval_types = (Backtrack, ConstructResult, Recurse, Traverse)
         if isinstance(block, end_interval_types) and found_start_block:
@@ -149,9 +159,6 @@ def _sanity_check_every_location_is_marked(ir_blocks):
         elif isinstance(block, (QueryRoot, Traverse, Recurse)):
             found_start_block = True
             mark_location_blocks = 0
-        # Don't need to mark locations after a fold block
-        elif isinstance(block, Fold):
-            break
 
 
 def _sanity_check_coerce_type_outside_of_fold(ir_blocks):

--- a/graphql_compiler/compiler/ir_sanity_checks.py
+++ b/graphql_compiler/compiler/ir_sanity_checks.py
@@ -149,6 +149,9 @@ def _sanity_check_every_location_is_marked(ir_blocks):
         elif isinstance(block, (QueryRoot, Traverse, Recurse)):
             found_start_block = True
             mark_location_blocks = 0
+        # Don't need to mark locations after a fold block
+        elif isinstance(block, Fold):
+            break
 
 
 def _sanity_check_coerce_type_outside_of_fold(ir_blocks):

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -1855,6 +1855,31 @@ FROM (
 
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
+    def test_multiple_folds_and_traverse(self):
+        test_data = test_input_data.multiple_folds_and_traverse()
+
+        expected_match = '''
+            SELECT
+                Animal___1.name AS `animal_name`,
+                $Animal___1___out_Animal_ParentOf.name AS `child_names_list`,
+                $Animal___1___out_Animal_ParentOf.uuid AS `child_uuids_list`,
+                $Animal___1___in_Animal_ParentOf.name AS `parent_names_list`,
+                $Animal___1___in_Animal_ParentOf.uuid AS `parent_uuids_list`
+            FROM (
+                MATCH {{
+                    class: Animal,
+                    as: Animal___1
+                }}
+                RETURN $matches
+            ) LET
+                $Animal___1___in_Animal_ParentOf =
+                    Animal___1.in("Animal_ParentOf").out("Animal_ParentOf").asList(),
+                $Animal___1___out_Animal_ParentOf =
+                    Animal___1.out("Animal_ParentOf").in("Animal_ParentOf").asList()
+        '''
+
+        check_test_data(self, test_data, expected_match)
+
     def test_fold_date_and_datetime_fields(self):
         test_data = test_input_data.fold_date_and_datetime_fields()
 

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -10,7 +10,23 @@ from ..compiler import OutputMetadata, compile_graphql_to_gremlin, compile_graph
 from .test_helpers import compare_gremlin, compare_input_metadata, compare_match, get_schema
 
 
-def check_test_data(test_case, test_data, expected_match, expected_gremlin):
+def check_test_data_match(test_case, test_data, expected, schema_based_type_equivalence_hints):
+    result = compile_graphql_to_match(test_case.schema, test_data.graphql_input,
+                                      type_equivalence_hints=schema_based_type_equivalence_hints)
+    compare_match(test_case, expected, result.query)
+    test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
+    compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
+
+
+def check_test_data_gremlin(test_case, test_data, expected, schema_based_type_equivalence_hints):
+    result = compile_graphql_to_gremlin(test_case.schema, test_data.graphql_input,
+                                        type_equivalence_hints=schema_based_type_equivalence_hints)
+    compare_gremlin(test_case, expected, result.query)
+    test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
+    compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
+
+
+def check_test_data(test_case, test_data, expected_match, expected_gremlin=None):
     """Assert that the GraphQL input generates all expected MATCH and Gremlin data."""
     if test_data.type_equivalence_hints:
         # For test convenience, we accept the type equivalence hints in string form.
@@ -22,17 +38,11 @@ def check_test_data(test_case, test_data, expected_match, expected_gremlin):
     else:
         schema_based_type_equivalence_hints = None
 
-    result = compile_graphql_to_match(test_case.schema, test_data.graphql_input,
-                                      type_equivalence_hints=schema_based_type_equivalence_hints)
-    compare_match(test_case, expected_match, result.query)
-    test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
-    compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
-
-    result = compile_graphql_to_gremlin(test_case.schema, test_data.graphql_input,
-                                        type_equivalence_hints=schema_based_type_equivalence_hints)
-    compare_gremlin(test_case, expected_gremlin, result.query)
-    test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
-    compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
+    check_test_data_match(test_case, test_data, expected_match,
+                          schema_based_type_equivalence_hints)
+    if expected_gremlin:
+        check_test_data_gremlin(test_case, test_data, expected_gremlin,
+                                schema_based_type_equivalence_hints)
 
 
 class CompilerTests(unittest.TestCase):
@@ -1691,6 +1701,86 @@ FROM (
 
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
+    def test_fold_and_traverse(self):
+        test_data = test_input_data.fold_and_traverse()
+
+        expected_match = '''
+            SELECT
+                Animal___1.name AS `animal_name`,
+                $Animal___1___in_Animal_ParentOf.name
+                    AS `sibling_and_self_names_list`
+            FROM (
+                MATCH {{
+                    class: Animal,
+                    as: Animal___1
+                }}
+                RETURN $matches
+            ) LET
+                $Animal___1___in_Animal_ParentOf =
+                    Animal___1.in("Animal_ParentOf").out("Animal_ParentOf").asList()
+        '''
+        expected_gremlin = '''
+            g.V('@class', 'Animal')
+            .as('Animal___1')
+            .in('Animal_ParentOf')
+            .as('Animal__in_Animal_ParentOf___1')
+            .back('Animal___1')
+            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
+                animal_name: m.Animal___1.name,
+                sibling_and_self_names_list: (
+                    (m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf == null) ? [] : (
+                        m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf.collect{
+                            entry -> entry.inV.next().name
+                        }
+                    )
+                )
+            ])}
+        '''
+
+        check_test_data(self, test_data, expected_match)
+
+    def test_traverse_and_fold_and_traverse(self):
+        test_data = test_input_data.traverse_and_fold_and_traverse()
+
+        expected_match = '''
+            SELECT
+                Animal___1.name AS `animal_name`,
+                $Animal__in_Animal_ParentOf___1___out_Animal_ParentOf.name
+                    AS `sibling_and_self_names_list`
+            FROM (
+                MATCH {{
+                    class: Animal,
+                    as: Animal___1
+                }}.in('Animal_ParentOf') {{
+                    as: Animal__in_Animal_ParentOf___1
+                }}
+                RETURN $matches
+            ) LET
+                $Animal__in_Animal_ParentOf___1___out_Animal_ParentOf =
+                    Animal__in_Animal_ParentOf___1
+                        .out("Animal_ParentOf")
+                        .in("Animal_ParentOf").asList()
+        '''
+        expected_gremlin = '''
+            g.V('@class', 'Animal')
+            .as('Animal___1')
+            .in('Animal_ParentOf')
+            .as('Animal__in_Animal_ParentOf___1')
+            .back('Animal___1')
+            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
+                animal_name: m.Animal___1.name,
+                sibling_and_self_names_list: (
+                    (m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf == null) ? [] : (
+                        m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf.collect{
+                            entry -> entry.inV.next().name
+                        }
+                    )
+                )
+            ])}
+        '''
+
+        check_test_data(self, test_data, expected_match)
+
     def test_multiple_outputs_in_same_fold(self):
         test_data = test_input_data.multiple_outputs_in_same_fold()
 
@@ -1727,6 +1817,44 @@ FROM (
         '''
 
         check_test_data(self, test_data, expected_match, expected_gremlin)
+
+    def test_multiple_outputs_in_same_fold_and_traverse(self):
+        test_data = test_input_data.multiple_outputs_in_same_fold_and_traverse()
+
+        expected_match = '''
+            SELECT
+                Animal___1.name AS `animal_name`,
+                $Animal___1___in_Animal_ParentOf.name AS `sibling_and_self_names_list`,
+                $Animal___1___in_Animal_ParentOf.uuid AS `sibling_and_self_uuids_list`
+            FROM (
+                MATCH {{
+                    class: Animal,
+                    as: Animal___1
+                }}
+                RETURN $matches
+            ) LET
+                $Animal___1___in_Animal_ParentOf =
+                    Animal___1.in("Animal_ParentOf").out("Animal_ParentOf").asList()
+        '''
+        expected_gremlin = '''
+            g.V('@class', 'Animal')
+            .as('Animal___1')
+            .in('Animal_ParentOf')
+            .as('Animal__in_Animal_ParentOf___1')
+            .back('Animal___1')
+            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
+                animal_name: m.Animal___1.name,
+                sibling_and_self_names_list: (
+                    (m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf == null) ? [] : (
+                        m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf.collect{
+                            entry -> entry.inV.next().name
+                        }
+                    )
+                )
+            ])}
+        '''
+
+        check_test_data(self, test_data, expected_match)
 
     def test_multiple_folds(self):
         test_data = test_input_data.multiple_folds()

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -1719,23 +1719,6 @@ FROM (
                 $Animal___1___in_Animal_ParentOf =
                     Animal___1.in("Animal_ParentOf").out("Animal_ParentOf").asList()
         '''
-        expected_gremlin = '''
-            g.V('@class', 'Animal')
-            .as('Animal___1')
-            .in('Animal_ParentOf')
-            .as('Animal__in_Animal_ParentOf___1')
-            .back('Animal___1')
-            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
-                animal_name: m.Animal___1.name,
-                sibling_and_self_names_list: (
-                    (m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf == null) ? [] : (
-                        m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf.collect{
-                            entry -> entry.inV.next().name
-                        }
-                    )
-                )
-            ])}
-        '''
 
         check_test_data(self, test_data, expected_match)
 
@@ -1760,23 +1743,6 @@ FROM (
                     Animal__in_Animal_ParentOf___1
                         .out("Animal_ParentOf")
                         .in("Animal_ParentOf").asList()
-        '''
-        expected_gremlin = '''
-            g.V('@class', 'Animal')
-            .as('Animal___1')
-            .in('Animal_ParentOf')
-            .as('Animal__in_Animal_ParentOf___1')
-            .back('Animal___1')
-            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
-                animal_name: m.Animal___1.name,
-                sibling_and_self_names_list: (
-                    (m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf == null) ? [] : (
-                        m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf.collect{
-                            entry -> entry.inV.next().name
-                        }
-                    )
-                )
-            ])}
         '''
 
         check_test_data(self, test_data, expected_match)
@@ -1835,23 +1801,6 @@ FROM (
             ) LET
                 $Animal___1___in_Animal_ParentOf =
                     Animal___1.in("Animal_ParentOf").out("Animal_ParentOf").asList()
-        '''
-        expected_gremlin = '''
-            g.V('@class', 'Animal')
-            .as('Animal___1')
-            .in('Animal_ParentOf')
-            .as('Animal__in_Animal_ParentOf___1')
-            .back('Animal___1')
-            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
-                animal_name: m.Animal___1.name,
-                sibling_and_self_names_list: (
-                    (m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf == null) ? [] : (
-                        m.Animal__in_Animal_ParentOf___1.out_Animal_ParentOf.collect{
-                            entry -> entry.inV.next().name
-                        }
-                    )
-                )
-            ])}
         '''
 
         check_test_data(self, test_data, expected_match)

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -937,6 +937,31 @@ def fold_on_output_variable():
         type_equivalence_hints=None)
 
 
+def fold_and_traverse():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            in_Animal_ParentOf @fold {
+                out_Animal_ParentOf {
+                    name @output(out_name: "sibling_and_self_names_list")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'sibling_and_self_names_list': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
 def fold_after_traverse():
     graphql_input = '''{
         Animal {
@@ -944,6 +969,33 @@ def fold_after_traverse():
             in_Animal_ParentOf {
                 out_Animal_ParentOf @fold {
                     name @output(out_name: "sibling_and_self_names_list")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'sibling_and_self_names_list': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def traverse_and_fold_and_traverse():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            in_Animal_ParentOf {
+                out_Animal_ParentOf @fold {
+                    in_Animal_ParentOf {
+                        name @output(out_name: "sibling_and_self_names_list")
+                    }
                 }
             }
         }
@@ -976,6 +1028,34 @@ def multiple_outputs_in_same_fold():
         'animal_name': OutputMetadata(type=GraphQLString, optional=False),
         'child_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
         'child_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
+def multiple_outputs_in_same_fold_and_traverse():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            in_Animal_ParentOf @fold {
+                out_Animal_ParentOf {
+                    name @output(out_name: "sibling_and_self_names_list")
+                    uuid @output(out_name: "sibling_and_self_uuids_list")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'sibling_and_self_names_list': OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False),
+        'sibling_and_self_uuids_list': OutputMetadata(
+            type=GraphQLList(GraphQLID), optional=False),
     }
     expected_input_metadata = {}
 

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -1096,6 +1096,40 @@ def multiple_folds():
         type_equivalence_hints=None)
 
 
+def multiple_folds_and_traverse():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ParentOf @fold {
+                in_Animal_ParentOf {
+                    name @output(out_name: "child_names_list")
+                    uuid @output(out_name: "child_uuids_list")
+                }
+            }
+            in_Animal_ParentOf @fold {
+                out_Animal_ParentOf {
+                    name @output(out_name: "parent_names_list")
+                    uuid @output(out_name: "parent_uuids_list")
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'child_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
+        'child_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
+        'parent_names_list': OutputMetadata(type=GraphQLList(GraphQLString), optional=False),
+        'parent_uuids_list': OutputMetadata(type=GraphQLList(GraphQLID), optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
 def fold_date_and_datetime_fields():
     graphql_input = '''{
         Animal {

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -196,11 +196,23 @@ class IrGenerationErrorTests(unittest.TestCase):
             }
         }'''
 
-        traversal_inside_fold_block = '''{
+        multi_level_outputs_inside_fold_block = '''{
             Animal {
                 out_Animal_ParentOf @fold {
+                    uuid @output(out_name: "uuid")
                     out_Animal_FedAt {
                         uuid @output(out_name: "uuid")
+                    }
+                }
+            }
+        }'''
+
+        traversal_inside_fold_block_after_output = '''{
+            Animal {
+                out_Animal_ParentOf @fold {
+                    uuid @output(out_name: "uuid")
+                    out_Animal_FedAt {
+                        uuid
                     }
                 }
             }
@@ -217,7 +229,8 @@ class IrGenerationErrorTests(unittest.TestCase):
 
         for graphql in (fold_on_property_field,
                         fold_on_root_vertex,
-                        traversal_inside_fold_block,
+                        multi_level_outputs_inside_fold_block,
+                        traversal_inside_fold_block_after_output,
                         no_outputs_inside_fold_block):
             with self.assertRaises(GraphQLCompilationError):
                 graphql_to_ir(self.schema, graphql)


### PR DESCRIPTION
Added `MATCH` generation support for `graphql` queries with traversal within a `@fold` scope. Also added test cases.