### PR TITLE
Replace explicitly-tracked context data with QueryMetadataTable info.

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -353,7 +353,6 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
     basic_blocks = []
     query_metadata_table = context['metadata']
     current_location_info = query_metadata_table.get_location_info(location)
-    context['location_types'][location] = strip_non_null_from_type(current_schema_type)
 
     vertex_fields, property_fields = fields
 
@@ -419,7 +418,6 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
             if context['marked_location_stack'][-1].num_traverses > 0:
                 location = query_metadata_table.revisit_location(location)
 
-                context['location_types'][location] = strip_non_null_from_type(current_schema_type)
                 basic_blocks.append(_mark_location(location))
                 context['marked_location_stack'].pop()
                 new_stack_entry = _construct_location_stack_entry(location, 0)
@@ -432,7 +430,7 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
 
         inner_location_info = LocationInfo(
             parent_location=location,
-            type=field_schema_type.name,
+            type=strip_non_null_from_type(field_schema_type),
             coerced_from_type=None,
             optional_scopes_depth=(
                 current_location_info.optional_scopes_depth + edge_traversal_is_optional),
@@ -513,7 +511,6 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
                 # don't accidentally return to a prior location instead.
                 location = query_metadata_table.revisit_location(location)
 
-                context['location_types'][location] = strip_non_null_from_type(current_schema_type)
                 basic_blocks.append(_mark_location(location))
                 context['marked_location_stack'].pop()
                 new_stack_entry = _construct_location_stack_entry(location, 0)
@@ -570,7 +567,7 @@ def _compile_fragment_ast(schema, current_schema_type, ast, location, context):
     #           then recurse into the fragment's selection.
     coerces_to_type_name = ast.type_condition.name.value
     coerces_to_type_obj = schema.get_type(coerces_to_type_name)
-    query_metadata_table.record_coercion_at_location(location, coerces_to_type_name)
+    query_metadata_table.record_coercion_at_location(location, coerces_to_type_obj)
 
     basic_blocks = []
 
@@ -587,7 +584,6 @@ def _compile_fragment_ast(schema, current_schema_type, ast, location, context):
 
     if not (is_same_type_as_scope or is_base_type_of_union):
         # Coercion is required.
-        context['coerced_locations'].add(location)
         basic_blocks.append(blocks.CoerceType({coerces_to_type_name}))
 
     inner_basic_blocks = _compile_ast_node_to_ir(
@@ -699,7 +695,7 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
     location = Location((base_start_type,))
     base_location_info = LocationInfo(
         parent_location=None,
-        type=base_start_type,
+        type=current_schema_type,
         coerced_from_type=None,
         optional_scopes_depth=0,
         recursive_scopes_depth=0,
@@ -725,12 +721,6 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
         # 'inputs' is a dict mapping input parameter names to their respective expected GraphQL
         # types, as automatically inferred by inspecting the query structure
         'inputs': dict(),
-        # 'location_types' is a dict mapping each Location to its GraphQLType
-        # (schema type of the location)
-        'location_types': dict(),
-        # 'coerced_locations' is the set of all locations whose type was coerced to a subtype
-        # of the type already implied by the GraphQL schema for that vertex field.
-        'coerced_locations': set(),
         # 'type_equivalence_hints' is a dict mapping GraphQL types to equivalent GraphQL unions
         'type_equivalence_hints': type_equivalence_hints or dict(),
         # The marked_location_stack explicitly maintains a stack (implemented as list)
@@ -777,12 +767,23 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
         for name, value in six.iteritems(outputs_context)
     }
 
+    location_types = {
+        location: location_info.type
+        for location, location_info in query_metadata_table.registered_locations
+    }
+
+    coerced_locations = {
+        location
+        for location, location_info in query_metadata_table.registered_locations
+        if location_info.coerced_from_type is not None
+    }
+
     return IrAndMetadata(
         ir_blocks=basic_blocks,
         input_metadata=context['inputs'],
         output_metadata=output_metadata,
-        location_types=context['location_types'],
-        coerced_locations=context['coerced_locations'])
+        location_types=location_types,
+        coerced_locations=coerced_locations)
 
 
 def _compile_output_step(outputs):

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -9,8 +9,11 @@ LocationInfo = namedtuple(
     'LocationInfo',
     (
         'parent_location',         # Location/FoldScopeLocation, the parent of the current location
-        'type',                    # str, the actual type name at that location
-        'coerced_from_type',       # str, the type before coercion, or None if no coercion applied
+        'type',                    # GraphQL type object for the type at that location
+
+        'coerced_from_type',       # GraphQL type object for the type before coercion,
+                                   # or None if no coercion was applied
+
         'optional_scopes_depth',   # int, how many nested optional scopes this location is in
         'recursive_scopes_depth',  # int, how many nested recursion scopes this location is in
         'is_within_fold',          # bool, True if this location is within a fold scope;
@@ -77,6 +80,12 @@ class QueryMetadataTable(object):
     def get_location_info(self, location):
         """Return the LocationInfo object for a given location."""
         return self._locations[location]
+
+    @property
+    def registered_locations(self):
+        """Return an iterable of (location, location_info) tuples for all registered locations."""
+        for location, location_info in six.iteritems(self._locations):
+            yield location, location_info
 
     def __str__(self):
         """Return a human-readable str representation of the QueryMetadataTable object."""


### PR DESCRIPTION
Initial cleanup of the context data maintained by the compiler frontend, by replacing its data with QueryMetadataTable info. More cleanup coming, just trying to keep it in small pieces.

@jmeulemans this changes the `type` data in the QueryMetadataTable from a string type name to a GraphQL type object. This is to make it possible to use the QueryMetadataTable for the `location_types` values. I think it's not a big deal since it's easy to go from a type object to a type name, but it's much harder to go the other way.