### PR TITLE
Add QueryMetadataTable, make FoldScopeLocations first-class location objects

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -436,7 +436,7 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
                 current_location_info.optional_scopes_depth + edge_traversal_is_optional),
             recursive_scopes_depth=(
                 current_location_info.recursive_scopes_depth + (recurse_directive is not None)),
-            is_folded=current_location_info.is_folded or (fold_directive is not None),
+            is_within_fold=current_location_info.is_within_fold or (fold_directive is not None),
         )
         query_metadata_table.register_location(inner_location, inner_location_info)
 
@@ -701,7 +701,7 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
         coerced_from_type=None,
         optional_scopes_depth=0,
         recursive_scopes_depth=0,
-        is_folded=False,
+        is_within_fold=False,
     )
     query_metadata_table = QueryMetadataTable(location, base_location_info)
 

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -803,18 +803,15 @@ def _compile_output_step(outputs):
         location = output_context['location']
         optional = output_context['optional']
         graphql_type = output_context['type']
-        fold_scope_location = output_context['fold']
 
         expression = None
         existence_check = None
-        if fold_scope_location:
+        if isinstance(location, FoldScopeLocation):
             if optional:
                 raise AssertionError(u'Unreachable state reached, optional in fold: '
                                      u'{}'.format(output_context))
 
-            _, field_name = location.get_location_name()
-            expression = expressions.FoldedOutputContextField(
-                fold_scope_location, field_name, graphql_type)
+            expression = expressions.FoldedOutputContextField(location, graphql_type)
         else:
             expression = expressions.OutputContextField(location, graphql_type)
 

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -403,6 +403,8 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
         in_topmost_optional_block = False
 
         edge_traversal_is_optional = optional_directive is not None
+        edge_traversal_is_folded = fold_directive is not None
+        edge_traversal_is_recursive = recurse_directive is not None
 
         # This is true for any vertex expanded within an @optional scope.
         # Currently @optional is not allowed within @optional.
@@ -435,8 +437,8 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
             optional_scopes_depth=(
                 current_location_info.optional_scopes_depth + edge_traversal_is_optional),
             recursive_scopes_depth=(
-                current_location_info.recursive_scopes_depth + (recurse_directive is not None)),
-            is_within_fold=current_location_info.is_within_fold or (fold_directive is not None),
+                current_location_info.recursive_scopes_depth + edge_traversal_is_recursive),
+            is_within_fold=(current_location_info.is_within_fold or edge_traversal_is_folded),
         )
         query_metadata_table.register_location(inner_location, inner_location_info)
 
@@ -465,7 +467,7 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
                                                 optional=edge_traversal_is_optional,
                                                 within_optional_scope=within_optional_scope))
 
-        if not fold_directive and not is_in_fold_scope(context):
+        if not edge_traversal_is_folded and not is_in_fold_scope(context):
             # Current block is either a Traverse or a Recurse that is not within any fold context.
             # Increment the `num_traverses` counter.
             old_location_stack_entry = context['marked_location_stack'][-1]
@@ -477,7 +479,7 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
                                                      inner_location, context)
         basic_blocks.extend(inner_basic_blocks)
 
-        if fold_directive:
+        if edge_traversal_is_folded:
             _validate_fold_has_outputs(context['fold'], context['outputs'])
             basic_blocks.append(blocks.Unfold())
             del context['fold']
@@ -502,7 +504,7 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
             (not has_encountered_output_source(context))
         )
         if backtracking_required:
-            if optional_directive is not None:
+            if edge_traversal_is_optional:
                 basic_blocks.append(blocks.Backtrack(location, optional=True))
 
                 # Exiting optional block!

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -430,7 +430,7 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
 
         inner_location_info = LocationInfo(
             parent_location=location,
-            type=field_schema_type,
+            type=field_schema_type.name,
             coerced_from_type=None,
             optional_scopes_depth=(
                 current_location_info.optional_scopes_depth + edge_traversal_is_optional),

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -353,6 +353,8 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
     basic_blocks = []
     query_metadata_table = context['metadata']
     current_location_info = query_metadata_table.get_location_info(location)
+    context['location_types'][location] = strip_non_null_from_type(current_schema_type)
+
     vertex_fields, property_fields = fields
 
     validate_vertex_directives(unique_local_directives)
@@ -373,8 +375,6 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
     # step V-3: mark the graph position, and process output_source directive
     if not is_in_fold_scope(context):
         # We only mark the position if we aren't in a folded scope.
-        # Folded scopes don't actually traverse to the location, so it's never really visited.
-        context['location_types'][location] = strip_non_null_from_type(current_schema_type)
         basic_blocks.append(_mark_location(location))
         # The following append is the Location corresponding to the initial MarkLocation
         # for the current vertex and the `num_traverses` counter set to 0.

--- a/graphql_compiler/compiler/context_helpers.py
+++ b/graphql_compiler/compiler/context_helpers.py
@@ -24,8 +24,9 @@ def has_encountered_output_source(context):
     return 'output_source' in context
 
 
-def validate_context_for_visiting_vertex_field(location, context):
+def validate_context_for_visiting_vertex_field(parent_location, vertex_field_name, context):
     """Ensure that the current context allows for visiting a vertex field."""
     if is_in_fold_innermost_scope_scope(context):
         raise GraphQLCompilationError(u'Traversing inside a @fold block after output is '
-                                      u'not supported! Location: {}'.format(location))
+                                      u'not supported! Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))

--- a/graphql_compiler/compiler/directive_helpers.py
+++ b/graphql_compiler/compiler/directive_helpers.py
@@ -153,7 +153,7 @@ def validate_root_vertex_directives(root_ast):
                                       u'{}'.format(disallowed_directives))
 
 
-def validate_vertex_field_directive_interactions(location, directives):
+def validate_vertex_field_directive_interactions(parent_location, vertex_field_name, directives):
     """Ensure that the specified vertex field directives are not mutually disallowed."""
     fold_directive = directives.get('fold', None)
     optional_directive = directives.get('optional', None)
@@ -162,26 +162,32 @@ def validate_vertex_field_directive_interactions(location, directives):
 
     if fold_directive and optional_directive:
         raise GraphQLCompilationError(u'@fold and @optional may not appear at the same '
-                                      u'vertex field! Location: {}'.format(location))
+                                      u'vertex field! Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
 
     if fold_directive and output_source_directive:
         raise GraphQLCompilationError(u'@fold and @output_source may not appear at the same '
-                                      u'vertex field! Location: {}'.format(location))
+                                      u'vertex field! Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
 
     if fold_directive and recurse_directive:
         raise GraphQLCompilationError(u'@fold and @recurse may not appear at the same '
-                                      u'vertex field! Location: {}'.format(location))
+                                      u'vertex field! Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
 
     if optional_directive and output_source_directive:
         raise GraphQLCompilationError(u'@optional and @output_source may not appear at the same '
-                                      u'vertex field! Location: {}'.format(location))
+                                      u'vertex field! Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
 
     if optional_directive and recurse_directive:
         raise GraphQLCompilationError(u'@optional and @recurse may not appear at the same '
-                                      u'vertex field! Location: {}'.format(location))
+                                      u'vertex field! Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
 
 
-def validate_vertex_field_directive_in_context(location, directives, context):
+def validate_vertex_field_directive_in_context(parent_location, vertex_field_name,
+                                               directives, context):
     """Ensure that the specified vertex field directives are allowed in the current context."""
     fold_directive = directives.get('fold', None)
     optional_directive = directives.get('optional', None)
@@ -194,26 +200,34 @@ def validate_vertex_field_directive_in_context(location, directives, context):
 
     if fold_directive and fold_context:
         raise GraphQLCompilationError(u'@fold is not allowed within a @fold traversal! '
-                                      u'Location: {}'.format(location))
+                                      u'Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
     if optional_directive and fold_context:
         raise GraphQLCompilationError(u'@optional is not allowed within a @fold traversal! '
-                                      u'Location: {}'.format(location))
+                                      u'Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
     if output_source_directive and fold_context:
         raise GraphQLCompilationError(u'@output_source is not allowed within a @fold traversal! '
-                                      u'Location: {}'.format(location))
+                                      u'Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
     if recurse_directive and fold_context:
         raise GraphQLCompilationError(u'@recurse is not allowed within a @fold traversal! '
-                                      u'Location: {}'.format(location))
+                                      u'Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
 
     if output_source_context and not fold_directive:
         raise GraphQLCompilationError(u'Found non-fold vertex field after the vertex marked '
-                                      u'output source! Location: {}'.format(location))
+                                      u'output source! Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
     if optional_context and optional_directive:
         raise GraphQLCompilationError(u'@optional is not allowed within a @optional traversal! '
-                                      u'Location: {}'.format(location))
+                                      u'Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
     if optional_context and fold_directive:
         raise GraphQLCompilationError(u'@fold is not allowed within a @optional traversal! '
-                                      u'Location: {}'.format(location))
+                                      u'Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))
     if optional_context and output_source_directive:
         raise GraphQLCompilationError(u'@output_source is not allowed within a @optional '
-                                      u'traversal! Location: {}'.format(location))
+                                      u'traversal! Parent location: {}, vertex field name: {}'
+                                      .format(parent_location, vertex_field_name))

