### PR TITLE
Pass the QueryMetadataTable out of frontend and into IR lowering.

### DIFF
--- a/graphql_compiler/compiler/common.py
+++ b/graphql_compiler/compiler/common.py
@@ -90,8 +90,7 @@ def _compile_graphql_generic(language, lowering_func, query_emitter_func,
         schema, graphql_string, type_equivalence_hints=type_equivalence_hints)
 
     lowered_ir_blocks = lowering_func(
-        ir_and_metadata.ir_blocks, ir_and_metadata.location_types,
-        ir_and_metadata.coerced_locations,
+        ir_and_metadata.ir_blocks, ir_and_metadata.query_metadata_table,
         type_equivalence_hints=type_equivalence_hints)
 
     query = query_emitter_func(lowered_ir_blocks)

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -125,8 +125,7 @@ IrAndMetadata = namedtuple(
         'ir_blocks',
         'input_metadata',
         'output_metadata',
-        'location_types',
-        'coerced_locations',
+        'query_metadata_table',
     )
 )
 
@@ -704,6 +703,8 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
 
     # Construct the starting context object.
     context = {
+        # 'metadata' is the QueryMetadataTable describing all the metadata collected during query
+        # processing, including location metadata (e.g. which locations are folded or optional).
         'metadata': query_metadata_table,
         # 'tags' is a dict containing
         #  - location: Location where the tag was defined
@@ -766,23 +767,11 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
         for name, value in six.iteritems(outputs_context)
     }
 
-    location_types = {
-        location: location_info.type
-        for location, location_info in query_metadata_table.registered_locations
-    }
-
-    coerced_locations = {
-        location
-        for location, location_info in query_metadata_table.registered_locations
-        if location_info.coerced_from_type is not None
-    }
-
     return IrAndMetadata(
         ir_blocks=basic_blocks,
         input_metadata=context['inputs'],
         output_metadata=output_metadata,
-        location_types=location_types,
-        coerced_locations=coerced_locations)
+        query_metadata_table=context['metadata'])
 
 
 def _compile_output_step(outputs):

--- a/graphql_compiler/compiler/ir_lowering_gremlin/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/__init__.py
@@ -10,14 +10,14 @@ from ..ir_lowering_common import (lower_context_field_existence, merge_consecuti
 # Public API #
 ##############
 
-def lower_ir(ir_blocks, location_types, coerced_locations, type_equivalence_hints=None):
+def lower_ir(ir_blocks, query_metadata_table, type_equivalence_hints=None):
     """Lower the IR into an IR form that can be represented in Gremlin queries.
 
     Args:
         ir_blocks: list of IR blocks to lower into Gremlin-compatible form
-        location_types: dict of location objects -> GraphQL type objects at that location
-        coerced_locations: set of locations where type coercions were applied to constrain the type
-                           relative to the type inferred by the GraphQL schema and the given field
+        query_metadata_table: QueryMetadataTable object containing all metadata collected during
+                              query processing, including location metadata (e.g. which locations
+                              are folded or optional).
         type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
                                 Used as a workaround for GraphQL's lack of support for
                                 inheritance across "types" (i.e. non-interfaces), as well as a

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -32,14 +32,15 @@ def check_test_data(test_case, test_data, expected_blocks, expected_location_typ
     test_case.assertEqual(
         test_data.expected_output_metadata, compilation_results.output_metadata)
     test_case.assertEqual(
-        expected_location_types, comparable_location_types(compilation_results.location_types))
+        expected_location_types,
+        get_comparable_location_types(compilation_results.query_metadata_table))
 
 
-def comparable_location_types(location_types):
-    """Convert the dict of Location -> GraphQL object type into a dict of Location -> string."""
+def get_comparable_location_types(query_metadata_table):
+    """Return the dict of location -> GraphQL type name for each location in the query."""
     return {
-        location: graphql_type.name
-        for location, graphql_type in six.iteritems(location_types)
+        location: location_info.type.name
+        for location, location_info in query_metadata_table.registered_locations
     }
 
 


### PR DESCRIPTION
Baby steps toward making lowering make full use of the QueryMetadataTable, continuing in the spirit of the smallest possible PR that makes a positive change without breaking tests.

This PR simply passes the QueryMetadataTable out of the compiler frontend and into the IR lowering, updates the API contracts and documentation around that change, and updates tests so they continue to pass.

Subsequent PRs will rewrite lowering steps to make them rely on the QueryMetadataTable more directly and in more depth, and work toward keeping the QueryMetadataTable in sync with IR transformations.