### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Current development version
 
+## v1.6.1
+
+- Fix a bad compilation bug on `@fold` and `@optional` in the same scope. [#86](https://github.com/kensho-technologies/graphql-compiler/pull/86)
+
+Thanks to `amartyashankha` for the fix!
+
 ## v1.6.0
 
 - Add full support for `Decimal` data, including both filtering and output. [#91](https://github.com/kensho-technologies/graphql-compiler/pull/91)

--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -14,7 +14,7 @@ from .schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal  # noqa
 
 
 __package_name__ = 'graphql-compiler'
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 
 
 def graphql_to_match(schema, graphql_query, parameters, type_equivalence_hints=None):


### PR DESCRIPTION
Fixes the bad compilation with `@fold` and `@optional` inside the same vertex field.