--- a/graphql_compiler/compiler/emit_match.py
+++ b/graphql_compiler/compiler/emit_match.py
@@ -107,8 +107,8 @@ def _represent_fold(fold_location, fold_ir_blocks):
     start_let_template = u'$%(mark_name)s = %(base_location)s'
     traverse_edge_template = u'.%(direction)s("%(edge_name)s")'
     base_template = start_let_template + traverse_edge_template
-    edge_direction, edge_name = fold_location.relative_position
-    mark_name = fold_location.get_location_name()
+    edge_direction, edge_name = fold_location.fold_path[0]
+    mark_name, _ = fold_location.get_location_name()
     base_location_name, _ = fold_location.base_location.get_location_name()
 
     validate_safe_string(mark_name)

--- a/graphql_compiler/compiler/emit_match.py
+++ b/graphql_compiler/compiler/emit_match.py
@@ -107,7 +107,7 @@ def _represent_fold(fold_location, fold_ir_blocks):
     start_let_template = u'$%(mark_name)s = %(base_location)s'
     traverse_edge_template = u'.%(direction)s("%(edge_name)s")'
     base_template = start_let_template + traverse_edge_template
-    edge_direction, edge_name = fold_location.fold_path[0]
+    edge_direction, edge_name = fold_location.get_first_folded_edge()
     mark_name, _ = fold_location.get_location_name()
     base_location_name, _ = fold_location.base_location.get_location_name()
 

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -441,22 +441,20 @@ class OutputContextField(Expression):
 class FoldedOutputContextField(Expression):
     """An expression used to output data captured in a @fold scope."""
 
-    def __init__(self, fold_scope_location, field_name, field_type):
+    def __init__(self, fold_scope_location, field_type):
         """Construct a new FoldedOutputContextField object for this folded field.
 
         Args:
-            fold_scope_location: FoldScopeLocation specifying the start of the @fold scope
-                                 where this output context field was captured.
-            field_name: string, the name of the field being output.
+            fold_scope_location: FoldScopeLocation specifying the location of
+                                 the context field being output.
             field_type: GraphQL type object, specifying the type of the field being output.
                         Since the field is folded, this must be a GraphQLList of some kind.
 
         Returns:
             new FoldedOutputContextField object
         """
-        super(FoldedOutputContextField, self).__init__(fold_scope_location, field_name, field_type)
+        super(FoldedOutputContextField, self).__init__(fold_scope_location, field_type)
         self.fold_scope_location = fold_scope_location
-        self.field_name = field_name
         self.field_type = field_type
         self.validate()
 
@@ -466,24 +464,22 @@ class FoldedOutputContextField(Expression):
             raise TypeError(u'Expected FoldScopeLocation fold_scope_location, got: {} {}'.format(
                 type(self.fold_scope_location), self.fold_scope_location))
 
-        validate_safe_string(self.field_name)
-
         if not isinstance(self.field_type, GraphQLList):
             raise ValueError(u'Invalid value of "field_type", expected a list type but got: '
                              u'{}'.format(self.field_type))
 
         inner_type = strip_non_null_from_type(self.field_type.of_type)
         if isinstance(inner_type, GraphQLList):
-            raise GraphQLCompilationError(u'Outputting list-valued fields in a @fold context is '
-                                          u'currently not supported: {} '
-                                          u'{}'.format(self.field_name, self.field_type.of_type))
+            raise GraphQLCompilationError(
+                u'Outputting list-valued fields in a @fold context is currently '
+                u'not supported: {} {}'.format(self.fold_scope_location, self.field_type.of_type))
 
     def to_match(self):
         """Return a unicode object with the MATCH representation of this expression."""
         self.validate()
         edge_direction, edge_name = self.fold_scope_location.get_first_folded_edge()
 
-        mark_name, _ = self.fold_scope_location.get_location_name()
+        mark_name, field_name = self.fold_scope_location.get_location_name()
         validate_safe_string(mark_name)
 
         template = u'$%(mark_name)s.%(field_name)s'
@@ -502,7 +498,7 @@ class FoldedOutputContextField(Expression):
             'mark_name': mark_name,
             'direction': edge_direction,
             'edge_name': edge_name,
-            'field_name': self.field_name,
+            'field_name': field_name,
         }
         return template % template_data
 
@@ -516,7 +512,6 @@ class FoldedOutputContextField(Expression):
         # the equality operator, we have to override equality and call is_same_type() here.
         return (type(self) == type(other) and
                 self.fold_scope_location == other.fold_scope_location and
-                self.field_name == other.field_name and
                 self.field_type.is_same_type(other.field_type))
 
     def __ne__(self, other):

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -481,9 +481,9 @@ class FoldedOutputContextField(Expression):
     def to_match(self):
         """Return a unicode object with the MATCH representation of this expression."""
         self.validate()
-        edge_direction, edge_name = self.fold_scope_location.relative_position
+        edge_direction, edge_name = self.fold_scope_location.fold_path[0]
 
-        mark_name = self.fold_scope_location.get_location_name()
+        mark_name, _ = self.fold_scope_location.get_location_name()
         validate_safe_string(mark_name)
 
         template = u'$%(mark_name)s.%(field_name)s'

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -481,7 +481,7 @@ class FoldedOutputContextField(Expression):
     def to_match(self):
         """Return a unicode object with the MATCH representation of this expression."""
         self.validate()
-        edge_direction, edge_name = self.fold_scope_location.fold_path[0]
+        edge_direction, edge_name = self.fold_scope_location.get_first_folded_edge()
 
         mark_name, _ = self.fold_scope_location.get_location_name()
         validate_safe_string(mark_name)

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -1,5 +1,6 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Common helper objects, base classes and methods."""
+from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 import string
 
@@ -17,6 +18,12 @@ STANDARD_DATE_FORMAT = 'yyyy-MM-dd'
 STANDARD_DATETIME_FORMAT = 'yyyy-MM-dd\'T\'HH:mm:ssX'
 
 VARIABLE_ALLOWED_CHARS = frozenset(six.text_type(string.ascii_letters + string.digits + '_'))
+
+OUTBOUND_EDGE_FIELD_PREFIX = 'out_'
+INBOUND_EDGE_FIELD_PREFIX = 'in_'
+
+OUTBOUND_EDGE_DIRECTION = 'out'
+INBOUND_EDGE_DIRECTION = 'in'
 
 
 FilterOperationInfo = namedtuple(
@@ -88,9 +95,30 @@ def strip_non_null_from_type(graphql_type):
     return graphql_type
 
 
+def get_edge_direction_and_name(vertex_field_name):
+    """Get the edge direction and name from a non-root vertex field name."""
+    edge_direction = None
+    edge_name = None
+    if vertex_field_name.startswith(OUTBOUND_EDGE_FIELD_PREFIX):
+        edge_direction = OUTBOUND_EDGE_DIRECTION
+        edge_name = vertex_field_name[len(OUTBOUND_EDGE_FIELD_PREFIX):]
+    elif vertex_field_name.startswith(INBOUND_EDGE_FIELD_PREFIX):
+        edge_direction = INBOUND_EDGE_DIRECTION
+        edge_name = vertex_field_name[len(INBOUND_EDGE_FIELD_PREFIX):]
+    else:
+        raise AssertionError(u'Unreachable condition reached:', vertex_field_name)
+
+    validate_safe_string(edge_name)
+
+    return edge_direction, edge_name
+
+
 def is_vertex_field_name(field_name):
     """Return True if the field's name indicates it is a non-root vertex field."""
-    return field_name.startswith('out_') or field_name.startswith('in_')
+    return (
+        field_name.startswith(OUTBOUND_EDGE_FIELD_PREFIX) or
+        field_name.startswith(INBOUND_EDGE_FIELD_PREFIX)
+    )
 
 
 def is_vertex_field_type(graphql_type):
@@ -169,7 +197,7 @@ def validate_edge_direction(edge_direction):
         raise TypeError(u'Expected string edge_direction, got: {} {}'.format(
                         type(edge_direction), edge_direction))
 
-    if edge_direction not in {u'in', u'out'}:
+    if edge_direction not in {INBOUND_EDGE_DIRECTION, OUTBOUND_EDGE_DIRECTION}:
         raise ValueError(u'Unrecognized edge direction: {}'.format(edge_direction))
 
 
