### PR TITLE
Delete unnecessary lowering pass.

### DIFF
--- a/graphql_compiler/compiler/ir_lowering_match/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_match/__init__.py
@@ -9,7 +9,7 @@ from ..ir_lowering_common import (extract_optional_location_root_info,
 from .ir_lowering import (lower_backtrack_blocks,
                           lower_folded_coerce_types_into_filter_blocks,
                           lower_has_substring_binary_compositions,
-                          lower_optional_traverse_blocks, remove_backtrack_blocks_from_fold,
+                          remove_backtrack_blocks_from_fold,
                           rewrite_binary_composition_inside_ternary_conditional,
                           truncate_repeated_single_step_traversals)
 from ..ir_sanity_checks import sanity_check_ir_blocks_from_frontend
@@ -81,7 +81,6 @@ def lower_ir(ir_blocks, location_types, type_equivalence_hints=None):
 
     match_query = lower_comparisons_to_between(match_query)
 
-    match_query = lower_optional_traverse_blocks(match_query, location_types)
     match_query = lower_backtrack_blocks(match_query, location_types)
     match_query = truncate_repeated_single_step_traversals(match_query)
     match_query = orientdb_class_with_while.workaround_type_coercions_in_recursions(match_query)

--- a/graphql_compiler/tests/test_ir_lowering.py
+++ b/graphql_compiler/tests/test_ir_lowering.py
@@ -477,8 +477,7 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         expected_final_query = convert_to_match_query(expected_final_blocks)
 
-        temp_query = ir_lowering_match.lower_optional_traverse_blocks(match_query, location_types)
-        temp_query = ir_lowering_match.lower_backtrack_blocks(temp_query, location_types)
+        temp_query = ir_lowering_match.lower_backtrack_blocks(match_query, location_types)
         final_query = ir_lowering_match.truncate_repeated_single_step_traversals(temp_query)
 
         check_test_data(self, expected_final_query, final_query)


### PR DESCRIPTION
Given that we now allow traversing inside optional scopes, Traverse blocks with optional=True do not require any special lowering. The corresponding Backtrack blocks' lowering is already handled in the generic Backtrack lowering step.