### PR TITLE
Ensure that multiple traversals from a type-coerced location work correctly

### DIFF
--- a/graphql_compiler/compiler/workarounds/orientdb_query_execution.py
+++ b/graphql_compiler/compiler/workarounds/orientdb_query_execution.py
@@ -267,8 +267,10 @@ def _expose_only_preferred_locations(match_query, location_types, coerced_locati
                     # we ensure that we again infer the same type bound.
                     eligible_location_types[current_step_location] = current_type_bound
 
-                    if current_step_location not in coerced_locations:
-                        # The type bound here is already implied by the GraphQL query structure.
+                    if (current_step_location not in coerced_locations or
+                            previous_type_bound is not None):
+                        # The type bound here is already implied by the GraphQL query structure,
+                        # or has already been applied at a previous occurrence of this location.
                         # We can simply delete the QueryRoot / CoerceType blocks that impart it.
                         if isinstance(match_step.root_block, QueryRoot):
                             new_root_block = None

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -567,6 +567,41 @@ def filter_then_apply_fragment():
         type_equivalence_hints=None)
 
 
+def filter_then_apply_fragment_with_multiple_traverses():
+    graphql_input = '''{
+        Species {
+            name @filter(op_name: "in_collection", value: ["$species"])
+                 @output(out_name: "species_name")
+            out_Species_Eats {
+                ... on Food {
+                    name @output(out_name: "food_name")
+                    out_Entity_Related {
+                        name @output(out_name: "entity_related_to_food")
+                    }
+                    in_Entity_Related {
+                        name @output(out_name: "food_related_to_entity")
+                    }
+                }
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'species_name': OutputMetadata(type=GraphQLString, optional=False),
+        'food_name': OutputMetadata(type=GraphQLString, optional=False),
+        'entity_related_to_food': OutputMetadata(type=GraphQLString, optional=False),
+        'food_related_to_entity': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {
+        'species': GraphQLList(GraphQLString),
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
 def filter_on_fragment_in_union():
     graphql_input = '''{
         Species {

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -976,6 +976,54 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
+    def test_filter_then_apply_fragment_with_multiple_traverses(self):
+        test_data = test_input_data.filter_then_apply_fragment_with_multiple_traverses()
+
+        base_location = helpers.Location(('Species',))
+        food_location = base_location.navigate_to_subpath('out_Species_Eats')
+        entity_related_location = food_location.navigate_to_subpath('out_Entity_Related')
+        food_related_location = food_location.navigate_to_subpath('in_Entity_Related')
+
+        expected_blocks = [
+            blocks.QueryRoot({'Species'}),
+            blocks.Filter(
+                expressions.BinaryComposition(
+                    u'contains',
+                    expressions.Variable('$species', GraphQLList(GraphQLString)),
+                    expressions.LocalField('name')
+                )
+            ),
+            blocks.MarkLocation(base_location),
+            blocks.Traverse('out', 'Species_Eats'),
+            blocks.CoerceType({'Food'}),
+            blocks.MarkLocation(food_location),
+            blocks.Traverse('out', 'Entity_Related'),
+            blocks.MarkLocation(entity_related_location),
+            blocks.Backtrack(food_location),
+            blocks.Traverse('in', 'Entity_Related'),
+            blocks.MarkLocation(food_related_location),
+            blocks.Backtrack(food_location),
+            blocks.Backtrack(base_location),
+            blocks.ConstructResult({
+                'species_name': expressions.OutputContextField(
+                    base_location.navigate_to_field('name'), GraphQLString),
+                'food_name': expressions.OutputContextField(
+                    food_location.navigate_to_field('name'), GraphQLString),
+                'entity_related_to_food': expressions.OutputContextField(
+                    entity_related_location.navigate_to_field('name'), GraphQLString),
+                'food_related_to_entity': expressions.OutputContextField(
+                    food_related_location.navigate_to_field('name'), GraphQLString),
+            }),
+        ]
+        expected_location_types = {
+            base_location: 'Species',
+            food_location: 'Food',
+            entity_related_location: 'Entity',
+            food_related_location: 'Entity',
+        }
+
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
+
     def test_filter_on_fragment_in_union(self):
         test_data = test_input_data.filter_on_fragment_in_union()
 


### PR DESCRIPTION
Added a test case that was incorrectly triggering an `AssertionError`, but now passes with the code change in this PR.