@@ -183,8 +211,28 @@ def validate_marked_location(location):
         raise GraphQLCompilationError(u'Cannot mark location at a field: {}'.format(location))
 
 
+@six.add_metaclass(ABCMeta)
+class BaseLocation(object):
+    """An abstract location object, describing a location in the GraphQL query."""
+
+    @abstractmethod
+    def navigate_to_field(self, field):
+        """Return a new BaseLocation object at the specified field of the current BaseLocation."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def navigate_to_subpath(self, child):
+        """Return a new BaseLocation after a traversal to the specified child location."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_location_name(self):
+        """Return a tuple of a unique name of the location, and the current field name (or None)."""
+        raise NotImplementedError()
+
+
 @six.python_2_unicode_compatible
-class Location(object):
+class Location(BaseLocation):
     def __init__(self, query_path, field=None, visit_counter=1):
         """Create a new Location object.
 
@@ -250,6 +298,19 @@ class Location(object):
             raise AssertionError(u'Currently at a field, cannot go to child: {}'.format(self))
         return Location(self.query_path + (child,))
 
+    def navigate_to_fold(self, folded_child):
+        """Return a new FoldScopeLocation for the folded child vertex of the current Location."""
+        if not isinstance(folded_child, six.string_types):
+            raise TypeError(u'Expected folded_child to be a string, was: {}'.format(folded_child))
+        if self.field:
+            raise AssertionError(u'Currently at a field, cannot go to folded child: '
+                                 u'{}'.format(self))
+
+        edge_direction, edge_name = get_edge_direction_and_name(folded_child)
+
+        fold_path = ((edge_direction, edge_name),)  # tuple containing one tuple of two elements
+        return FoldScopeLocation(self, fold_path)
+
     def revisit(self):
         """Return a new Location object with an incremented 'visit_counter'."""
         if self.field:
@@ -286,18 +347,19 @@ class Location(object):
 
 
 @six.python_2_unicode_compatible
-class FoldScopeLocation(object):
-    def __init__(self, base_location, relative_position):
+class FoldScopeLocation(BaseLocation):
+    def __init__(self, base_location, fold_path, field=None):
         """Create a new FoldScopeLocation object. Used to represent the locations of @fold scopes.
 
         Args:
             base_location: Location object defining where the @fold scope is rooted. In other words,
                            the location of the tightest scope that fully contains the @fold scope.
-            relative_position: (edge_direction, edge_name) tuple, representing where the @fold scope
-                               lies within its base_location scope.
+            fold_path: tuple of (edge_direction, edge_name) tuples, containing the traversal path
+                       of the fold, starting from the base_location of the @fold scope.
+            field: string if at a field in a vertex, or None if at a vertex
 
         Returns:
-            a new FoldScopeLocation object
+            new FoldScopeLocation object
         """
         if not isinstance(base_location, Location):
             raise TypeError(u'Expected a Location for base_location, got: '
@@ -307,28 +369,50 @@ class FoldScopeLocation(object):
             raise ValueError(u'Expected Location object that points to a vertex, got: '
                              u'{}'.format(base_location))
 
-        if not isinstance(relative_position, tuple) or not len(relative_position) == 2:
-            raise TypeError(u'Expected relative_position to be a tuple of two elements, got: '
-                            u'{} {}'.format(type(relative_position), relative_position))
-
-        # If we ever allow folds deeper than a single level,
-        # relative_position might need rethinking.
-        edge_direction, edge_name = relative_position
-        validate_edge_direction(edge_direction)
-        validate_safe_string(edge_name)
+        if not isinstance(fold_path, tuple) or len(fold_path) == 0:
+            raise TypeError(u'Expected fold_path to be a non-empty tuple, but got: {} {}'
+                            .format(type(fold_path), fold_path))
+        fold_path_is_valid = all(
+            len(element) == 2 and element[0] in {OUTBOUND_EDGE_DIRECTION, INBOUND_EDGE_DIRECTION}
+            for element in fold_path
+        )
+        if not fold_path_is_valid:
+            raise ValueError(u'Encountered an invalid fold_path: {}'.format(fold_path))
 
         self.base_location = base_location
-        self.relative_position = relative_position
+        self.fold_path = fold_path
+        self.field = field
 
     def get_location_name(self):
-        """Return a unique name for the FoldScopeLocation."""
-        edge_direction, edge_name = self.relative_position
-        return (self.base_location.get_location_name()[0] + u'___' +
-                edge_direction + u'_' + edge_name)
+        """Return a tuple of a unique name of the location, and the current field name (or None)."""
+        fold_path_representation = u'__'.join(
+            u'_'.join((edge_direction, edge_name))
+            for edge_direction, edge_name in self.fold_path
+        )
+        unique_name = self.base_location.get_location_name()[0] + u'___' + fold_path_representation
+        return (unique_name, self.field)
+
+    def navigate_to_field(self, field):
+        """Return a new location object at the specified field of the current location."""
+        if self.field:
+            raise AssertionError(u'Already at a field, cannot nest fields: {}'.format(self))
+        return FoldScopeLocation(self.base_location, self.fold_path, field=field)
+
+    def navigate_to_subpath(self, child):
+        """Return a new location after a traversal to the specified child location."""
+        if not isinstance(child, six.string_types):
+            raise TypeError(u'Expected child to be a string, was: {}'.format(child))
+        if self.field:
+            raise AssertionError(u'Currently at a field, cannot go to child: {}'.format(self))
+
+        edge_direction, edge_name = get_edge_direction_and_name(child)
+        new_fold_path = self.fold_path + (edge_direction, edge_name)
+        return FoldScopeLocation(self.base_location, new_fold_path)
 
     def __str__(self):
         """Return a human-readable str representation of the FoldScopeLocation object."""
-        return u'FoldScopeLocation({}, {})'.format(self.base_location, self.relative_position)
+        return u'FoldScopeLocation({}, {}, field={})'.format(
+            self.base_location, self.fold_path, self.field)
 
     def __repr__(self):
         """Return a human-readable str representation of the FoldScopeLocation object."""
@@ -338,7 +422,8 @@ class FoldScopeLocation(object):
         """Return True if the FoldScopeLocations are equal, and False otherwise."""
         return (type(self) == type(other) and
                 self.base_location == other.base_location and
-                self.relative_position == other.relative_position)
+                self.fold_path == other.fold_path and
+                self.field == other.field)
 
     def __ne__(self, other):
         """Check another object for non-equality against this one."""
@@ -346,4 +431,4 @@ class FoldScopeLocation(object):
 
     def __hash__(self):
         """Return the object's hash value."""
-        return hash(self.base_location) ^ hash(self.relative_position)
+        return hash(self.base_location) ^ hash(self.fold_path) ^ hash(self.field)

--- a/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
@@ -168,7 +168,7 @@ class GremlinFoldedOutputContextField(Expression):
     def to_gremlin(self):
         """Return a unicode object with the Gremlin representation of this expression."""
         self.validate()
-        edge_direction, edge_name = self.fold_scope_location.fold_path[0]
+        edge_direction, edge_name = self.fold_scope_location.get_first_folded_edge()
         inverse_direction_table = {
             'out': 'in',
             'in': 'out',

--- a/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
@@ -125,13 +125,12 @@ def rewrite_filters_in_optional_blocks(ir_blocks):
 class GremlinFoldedOutputContextField(Expression):
     """A Gremlin-specific FoldedOutputContextField that knows how to output itself as Gremlin."""
 
-    def __init__(self, fold_scope_location, folded_ir_blocks, field_name, field_type):
+    def __init__(self, fold_scope_location, folded_ir_blocks, field_type):
         """Create a new GremlinFoldedOutputContextField."""
         super(GremlinFoldedOutputContextField, self).__init__(
-            fold_scope_location, folded_ir_blocks, field_name, field_type)
+            fold_scope_location, folded_ir_blocks, field_type)
         self.fold_scope_location = fold_scope_location
         self.folded_ir_blocks = folded_ir_blocks
-        self.field_name = field_name
         self.field_type = field_type
         self.validate()
 
@@ -149,17 +148,15 @@ class GremlinFoldedOutputContextField(Expression):
                     u'Allowed types are {}.'
                     .format(type(block), self.folded_ir_blocks, allowed_block_types))
 
-        validate_safe_string(self.field_name)
-
         if not isinstance(self.field_type, GraphQLList):
             raise ValueError(u'Invalid value of "field_type", expected a list type but got: '
                              u'{}'.format(self.field_type))
 
         inner_type = strip_non_null_from_type(self.field_type.of_type)
         if isinstance(inner_type, GraphQLList):
