### PR TITLE
Truncate repeated single step traversals in CompoundMatchQuery.

### DIFF
--- a/graphql_compiler/compiler/ir_lowering_match/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_match/__init__.py
@@ -19,7 +19,7 @@ from .optional_traversal import (collect_filters_to_first_location_occurrence,
                                  lower_context_field_expressions, prune_non_existent_outputs)
 from ..match_query import convert_to_match_query
 from ..workarounds import orientdb_class_with_while, orientdb_eval_scheduling
-from .utils import construct_where_filter_predicate
+from .utils import construct_where_filter_predicate, CompoundMatchQuery
 
 ##############
 # Public API #
@@ -103,4 +103,9 @@ def lower_ir(ir_blocks, location_types, type_equivalence_hints=None):
     compound_match_query = lower_context_field_expressions(
         compound_match_query)
 
-    return compound_match_query
+    lowered_match_queries = []
+    for match_query in compound_match_query.match_queries:
+        new_match_query = truncate_repeated_single_step_traversals(match_query)
+        lowered_match_queries.append(new_match_query)
+
+    return CompoundMatchQuery(match_queries=lowered_match_queries)

--- a/graphql_compiler/compiler/ir_lowering_match/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_match/__init__.py
@@ -16,10 +16,11 @@ from ..ir_sanity_checks import sanity_check_ir_blocks_from_frontend
 from .between_lowering import lower_comparisons_to_between
 from .optional_traversal import (collect_filters_to_first_location_occurrence,
                                  convert_optional_traversals_to_compound_match_query,
-                                 lower_context_field_expressions, prune_non_existent_outputs)
+                                 lower_context_field_expressions, lower_sub_queries,
+                                 prune_non_existent_outputs)
 from ..match_query import convert_to_match_query
 from ..workarounds import orientdb_class_with_while, orientdb_eval_scheduling
-from .utils import construct_where_filter_predicate, CompoundMatchQuery
+from .utils import construct_where_filter_predicate
 
 ##############
 # Public API #
@@ -103,9 +104,4 @@ def lower_ir(ir_blocks, location_types, type_equivalence_hints=None):
     compound_match_query = lower_context_field_expressions(
         compound_match_query)
 
-    lowered_match_queries = []
-    for match_query in compound_match_query.match_queries:
-        new_match_query = truncate_repeated_single_step_traversals(match_query)
-        lowered_match_queries.append(new_match_query)
-
-    return CompoundMatchQuery(match_queries=lowered_match_queries)
+    return lower_sub_queries(compound_match_query)

--- a/graphql_compiler/compiler/ir_lowering_match/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_match/__init__.py
@@ -11,13 +11,13 @@ from .ir_lowering import (lower_backtrack_blocks,
                           lower_has_substring_binary_compositions,
                           remove_backtrack_blocks_from_fold,
                           rewrite_binary_composition_inside_ternary_conditional,
-                          truncate_repeated_single_step_traversals)
+                          truncate_repeated_single_step_traversals,
+                          truncate_repeated_single_step_traversals_in_sub_queries)
 from ..ir_sanity_checks import sanity_check_ir_blocks_from_frontend
 from .between_lowering import lower_comparisons_to_between
 from .optional_traversal import (collect_filters_to_first_location_occurrence,
                                  convert_optional_traversals_to_compound_match_query,
-                                 lower_context_field_expressions, lower_sub_queries,
-                                 prune_non_existent_outputs)
+                                 lower_context_field_expressions, prune_non_existent_outputs)
 from ..match_query import convert_to_match_query
 from ..workarounds import orientdb_class_with_while, orientdb_eval_scheduling
 from .utils import construct_where_filter_predicate
@@ -104,4 +104,7 @@ def lower_ir(ir_blocks, location_types, type_equivalence_hints=None):
     compound_match_query = lower_context_field_expressions(
         compound_match_query)
 
-    return lower_sub_queries(compound_match_query)
+    compound_match_query = truncate_repeated_single_step_traversals_in_sub_queries(
+        compound_match_query)
+
+    return compound_match_query

--- a/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
@@ -16,6 +16,7 @@ from ..expressions import (BinaryComposition, ContextField, ContextFieldExistenc
                            FoldedOutputContextField, Literal, LocalField, TernaryConditional,
                            TrueLiteral)
 from ..helpers import FoldScopeLocation
+from .utils import CompoundMatchQuery
 
 
 ##################################
@@ -351,3 +352,13 @@ def remove_backtrack_blocks_from_fold(folded_ir_blocks):
         if not isinstance(block, Backtrack):
             new_folded_ir_blocks.append(block)
     return new_folded_ir_blocks
+
+
+def truncate_repeated_single_step_traversals_in_sub_queries(compound_match_query):
+    """For each sub-query, remove one-step traversals that overlap a previous traversal location."""
+    lowered_match_queries = []
+    for match_query in compound_match_query.match_queries:
+        new_match_query = truncate_repeated_single_step_traversals(match_query)
+        lowered_match_queries.append(new_match_query)
+
+    return CompoundMatchQuery(match_queries=lowered_match_queries)

