### PR TITLE
Add corresponding Backtrack blocks to Traverse blocks inside fold scopes

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -493,11 +493,9 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
 
         # If we are currently evaluating a @fold vertex,
         # we didn't Traverse into it, so we don't need to backtrack out either.
-        # We also don't backtrack if we're currently inside a @fold scope, or
-        # if we've reached an @output_source.
+        # We also don't backtrack if we've reached an @output_source.
         backtracking_required = (
             (not fold_directive) and
-            (not isinstance(location, FoldScopeLocation)) and
             (not has_encountered_output_source(context))
         )
         if backtracking_required:

--- a/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
@@ -303,9 +303,9 @@ def _convert_folded_blocks(folded_ir_blocks):
             new_block = GremlinFoldedFilter(new_predicate)
         elif isinstance(block, Traverse):
             new_block = GremlinFoldedTraverse.from_traverse(block)
-        elif isinstance(block, MarkLocation):
-            # We remove MarkLocation blocks from the folded blocks output,
-            # since they do not produce any Gremlin output code.
+        elif isinstance(block, (MarkLocation, Backtrack)):
+            # We remove MarkLocation and Backtrack blocks from the folded blocks output,
+            # since they do not produce any Gremlin output code inside folds.
             continue
         else:
             raise AssertionError(u'Found an unexpected IR block in the folded IR blocks: '

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -2238,6 +2238,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(parent_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
             blocks.MarkLocation(first_traversed_fold),
+            blocks.Backtrack(parent_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -2271,6 +2272,8 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(first_traversed_fold),
             blocks.Traverse('out', 'Animal_OfSpecies'),
             blocks.MarkLocation(second_traversed_fold),
+            blocks.Backtrack(first_traversed_fold),
+            blocks.Backtrack(parent_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -2305,6 +2308,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(sibling_fold),
             blocks.Traverse('out', 'Animal_OfSpecies'),
             blocks.MarkLocation(sibling_species_fold),
+            blocks.Backtrack(sibling_fold),
             blocks.Unfold(),
             blocks.Backtrack(base_location),
             blocks.ConstructResult({
@@ -2365,6 +2369,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
             blocks.MarkLocation(first_traversed_fold),
+            blocks.Backtrack(base_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -2435,11 +2440,13 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_out_fold),
             blocks.Traverse('in', 'Animal_ParentOf'),
             blocks.MarkLocation(base_out_traversed_fold),
+            blocks.Backtrack(base_out_fold),
             blocks.Unfold(),
             blocks.Fold(base_in_fold),
             blocks.MarkLocation(base_in_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
             blocks.MarkLocation(base_in_traversed_fold),
+            blocks.Backtrack(base_in_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -2593,6 +2600,7 @@ class IrGenerationTests(unittest.TestCase):
                 )
             ),
             blocks.MarkLocation(inner_fold),
+            blocks.Backtrack(parent_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'name': expressions.OutputContextField(
@@ -2759,6 +2767,8 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(first_traversed_fold),
             blocks.Traverse('out', 'Animal_OfSpecies'),
             blocks.MarkLocation(second_traversed_fold),
+            blocks.Backtrack(first_traversed_fold),
+            blocks.Backtrack(base_parent_fold),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
@@ -3663,6 +3673,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(fold_scope),
             blocks.Traverse('out', 'Animal_ParentOf'),
             blocks.MarkLocation(first_traversed_fold),
+            blocks.Backtrack(fold_scope),
             blocks.Unfold(),
             blocks.ConstructResult({
                 'grandparent_name': expressions.TernaryConditional(
@@ -3705,6 +3716,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_fold),
             blocks.Traverse('out', 'Animal_ParentOf'),
             blocks.MarkLocation(first_traversed_fold),
+            blocks.Backtrack(base_fold),
             blocks.Unfold(),
             blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(parent_location),


### PR DESCRIPTION
Make Backtrack blocks be emitted when backing out of traversals inside a fold.

Unless an "output_source" directive was encountered, we now have a corresponding Backtrack block for every Traverse block that appears in the IR -- this now includes blocks in folded scopes.