-            raise GraphQLCompilationError(u'Outputting list-valued fields in a @fold context is '
-                                          u'currently not supported: {} '
-                                          u'{}'.format(self.field_name, self.field_type.of_type))
+            raise GraphQLCompilationError(
+                u'Outputting list-valued fields in a @fold context is currently '
+                u'not supported: {} {}'.format(self.fold_scope_location, self.field_type.of_type))
 
     def to_match(self):
         """Must never be called."""
@@ -169,14 +166,19 @@ class GremlinFoldedOutputContextField(Expression):
         """Return a unicode object with the Gremlin representation of this expression."""
         self.validate()
         edge_direction, edge_name = self.fold_scope_location.get_first_folded_edge()
+        validate_safe_string(edge_name)
+
         inverse_direction_table = {
             'out': 'in',
             'in': 'out',
         }
         inverse_direction = inverse_direction_table[edge_direction]
 
-        mark_name, _ = self.fold_scope_location.base_location.get_location_name()
-        validate_safe_string(mark_name)
+        base_location_name, _ = self.fold_scope_location.base_location.get_location_name()
+        validate_safe_string(base_location_name)
+
+        _, field_name = self.fold_scope_location.get_location_name()
+        validate_safe_string(field_name)
 
         if not self.folded_ir_blocks:
             # There is no filtering nor type coercions applied to this @fold scope.