--- a/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
@@ -158,13 +158,13 @@ def truncate_repeated_single_step_traversals(match_query):
             if single_step.as_block.location in visited_locations:
                 # This location was visited before, omit the traversal.
                 ignore_traversal = True
-        else:
+
+        if not ignore_traversal:
             # For each step in this traversal, mark its location as visited.
             for step in current_match_traversal:
                 if step.as_block is not None:
                     visited_locations.add(step.as_block.location)
 
-        if not ignore_traversal:
             new_match_traversals.append(current_match_traversal)
 
     return match_query._replace(match_traversals=new_match_traversals)

--- a/graphql_compiler/compiler/ir_lowering_match/optional_traversal.py
+++ b/graphql_compiler/compiler/ir_lowering_match/optional_traversal.py
@@ -9,7 +9,6 @@ from ..expressions import (BinaryComposition, ContextField, FoldedOutputContextF
                            LocalField, OutputContextField, TernaryConditional, TrueLiteral,
                            UnaryTransformation, Variable)
 from ..match_query import MatchQuery, MatchStep
-from .ir_lowering import truncate_repeated_single_step_traversals
 from .utils import (BetweenClause, CompoundMatchQuery, expression_list_to_conjunction,
                     filter_edge_field_non_existence)
 
@@ -560,13 +559,3 @@ def lower_context_field_expressions(compound_match_query):
             )
 
     return CompoundMatchQuery(match_queries=new_match_queries)
-
-
-def lower_sub_queries(compound_match_query):
-    """Apply lowering steps to each sub-query within the given CompoundMatchQuery."""
-    lowered_match_queries = []
-    for match_query in compound_match_query.match_queries:
-        new_match_query = truncate_repeated_single_step_traversals(match_query)
-        lowered_match_queries.append(new_match_query)
-
-    return CompoundMatchQuery(match_queries=lowered_match_queries)

--- a/graphql_compiler/compiler/ir_lowering_match/optional_traversal.py
+++ b/graphql_compiler/compiler/ir_lowering_match/optional_traversal.py
@@ -9,6 +9,7 @@ from ..expressions import (BinaryComposition, ContextField, FoldedOutputContextF
                            LocalField, OutputContextField, TernaryConditional, TrueLiteral,
                            UnaryTransformation, Variable)
 from ..match_query import MatchQuery, MatchStep
+from .ir_lowering import truncate_repeated_single_step_traversals
 from .utils import (BetweenClause, CompoundMatchQuery, expression_list_to_conjunction,
                     filter_edge_field_non_existence)
 
@@ -559,3 +560,13 @@ def lower_context_field_expressions(compound_match_query):
             )
 
     return CompoundMatchQuery(match_queries=new_match_queries)
+
+
+def lower_sub_queries(compound_match_query):
+    """Apply lowering steps to each sub-query within the given CompoundMatchQuery."""
+    lowered_match_queries = []
+    for match_query in compound_match_query.match_queries:
+        new_match_query = truncate_repeated_single_step_traversals(match_query)
+        lowered_match_queries.append(new_match_query)
+
+    return CompoundMatchQuery(match_queries=lowered_match_queries)

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -3264,10 +3264,6 @@ class CompilerTests(unittest.TestCase):
                             )
                         )),
                         as: Animal___1
-                    }} ,
-                    {{
-                        class: Animal,
-                        as: Animal___1
                     }}
                     RETURN $matches
                 )
@@ -3295,10 +3291,6 @@ class CompilerTests(unittest.TestCase):
                         as: Animal__in_Animal_ParentOf___1
                     }}.out('Animal_ParentOf') {{
                         as: Animal__in_Animal_ParentOf__out_Animal_ParentOf___1
-                    }} ,
-                    {{
-                        class: Animal,
-                        as: Animal___1
                     }}
                     RETURN $matches
                 )
@@ -3436,10 +3428,6 @@ class CompilerTests(unittest.TestCase):
                     }}.in('Animal_ParentOf') {{
                         optional: true,
                         as: Animal__in_Animal_ParentOf___1
-                    }} ,
-                    {{
-                        class: Animal,
-                        as: Animal___1
                     }}
                     RETURN $matches
                 )
@@ -3823,11 +3811,7 @@ class CompilerTests(unittest.TestCase):
                     }}.out('Animal_FedAt') {{
                         optional: true,
                         as: Animal__out_Animal_ParentOf__out_Animal_FedAt___1
-                    }} ,
-                    {{
-                        class: Animal,
-                        as: Animal__out_Animal_ParentOf___1
-                    }} ,
+                    }},
                     {{
                         class: Animal,
                         as: Animal___1


### PR DESCRIPTION
Also fixed bug in `truncate_repeated_single_step_traversals`.