### PR TITLE
Add a script that ensures all python files have a copyright notice.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ install:
   - pip install -r dev-requirements.txt
   - pip install -e .
 script:
+  - ./scripts/copyright_line_check.sh
+  - isort --check-only --verbose --recursive graphql_compiler/
   - flake8 graphql_compiler/
   - pydocstyle graphql_compiler/
-  - isort --check-only --verbose --recursive graphql_compiler/
   - pylint graphql_compiler/
   - bandit -r graphql_compiler/
   - py.test --cov=graphql_compiler graphql_compiler/tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,13 +33,19 @@ This project follows the
 
 Additionally, any contributions must pass the following set of lint and style checks with no issues:
 ```
+isort --check-only --verbose --recursive graphql_compiler/
+
 flake8 graphql_compiler/
 
 pydocstyle graphql_compiler/
 
-isort --check-only --verbose --recursive graphql_compiler/
-
 pylint graphql_compiler/
 
 bandit -r graphql_compiler/
+```
+
+Finally, all python files in the repository must display the copyright of the project,
+to protect the terms of the license. Please make sure that your files start with a line like:
+```
+# Copyright 20xx-present Kensho Technologies, LLC.
 ```

--- a/graphql_compiler/tool.py
+++ b/graphql_compiler/tool.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2017-present Kensho Technologies, LLC.
 """Utility modeled after json.tool, pretty-prints GraphQL read from stdin and outputs to stdout.
 

--- a/scripts/copyright_line_check.sh
+++ b/scripts/copyright_line_check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright 2018-present Kensho Technologies, LLC.
+
+# Fail on first error, on undefined variables, and on errors in a pipeline.
+set -euo pipefail
+
+# Enable recursive globbing, and make globs that do not match return null values.
+shopt -s globstar nullglob
+
+# Make sure the current working directory is the root directory.
+if [ ! -f "./requirements.txt" ] || [ ! -f "./CHANGELOG.md" ]; then
+    echo -e 'Please run this script from the root directory of the repo:\n'
+    echo -e '    ./scripts/copyright_line_check.sh\n'
+    exit 1
+fi
+
+ensure_file_has_copyright_line() {
+    filename="$1"
+
+    lines_to_examine=2
+    copyright_regex='# Copyright 2\d\d\d\-present Kensho Technologies, LLC\.'
+
+    set +e
+    head -"$lines_to_examine" "$filename" | grep -e "$copyright_regex" >/dev/null
+    result="$?"
+    set -e
+
+    if [[ "$result" != "0" ]]; then
+        # The check will have to be more sophisticated if we
+        echo "The file $filename appears to be missing a copyright line."
+        echo 'Please add the following at the top of the file (right after the #! line in scripts):'
+        echo -e "\n    # Copyright $(date +%Y)-present Kensho Technologies, LLC.\n"
+    fi
+}
+
+ensure_file_has_copyright_line './setup.py'
+for filename in ./graphql_compiler/**/*.py; do
+    ensure_file_has_copyright_line "$filename"
+done
+

--- a/scripts/copyright_line_check.sh
+++ b/scripts/copyright_line_check.sh
@@ -33,7 +33,12 @@ ensure_file_has_copyright_line() {
     fi
 }
 
+# There may be many Python files in the root directory that are not checked into the repo:
+# virtualenv files, package build files etc.
+# Only check the setup.py file in the root directory.
 ensure_file_has_copyright_line './setup.py'
+
+# Check every python file in the package's source directory.
 for filename in ./graphql_compiler/**/*.py; do
     ensure_file_has_copyright_line "$filename"
 done


### PR DESCRIPTION
All python files need to have a copyright notice at the top of the file. This script will make sure that all newly-added files follow that requirement.