@@ -189,8 +191,8 @@ class GremlinFoldedOutputContextField(Expression):
             #     )
             # )
             template = (
-                u'((m.{mark_name}.{direction}_{edge_name} == null) ? [] : ('
-                u'm.{mark_name}.{direction}_{edge_name}.collect{{'
+                u'((m.{base_location_name}.{direction}_{edge_name} == null) ? [] : ('
+                u'm.{base_location_name}.{direction}_{edge_name}.collect{{'
                 u'entry -> entry.{inverse_direction}V.next().{field_name}{maybe_format}'
                 u'}}'
                 u'))'
@@ -210,8 +212,8 @@ class GremlinFoldedOutputContextField(Expression):
             #     )
             # )
             template = (
-                u'((m.{mark_name}.{direction}_{edge_name} == null) ? [] : ('
-                u'm.{mark_name}.{direction}_{edge_name}.collect{{'
+                u'((m.{base_location_name}.{direction}_{edge_name} == null) ? [] : ('
+                u'm.{base_location_name}.{direction}_{edge_name}.collect{{'
                 u'entry -> entry.{inverse_direction}V.next()'
                 u'}}'
                 u'.{filters_and_traverses}'
@@ -229,10 +231,10 @@ class GremlinFoldedOutputContextField(Expression):
             maybe_format = '.format("' + STANDARD_DATETIME_FORMAT + '")'
 
         template_data = {
-            'mark_name': mark_name,
+            'base_location_name': base_location_name,
             'direction': edge_direction,
             'edge_name': edge_name,
-            'field_name': self.field_name,
+            'field_name': field_name,
             'inverse_direction': inverse_direction,
             'maybe_format': maybe_format,
             'filters_and_traverses': filter_and_traverse_data,
@@ -324,8 +326,8 @@ def lower_folded_outputs(ir_blocks):
 
     # Turn folded Filter blocks into GremlinFoldedFilter blocks.
     converted_folds = {
-        key: _convert_folded_blocks(folded_ir_blocks)
-        for key, folded_ir_blocks in six.iteritems(folds)
+        base_fold_location.get_location_name()[0]: _convert_folded_blocks(folded_ir_blocks)
+        for base_fold_location, folded_ir_blocks in six.iteritems(folds)
     }
 
     new_output_fields = dict()
@@ -335,10 +337,11 @@ def lower_folded_outputs(ir_blocks):
         # Turn FoldedOutputContextField expressions into GremlinFoldedOutputContextField ones.
         if isinstance(output_expression, FoldedOutputContextField):
             # Get the matching folded IR blocks and put them in the new context field.
-            folded_ir_blocks = converted_folds[output_expression.fold_scope_location]
+            base_fold_location_name = output_expression.fold_scope_location.get_location_name()[0]
+            folded_ir_blocks = converted_folds[base_fold_location_name]
             new_output_expression = GremlinFoldedOutputContextField(
                 output_expression.fold_scope_location, folded_ir_blocks,
-                output_expression.field_name, output_expression.field_type)
+                output_expression.field_type)
 
         new_output_fields[output_name] = new_output_expression
 

--- a/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
@@ -168,7 +168,7 @@ class GremlinFoldedOutputContextField(Expression):
     def to_gremlin(self):
         """Return a unicode object with the Gremlin representation of this expression."""
         self.validate()
-        edge_direction, edge_name = self.fold_scope_location.relative_position
+        edge_direction, edge_name = self.fold_scope_location.fold_path[0]
         inverse_direction_table = {
             'out': 'in',
             'in': 'out',

--- a/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
@@ -271,10 +271,9 @@ def _translate_equivalent_locations(match_query, location_translations):
             fold_path = expression.fold_scope_location.fold_path
             fold_field = expression.fold_scope_location.field
             new_fold_scope_location = FoldScopeLocation(new_location, fold_path, field=fold_field)
-            field_name = expression.field_name
             field_type = expression.field_type
 
-            return FoldedOutputContextField(new_fold_scope_location, field_name, field_type)
+            return FoldedOutputContextField(new_fold_scope_location, field_type)
         else:
             return expression
 

--- a/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
@@ -268,8 +268,9 @@ def _translate_equivalent_locations(match_query, location_translations):
             old_location = expression.fold_scope_location.base_location
             new_location = location_translations.get(old_location, old_location)
 
-            relative_position = expression.fold_scope_location.relative_position
-            new_fold_scope_location = FoldScopeLocation(new_location, relative_position)
+            fold_path = expression.fold_scope_location.fold_path
+            fold_field = expression.fold_scope_location.field
+            new_fold_scope_location = FoldScopeLocation(new_location, fold_path, field=fold_field)
             field_name = expression.field_name
             field_type = expression.field_type
 
@@ -309,10 +310,11 @@ def _translate_equivalent_locations(match_query, location_translations):
     new_folds = {}
     # Update the Location within each FoldScopeLocation
     for fold_scope_location, fold_ir_blocks in six.iteritems(match_query.folds):
-        relative_position = fold_scope_location.relative_position
+        fold_path = fold_scope_location.fold_path
+        fold_field = fold_scope_location.field
         old_location = fold_scope_location.base_location
         new_location = location_translations.get(old_location, old_location)
-        new_fold_scope_location = FoldScopeLocation(new_location, relative_position)
+        new_fold_scope_location = FoldScopeLocation(new_location, fold_path, field=fold_field)
 
         new_folds[new_fold_scope_location] = fold_ir_blocks
 

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -13,7 +13,8 @@ LocationInfo = namedtuple(
         'coerced_from_type',       # str, the type before coercion, or None if no coercion applied
         'optional_scopes_depth',   # int, how many nested optional scopes this location is in
         'recursive_scopes_depth',  # int, how many nested recursion scopes this location is in
-        'is_within_fold',          # bool, True if this location is within an optional scope
+        'is_within_fold',          # bool, True if this location is within a fold scope;
+                                   #       fold scopes are not allowed to nest within each other.
     )
 )
 

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -1,0 +1,87 @@
+from collections import namedtuple
+
+import six
+
+
+LocationInfo = namedtuple(
+    'LocationInfo',
+    (
+        'parent_location',         # Location/FoldScopeLocation, the parent of the current location
+        'type',                    # str, the actual type name at that location
+        'coerced_from_type',       # str, the type before coercion, or None if no coercion applied
+        'optional_scopes_depth',   # int, how many nested optional scopes this location is in
+        'recursive_scopes_depth',  # int, how many nested recursion scopes this location is in
+        'is_folded',               # bool, True if this location is within an optional scope
+    )
+)
+
+
+@six.python_2_unicode_compatible
+class QueryMetadataTable(object):
+    """Query metadata container with info on locations, inputs, outputs, and tags in the query."""
+
+    def __init__(self, root_location, root_location_info):
+        """Create a new empty QueryMetadataTable object."""
+        self._root_location = root_location  # Location, the root location of the entire query
+        self._locations = dict()             # dict, Location/FoldScopeLocation -> LocationInfo
+        self._inputs = dict()                # dict, input name -> input info namedtuple
+        self._outputs = dict()               # dict, output name -> output info namedtuple
+        self._tags = dict()                  # dict, tag name -> tag info namedtuple
+        self.register_location(root_location, root_location_info)
+
+    @property
+    def root_location(self):
+        """Return the root location of the query."""
+        return self._root_location
+
+    def register_location(self, location, location_info):
+        """Record a new location's metadata in the metadata table."""
+        old_info = self._locations.get(location, None)
+        if old_info is not None:
+            raise AssertionError(u'Attempting to register an already-registered location {}: '
+                                 u'old info {}, new info {}'
+                                 .format(location, old_info, location_info))
+        self._locations[location] = location_info
+
+    def revisit_location(self, location):
+        """Revisit a location, returning the revisited location after setting its metadata."""
+        # This helper exists to avoid accidentally recording outdated metadata for the revisited
+        # location. The metadata could be outdated, for example, if the original location_info
+        # is preserved and not updated if a coercion is recorded at the given location.
+        # In that case, the QueryMetadataTable will update its local info object, but the caller
+        # might still be holding on to the original info object, therefore registering stale data.
+        # This function ensures that the latest metadata on the location is always used instead.
+        revisited_location = location.revisit()
+        self.register_location(revisited_location, self.get_location_info(location))
+        return revisited_location
+
+    def record_coercion_at_location(self, location, coerced_to_type):
+        """Record that a particular location is getting coerced to a different type."""
+        current_info = self._locations.get(location, None)
+        if current_info is None:
+            raise AssertionError(u'Attempting to record a coercion at an unregistered location {}: '
+                                 u'coerced_to_type {}'.format(location, coerced_to_type))
+
+        if current_info.coerced_from_type is not None:
+            raise AssertionError(u'Attempting to record a second coercion at the same location {}: '
+                                 u'{} {}'.format(location, current_info, coerced_to_type))
+
+        new_info = current_info._replace(
+            type=coerced_to_type,
+            coerced_from_type=current_info.type)
+        self._locations[location] = new_info
+
+    def get_location_info(self, location):
+        """Return the LocationInfo object for a given location."""
+        return self._locations[location]
+
+    def __str__(self):
+        """Return a human-readable str representation of the QueryMetadataTable object."""
+        return (
+            u'QueryMetadataTable(root_location={}, locations={}, inputs={}, outputs={}, tags={})'
+            .format(self._root_location, self._locations, self._inputs, self._outputs, self._tags)
+        )
+
+    def __repr__(self):
+        """Return a human-readable str representation of the QueryMetadataTable object."""
+        return self.__str__()

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -13,7 +13,7 @@ LocationInfo = namedtuple(
         'coerced_from_type',       # str, the type before coercion, or None if no coercion applied
         'optional_scopes_depth',   # int, how many nested optional scopes this location is in
         'recursive_scopes_depth',  # int, how many nested recursion scopes this location is in
-        'is_folded',               # bool, True if this location is within an optional scope
+        'is_within_fold',          # bool, True if this location is within an optional scope
     )
 )
 

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -1,3 +1,5 @@
+# Copyright 2018-present Kensho Technologies, LLC.
+"""Utilities for recording, inspecting, and manipulating metadata collected during compilation."""
 from collections import namedtuple
 
 import six

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -2104,7 +2104,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Species',))
         animal_location = base_location.navigate_to_subpath('in_Animal_OfSpecies')
-        animal_fold = helpers.FoldScopeLocation(animal_location, ('in', 'Animal_ParentOf'))
+        animal_fold = helpers.FoldScopeLocation(animal_location, (('in', 'Animal_ParentOf'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Species'}),
@@ -2168,7 +2168,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.fold_on_output_variable()
 
         base_location = helpers.Location(('Animal',))
-        base_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2194,7 +2194,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
-        parent_fold = helpers.FoldScopeLocation(parent_location, ('out', 'Animal_ParentOf'))
+        parent_fold = helpers.FoldScopeLocation(parent_location, (('out', 'Animal_ParentOf'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2223,7 +2223,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.fold_and_traverse()
 
         base_location = helpers.Location(('Animal',))
-        parent_fold = helpers.FoldScopeLocation(base_location, ('in', 'Animal_ParentOf'))
+        parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         expected_blocks = [
@@ -2251,7 +2251,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.fold_and_deep_traverse()
 
         base_location = helpers.Location(('Animal',))
-        parent_fold = helpers.FoldScopeLocation(base_location, ('in', 'Animal_ParentOf'))
+        parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         sibling_location = parent_location.navigate_to_subpath('out_Animal_ParentOf')
 
@@ -2283,7 +2283,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
-        sibling_fold = helpers.FoldScopeLocation(parent_location, ('out', 'Animal_ParentOf'))
+        sibling_fold = helpers.FoldScopeLocation(parent_location, (('out', 'Animal_ParentOf'),))
         sibling_location = parent_location.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
@@ -2315,7 +2315,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.multiple_outputs_in_same_fold()
 
         base_location = helpers.Location(('Animal',))
-        base_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2342,7 +2342,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.multiple_outputs_in_same_fold_and_traverse()
 
         base_location = helpers.Location(('Animal',))
-        base_fold = helpers.FoldScopeLocation(base_location, ('in', 'Animal_ParentOf'))
+        base_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         expected_blocks = [
@@ -2372,8 +2372,8 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.multiple_folds()
 
         base_location = helpers.Location(('Animal',))
-        base_out_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
-        base_in_fold = helpers.FoldScopeLocation(base_location, ('in', 'Animal_ParentOf'))
+        base_out_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
+        base_in_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2405,9 +2405,9 @@ class IrGenerationTests(unittest.TestCase):
     def test_multiple_folds_and_traverse(self):
         test_data = test_input_data.multiple_folds_and_traverse()
         base_location = helpers.Location(('Animal',))
-        base_out_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_out_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
         base_out_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
-        base_in_fold = helpers.FoldScopeLocation(base_location, ('in', 'Animal_ParentOf'))
+        base_in_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
         base_in_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         expected_blocks = [
@@ -2445,8 +2445,8 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.fold_date_and_datetime_fields()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
-        base_fed_at_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_FedAt'))
+        base_parent_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
+        base_fed_at_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_FedAt'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2478,7 +2478,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(
-            base_location, ('out', 'Animal_ImportantEvent'))
+            base_location, (('out', 'Animal_ImportantEvent'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2503,7 +2503,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_filters_and_multiple_outputs_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        entity_fold = helpers.FoldScopeLocation(base_location, ('out', 'Entity_Related'))
+        entity_fold = helpers.FoldScopeLocation(base_location, (('out', 'Entity_Related'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2543,7 +2543,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_filters_and_multiple_outputs_within_fold_traversal()
 
         base_location = helpers.Location(('Animal',))
-        parent_fold = helpers.FoldScopeLocation(base_location, ('in', 'Animal_ParentOf'))
+        parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         expected_blocks = [
@@ -2588,7 +2588,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(
-            base_location, ('out', 'Entity_Related'))
+            base_location, (('out', 'Entity_Related'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2613,7 +2613,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.filter_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_parent_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2647,7 +2647,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.filter_on_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_parent_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2687,7 +2687,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_on_interface_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, ('out', 'Entity_Related'))
+        base_parent_fold = helpers.FoldScopeLocation(base_location, (('out', 'Entity_Related'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2713,7 +2713,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_on_interface_within_fold_traversal()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, ('in', 'Animal_ParentOf'))
+        base_parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         entity_location = parent_location.navigate_to_subpath('out_Entity_Related')
 
@@ -2746,7 +2746,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(
-            base_location, ('out', 'Animal_ImportantEvent'))
+            base_location, (('out', 'Animal_ImportantEvent'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -3528,7 +3528,8 @@ class IrGenerationTests(unittest.TestCase):
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         revisited_base_location = base_location.revisit()
-        fold_scope = helpers.FoldScopeLocation(revisited_base_location, ('out', 'Animal_ParentOf'))
+        fold_scope = helpers.FoldScopeLocation(
+            revisited_base_location, (('out', 'Animal_ParentOf'),))
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -3566,7 +3567,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
-        base_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
         revisited_base_location = base_location.revisit()
 
         expected_blocks = [
@@ -3607,7 +3608,8 @@ class IrGenerationTests(unittest.TestCase):
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         grandparent_location = parent_location.navigate_to_subpath('in_Animal_ParentOf')
         revisited_base_location = base_location.revisit()
-        fold_scope = helpers.FoldScopeLocation(revisited_base_location, ('out', 'Animal_ParentOf'))
+        fold_scope = helpers.FoldScopeLocation(
+            revisited_base_location, (('out', 'Animal_ParentOf'),))
         fold_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
@@ -3653,7 +3655,7 @@ class IrGenerationTests(unittest.TestCase):
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         grandparent_location = parent_location.navigate_to_subpath('in_Animal_ParentOf')
-        base_fold = helpers.FoldScopeLocation(base_location, ('out', 'Animal_ParentOf'))
+        base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
         fold_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         revisited_base_location = base_location.revisit()
 

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -2104,7 +2104,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Species',))
         animal_location = base_location.navigate_to_subpath('in_Animal_OfSpecies')
-        animal_fold = helpers.FoldScopeLocation(animal_location, (('in', 'Animal_ParentOf'),))
+        animal_fold = animal_location.navigate_to_fold('in_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Species'}),
@@ -2154,7 +2154,7 @@ class IrGenerationTests(unittest.TestCase):
                 'parent_name': expressions.OutputContextField(
                     animal_location.navigate_to_field('name'), GraphQLString),
                 'child_names': expressions.FoldedOutputContextField(
-                    animal_fold, 'name', GraphQLList(GraphQLString)),
+                    animal_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2168,7 +2168,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.fold_on_output_variable()
 
         base_location = helpers.Location(('Animal',))
-        base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
+        base_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2179,7 +2179,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_names_list': expressions.FoldedOutputContextField(
-                    base_fold, 'name', GraphQLList(GraphQLString)),
+                    base_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2194,7 +2194,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
-        parent_fold = helpers.FoldScopeLocation(parent_location, (('out', 'Animal_ParentOf'),))
+        parent_fold = parent_location.navigate_to_fold('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2208,7 +2208,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'sibling_and_self_names_list': expressions.FoldedOutputContextField(
-                    parent_fold, 'name', GraphQLList(GraphQLString)),
+                    parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2223,7 +2223,8 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.fold_and_traverse()
 
         base_location = helpers.Location(('Animal',))
-        parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
+        parent_fold = base_location.navigate_to_fold('in_Animal_ParentOf')
+        first_traversed_fold = parent_fold.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2235,7 +2236,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'sibling_and_self_names_list': expressions.FoldedOutputContextField(
-                    parent_fold, 'name', GraphQLList(GraphQLString)),
+                    first_traversed_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2249,7 +2250,9 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.fold_and_deep_traverse()
 
         base_location = helpers.Location(('Animal',))
-        parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
+        parent_fold = base_location.navigate_to_fold('in_Animal_ParentOf')
+        first_traversed_fold = parent_fold.navigate_to_subpath('out_Animal_ParentOf')
+        second_traversed_fold = first_traversed_fold.navigate_to_subpath('out_Animal_OfSpecies')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2262,7 +2265,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'sibling_and_self_species_list': expressions.FoldedOutputContextField(
-                    parent_fold, 'name', GraphQLList(GraphQLString)),
+                    second_traversed_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2277,7 +2280,8 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
-        sibling_fold = helpers.FoldScopeLocation(parent_location, (('out', 'Animal_ParentOf'),))
+        sibling_fold = parent_location.navigate_to_fold('out_Animal_ParentOf')
+        sibling_species_fold = sibling_fold.navigate_to_subpath('out_Animal_OfSpecies')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2292,7 +2296,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'sibling_and_self_species_list': expressions.FoldedOutputContextField(
-                    sibling_fold, 'name', GraphQLList(GraphQLString)),
+                    sibling_species_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2307,7 +2311,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.multiple_outputs_in_same_fold()
 
         base_location = helpers.Location(('Animal',))
-        base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
+        base_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2318,9 +2322,9 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_names_list': expressions.FoldedOutputContextField(
-                    base_fold, 'name', GraphQLList(GraphQLString)),
+                    base_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'child_uuids_list': expressions.FoldedOutputContextField(
-                    base_fold, 'uuid', GraphQLList(GraphQLID)),
+                    base_fold.navigate_to_field('uuid'), GraphQLList(GraphQLID)),
             }),
         ]
         expected_location_types = {
@@ -2334,7 +2338,8 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.multiple_outputs_in_same_fold_and_traverse()
 
         base_location = helpers.Location(('Animal',))
-        base_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
+        base_fold = base_location.navigate_to_fold('in_Animal_ParentOf')
+        first_traversed_fold = base_fold.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2346,9 +2351,9 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'sibling_and_self_names_list': expressions.FoldedOutputContextField(
-                    base_fold, 'name', GraphQLList(GraphQLString)),
+                    first_traversed_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'sibling_and_self_uuids_list': expressions.FoldedOutputContextField(
-                    base_fold, 'uuid', GraphQLList(GraphQLID)),
+                    first_traversed_fold.navigate_to_field('uuid'), GraphQLList(GraphQLID)),
             }),
         ]
         expected_location_types = {
@@ -2362,8 +2367,8 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.multiple_folds()
 
         base_location = helpers.Location(('Animal',))
-        base_out_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
-        base_in_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
+        base_out_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
+        base_in_fold = base_location.navigate_to_fold('in_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2376,13 +2381,13 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_names_list': expressions.FoldedOutputContextField(
-                    base_out_fold, 'name', GraphQLList(GraphQLString)),
+                    base_out_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'child_uuids_list': expressions.FoldedOutputContextField(
-                    base_out_fold, 'uuid', GraphQLList(GraphQLID)),
+                    base_out_fold.navigate_to_field('uuid'), GraphQLList(GraphQLID)),
                 'parent_names_list': expressions.FoldedOutputContextField(
-                    base_in_fold, 'name', GraphQLList(GraphQLString)),
+                    base_in_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'parent_uuids_list': expressions.FoldedOutputContextField(
-                    base_in_fold, 'uuid', GraphQLList(GraphQLID)),
+                    base_in_fold.navigate_to_field('uuid'), GraphQLList(GraphQLID)),
             }),
         ]
         expected_location_types = {
@@ -2395,8 +2400,10 @@ class IrGenerationTests(unittest.TestCase):
     def test_multiple_folds_and_traverse(self):
         test_data = test_input_data.multiple_folds_and_traverse()
         base_location = helpers.Location(('Animal',))
-        base_out_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
-        base_in_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
+        base_out_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
+        base_out_traversed_fold = base_out_fold.navigate_to_subpath('in_Animal_ParentOf')
+        base_in_fold = base_location.navigate_to_fold('in_Animal_ParentOf')
+        base_in_traversed_fold = base_in_fold.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2411,13 +2418,13 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'spouse_and_self_names_list': expressions.FoldedOutputContextField(
-                    base_out_fold, 'name', GraphQLList(GraphQLString)),
+                    base_out_traversed_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'spouse_and_self_uuids_list': expressions.FoldedOutputContextField(
-                    base_out_fold, 'uuid', GraphQLList(GraphQLID)),
+                    base_out_traversed_fold.navigate_to_field('uuid'), GraphQLList(GraphQLID)),
                 'sibling_and_self_names_list': expressions.FoldedOutputContextField(
-                    base_in_fold, 'name', GraphQLList(GraphQLString)),
+                    base_in_traversed_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'sibling_and_self_uuids_list': expressions.FoldedOutputContextField(
-                    base_in_fold, 'uuid', GraphQLList(GraphQLID)),
+                    base_in_traversed_fold.navigate_to_field('uuid'), GraphQLList(GraphQLID)),
             }),
         ]
         expected_location_types = {
@@ -2431,8 +2438,8 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.fold_date_and_datetime_fields()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
-        base_fed_at_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_FedAt'),))
+        base_parent_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
+        base_fed_at_fold = base_location.navigate_to_fold('out_Animal_FedAt')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2445,9 +2452,9 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_birthdays_list': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'birthday', GraphQLList(GraphQLDate)),
+                    base_parent_fold.navigate_to_field('birthday'), GraphQLList(GraphQLDate)),
                 'fed_at_datetimes_list': expressions.FoldedOutputContextField(
-                    base_fed_at_fold, 'event_date', GraphQLList(GraphQLDateTime)),
+                    base_fed_at_fold.navigate_to_field('event_date'), GraphQLList(GraphQLDateTime)),
             }),
         ]
         expected_location_types = {
@@ -2463,8 +2470,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_to_union_base_type_inside_fold()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(
-            base_location, (('out', 'Animal_ImportantEvent'),))
+        base_parent_fold = base_location.navigate_to_fold('out_Animal_ImportantEvent')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2475,7 +2481,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'important_events': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'name', GraphQLList(GraphQLString)),
+                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2489,7 +2495,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_filters_and_multiple_outputs_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        entity_fold = helpers.FoldScopeLocation(base_location, (('out', 'Entity_Related'),))
+        entity_fold = base_location.navigate_to_fold('out_Entity_Related')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2511,11 +2517,11 @@ class IrGenerationTests(unittest.TestCase):
             blocks.Unfold(),
             blocks.ConstructResult({
                 'related_animals': expressions.FoldedOutputContextField(
-                    entity_fold, 'name', GraphQLList(GraphQLString)),
+                    entity_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'related_birthdays': expressions.FoldedOutputContextField(
-                    entity_fold, 'birthday', GraphQLList(GraphQLDate)),
+                    entity_fold.navigate_to_field('birthday'), GraphQLList(GraphQLDate)),
             }),
         ]
         expected_location_types = {
@@ -2529,7 +2535,8 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_filters_and_multiple_outputs_within_fold_traversal()
 
         base_location = helpers.Location(('Animal',))
-        parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
+        parent_fold = base_location.navigate_to_fold('in_Animal_ParentOf')
+        inner_fold = parent_fold.navigate_to_subpath('out_Entity_Related')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2551,12 +2558,12 @@ class IrGenerationTests(unittest.TestCase):
             ),
             blocks.Unfold(),
             blocks.ConstructResult({
-                'related_animals': expressions.FoldedOutputContextField(
-                    parent_fold, 'name', GraphQLList(GraphQLString)),
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
+                'related_animals': expressions.FoldedOutputContextField(
+                    inner_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'related_birthdays': expressions.FoldedOutputContextField(
-                    parent_fold, 'birthday', GraphQLList(GraphQLDate)),
+                    inner_fold.navigate_to_field('birthday'), GraphQLList(GraphQLDate)),
             }),
         ]
         expected_location_types = {
@@ -2571,8 +2578,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.no_op_coercion_inside_fold()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(
-            base_location, (('out', 'Entity_Related'),))
+        base_parent_fold = base_location.navigate_to_fold('out_Entity_Related')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2583,7 +2589,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'related_entities': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'name', GraphQLList(GraphQLString)),
+                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2597,7 +2603,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.filter_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
+        base_parent_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2615,9 +2621,9 @@ class IrGenerationTests(unittest.TestCase):
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_list': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'name', GraphQLList(GraphQLString)),
+                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'child_descriptions': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'description', GraphQLList(GraphQLString)),
+                    base_parent_fold.navigate_to_field('description'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2631,7 +2637,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.filter_on_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
+        base_parent_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2657,7 +2663,7 @@ class IrGenerationTests(unittest.TestCase):
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'child_list': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'name', GraphQLList(GraphQLString)),
+                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2671,7 +2677,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_on_interface_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, (('out', 'Entity_Related'),))
+        base_parent_fold = base_location.navigate_to_fold('out_Entity_Related')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2683,7 +2689,7 @@ class IrGenerationTests(unittest.TestCase):
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'related_animals': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'name', GraphQLList(GraphQLString)),
+                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2697,7 +2703,9 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_on_interface_within_fold_traversal()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
+        base_parent_fold = base_location.navigate_to_fold('in_Animal_ParentOf')
+        first_traversed_fold = base_parent_fold.navigate_to_subpath('out_Entity_Related')
+        second_traversed_fold = first_traversed_fold.navigate_to_subpath('out_Animal_OfSpecies')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2711,7 +2719,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'related_animal_species': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'name', GraphQLList(GraphQLString)),
+                    second_traversed_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -2725,8 +2733,7 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_on_union_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = helpers.FoldScopeLocation(
-            base_location, (('out', 'Animal_ImportantEvent'),))
+        base_parent_fold = base_location.navigate_to_fold('out_Animal_ImportantEvent')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2738,7 +2745,7 @@ class IrGenerationTests(unittest.TestCase):
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'birth_events': expressions.FoldedOutputContextField(
-                    base_parent_fold, 'name', GraphQLList(GraphQLString)),
+                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -3508,8 +3515,7 @@ class IrGenerationTests(unittest.TestCase):
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         revisited_base_location = base_location.revisit()
-        fold_scope = helpers.FoldScopeLocation(
-            revisited_base_location, (('out', 'Animal_ParentOf'),))
+        fold_scope = revisited_base_location.navigate_to_fold('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -3531,7 +3537,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'child_names_list': expressions.FoldedOutputContextField(
-                    fold_scope, 'name', GraphQLList(GraphQLString)),
+                    fold_scope.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -3547,7 +3553,7 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
-        base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
+        base_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
         revisited_base_location = base_location.revisit()
 
         expected_blocks = [
@@ -3570,7 +3576,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'child_names_list': expressions.FoldedOutputContextField(
-                    base_fold, 'name', GraphQLList(GraphQLString)),
+                    base_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -3588,8 +3594,8 @@ class IrGenerationTests(unittest.TestCase):
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         grandparent_location = parent_location.navigate_to_subpath('in_Animal_ParentOf')
         revisited_base_location = base_location.revisit()
-        fold_scope = helpers.FoldScopeLocation(
-            revisited_base_location, (('out', 'Animal_ParentOf'),))
+        fold_scope = revisited_base_location.navigate_to_fold('out_Animal_ParentOf')
+        first_traversed_fold = fold_scope.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -3615,7 +3621,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'grandchild_names_list': expressions.FoldedOutputContextField(
-                    fold_scope, 'name', GraphQLList(GraphQLString)),
+                    first_traversed_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
@@ -3633,7 +3639,8 @@ class IrGenerationTests(unittest.TestCase):
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         grandparent_location = parent_location.navigate_to_subpath('in_Animal_ParentOf')
-        base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
+        base_fold = base_location.navigate_to_fold('out_Animal_ParentOf')
+        first_traversed_fold = base_fold.navigate_to_subpath('out_Animal_ParentOf')
         revisited_base_location = base_location.revisit()
 
         expected_blocks = [
@@ -3660,7 +3667,7 @@ class IrGenerationTests(unittest.TestCase):
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'grandchild_names_list': expressions.FoldedOutputContextField(
-                    base_fold, 'name', GraphQLList(GraphQLString)),
+                    first_traversed_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -2160,6 +2160,7 @@ class IrGenerationTests(unittest.TestCase):
         expected_location_types = {
             base_location: 'Species',
             animal_location: 'Animal',
+            animal_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2183,8 +2184,8 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2212,9 +2213,9 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
             parent_location: 'Animal',
+            parent_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2240,8 +2241,9 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            parent_fold: 'Animal',
+            first_traversed_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2269,8 +2271,10 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            parent_fold: 'Animal',
+            first_traversed_fold: 'Animal',
+            second_traversed_fold: 'Species',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2300,9 +2304,10 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
             parent_location: 'Animal',
+            sibling_fold: 'Animal',
+            sibling_species_fold: 'Species',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2328,8 +2333,8 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2357,8 +2362,9 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_fold: 'Animal',
+            first_traversed_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2391,8 +2397,9 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_out_fold: 'Animal',
+            base_in_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2428,8 +2435,11 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_out_fold: 'Animal',
+            base_out_traversed_fold: 'Animal',
+            base_in_fold: 'Animal',
+            base_in_traversed_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2458,8 +2468,9 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_parent_fold: 'Animal',
+            base_fed_at_fold: 'Event',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2470,23 +2481,23 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_to_union_base_type_inside_fold()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = base_location.navigate_to_fold('out_Animal_ImportantEvent')
+        important_event_fold = base_location.navigate_to_fold('out_Animal_ImportantEvent')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(base_parent_fold),
+            blocks.Fold(important_event_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'important_events': expressions.FoldedOutputContextField(
-                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
+                    important_event_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            important_event_fold: 'Event',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2495,12 +2506,12 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_filters_and_multiple_outputs_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        entity_fold = base_location.navigate_to_fold('out_Entity_Related')
+        related_entity_fold = base_location.navigate_to_fold('out_Entity_Related')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(entity_fold),
+            blocks.Fold(related_entity_fold),
             blocks.CoerceType({'Animal'}),
             blocks.Filter(expressions.BinaryComposition(
                 u'has_substring',
@@ -2517,16 +2528,16 @@ class IrGenerationTests(unittest.TestCase):
             blocks.Unfold(),
             blocks.ConstructResult({
                 'related_animals': expressions.FoldedOutputContextField(
-                    entity_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
+                    related_entity_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'related_birthdays': expressions.FoldedOutputContextField(
-                    entity_fold.navigate_to_field('birthday'), GraphQLList(GraphQLDate)),
+                    related_entity_fold.navigate_to_field('birthday'), GraphQLList(GraphQLDate)),
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            related_entity_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2567,8 +2578,9 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            parent_fold: 'Animal',
+            inner_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2578,23 +2590,23 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.no_op_coercion_inside_fold()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = base_location.navigate_to_fold('out_Entity_Related')
+        related_entity_fold = base_location.navigate_to_fold('out_Entity_Related')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(base_parent_fold),
+            blocks.Fold(related_entity_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'related_entities': expressions.FoldedOutputContextField(
-                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
+                    related_entity_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            related_entity_fold: 'Entity',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2627,8 +2639,8 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_parent_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2667,8 +2679,8 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_parent_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2677,24 +2689,24 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_on_interface_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = base_location.navigate_to_fold('out_Entity_Related')
+        related_entity_fold = base_location.navigate_to_fold('out_Entity_Related')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(base_parent_fold),
+            blocks.Fold(related_entity_fold),
             blocks.CoerceType({'Animal'}),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'related_animals': expressions.FoldedOutputContextField(
-                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
+                    related_entity_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            related_entity_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2723,8 +2735,10 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            base_parent_fold: 'Animal',
+            first_traversed_fold: 'Animal',
+            second_traversed_fold: 'Species',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -2733,24 +2747,24 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.coercion_on_union_within_fold_scope()
 
         base_location = helpers.Location(('Animal',))
-        base_parent_fold = base_location.navigate_to_fold('out_Animal_ImportantEvent')
+        important_event_fold = base_location.navigate_to_fold('out_Animal_ImportantEvent')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Fold(base_parent_fold),
+            blocks.Fold(important_event_fold),
             blocks.CoerceType({'BirthEvent'}),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'name': expressions.OutputContextField(
                     base_location.navigate_to_field('name'), GraphQLString),
                 'birth_events': expressions.FoldedOutputContextField(
-                    base_parent_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
+                    important_event_fold.navigate_to_field('name'), GraphQLList(GraphQLString)),
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
+            important_event_fold: 'BirthEvent',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -3140,7 +3154,6 @@ class IrGenerationTests(unittest.TestCase):
             }),
         ]
         expected_location_types = {
-            # No MarkLocation blocks are output within folded scopes.
             base_location: 'Animal',
             parent_location: 'Animal',
             entity_location: 'Animal',
@@ -3544,6 +3557,7 @@ class IrGenerationTests(unittest.TestCase):
             base_location: 'Animal',
             parent_location: 'Animal',
             revisited_base_location: 'Animal',
+            fold_scope: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -3583,6 +3597,7 @@ class IrGenerationTests(unittest.TestCase):
             base_location: 'Animal',
             parent_location: 'Animal',
             revisited_base_location: 'Animal',
+            base_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -3629,6 +3644,8 @@ class IrGenerationTests(unittest.TestCase):
             parent_location: 'Animal',
             grandparent_location: 'Animal',
             revisited_base_location: 'Animal',
+            fold_scope: 'Animal',
+            first_traversed_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
@@ -3675,6 +3692,8 @@ class IrGenerationTests(unittest.TestCase):
             parent_location: 'Animal',
             grandparent_location: 'Animal',
             revisited_base_location: 'Animal',
+            base_fold: 'Animal',
+            first_traversed_fold: 'Animal',
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -2224,14 +2224,12 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
-        parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
             blocks.Fold(parent_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
-            blocks.Backtrack(parent_location),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -2252,8 +2250,6 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
-        parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
-        sibling_location = parent_location.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2261,8 +2257,6 @@ class IrGenerationTests(unittest.TestCase):
             blocks.Fold(parent_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
             blocks.Traverse('out', 'Animal_OfSpecies'),
-            blocks.Backtrack(sibling_location),
-            blocks.Backtrack(parent_location),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -2284,7 +2278,6 @@ class IrGenerationTests(unittest.TestCase):
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         sibling_fold = helpers.FoldScopeLocation(parent_location, (('out', 'Animal_ParentOf'),))
-        sibling_location = parent_location.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2293,7 +2286,6 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(parent_location),
             blocks.Fold(sibling_fold),
             blocks.Traverse('out', 'Animal_OfSpecies'),
-            blocks.Backtrack(sibling_location),
             blocks.Unfold(),
             blocks.Backtrack(base_location),
             blocks.ConstructResult({
@@ -2343,14 +2335,12 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         base_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
-        parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
             blocks.Fold(base_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
-            blocks.Backtrack(parent_location),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -2406,20 +2396,16 @@ class IrGenerationTests(unittest.TestCase):
         test_data = test_input_data.multiple_folds_and_traverse()
         base_location = helpers.Location(('Animal',))
         base_out_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
-        base_out_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         base_in_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
-        base_in_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
             blocks.Fold(base_out_fold),
             blocks.Traverse('in', 'Animal_ParentOf'),
-            blocks.Backtrack(base_out_location),
             blocks.Unfold(),
             blocks.Fold(base_in_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
-            blocks.Backtrack(base_in_location),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -2544,7 +2530,6 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
-        parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2564,7 +2549,6 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.Variable('$latest', GraphQLDate)
                 )
             ),
-            blocks.Backtrack(parent_location),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'related_animals': expressions.FoldedOutputContextField(
@@ -2714,8 +2698,6 @@ class IrGenerationTests(unittest.TestCase):
 
         base_location = helpers.Location(('Animal',))
         base_parent_fold = helpers.FoldScopeLocation(base_location, (('in', 'Animal_ParentOf'),))
-        parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
-        entity_location = parent_location.navigate_to_subpath('out_Entity_Related')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -2724,8 +2706,6 @@ class IrGenerationTests(unittest.TestCase):
             blocks.Traverse('out', 'Entity_Related'),
             blocks.CoerceType({'Animal'}),
             blocks.Traverse('out', 'Animal_OfSpecies'),
-            blocks.Backtrack(entity_location),
-            blocks.Backtrack(parent_location),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -3610,7 +3590,6 @@ class IrGenerationTests(unittest.TestCase):
         revisited_base_location = base_location.revisit()
         fold_scope = helpers.FoldScopeLocation(
             revisited_base_location, (('out', 'Animal_ParentOf'),))
-        fold_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
 
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
@@ -3625,7 +3604,6 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(revisited_base_location),
             blocks.Fold(fold_scope),
             blocks.Traverse('out', 'Animal_ParentOf'),
-            blocks.Backtrack(fold_location),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'grandparent_name': expressions.TernaryConditional(
@@ -3656,7 +3634,6 @@ class IrGenerationTests(unittest.TestCase):
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')
         grandparent_location = parent_location.navigate_to_subpath('in_Animal_ParentOf')
         base_fold = helpers.FoldScopeLocation(base_location, (('out', 'Animal_ParentOf'),))
-        fold_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         revisited_base_location = base_location.revisit()
 
         expected_blocks = [
@@ -3664,7 +3641,6 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_location),
             blocks.Fold(base_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
-            blocks.Backtrack(fold_location),
             blocks.Unfold(),
             blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(parent_location),

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -245,6 +245,15 @@ class IrGenerationErrorTests(unittest.TestCase):
             }
         }'''
 
+        list_output_inside_fold_block = '''{
+            Animal {
+                uuid @output(out_name: "uuid")
+                out_Animal_ParentOf @fold {
+                    alias @output(out_name: "disallowed_folded_list_output")
+                }
+            }
+        }'''
+
         fold_within_fold = '''{
             Animal {
                 out_Animal_ParentOf @fold {
@@ -318,6 +327,7 @@ class IrGenerationErrorTests(unittest.TestCase):
                         multi_level_outputs_inside_fold_block,
                         traversal_inside_fold_block_after_output,
                         no_outputs_inside_fold_block,
+                        list_output_inside_fold_block,
                         fold_within_fold,
                         optional_within_fold,
                         recurse_within_fold,


### PR DESCRIPTION
In the interest of making this easier to review, I'm opening this PR as the smallest possible change that provides enough context on what's going on while making tests pass.

What this PR does:
- Adds the `QueryMetadataTable` object and passes it around via the `context` object in the compiler front-end.
- Makes `FoldScopeLocation` objects be first-class locations, with all the right methods so we can support recording their metadata.
- Refactors the code around outputting folded fields to account for the new `FoldScopeLocation` functionality, since the field output expressions no longer have to know what field they are outputting -- the `FoldScopeLocation` handles that now. This removes a fairly large amount of severe tech debt.
- Records and reports the types of all locations, including locations inside `@fold` scopes.
- Adds a test case to make sure that outputting list-valued fields inside a `@fold` is prohibited, since that is not supported by OrientDB.
- Updates all IR generation test cases accordingly, while making sure that the final generated MATCH and Gremlin has not changed.

What it does not do (for the sake of limiting the size of the PR) and will be handled in a future PR:
- The `QueryMetadataTable` does not yet record outputs, tags, filters, and other query meta-information that would be useful.
- The PR does not remove many of the other uses of the `context` object that can now be served via the `QueryMetadataTable`. For example, `location_types` can now be computed directly from the `QueryMetadataTable`, and the `marked_location_stack` can be implicitly maintained and calculated as needed from the parent and optional depth data in the `QueryMetadataTable`.
- The `QueryMetadataTable` is only used in the front-end of the compiler, and is discarded before lowering begins instead of being propagated and maintained throughout the lifetime of the query compilation process.
- None of the lowering code is updated to take advantage of the new capabilities of the `QueryMetadataTable` -- any changes there are simply to make the fold-related changes work.
- It does not do as much cleanup as can be done in the front-end code, and instead tries to preserve as much of the existing code structure as possible in order to keep the PR small.