### PR TITLE
Include QueryMetadataTable in IR sanity checks.

### DIFF
--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -331,7 +331,9 @@ class Location(BaseLocation):
     def is_revisited_at(self, other_location):
         """Return True if other_location is a revisit of this location, and False otherwise."""
         # Note that FoldScopeLocation objects cannot revisit Location objects, or each other.
-        return isinstance(other_location, Location) and self.query_path == other_location.query_path
+        return (isinstance(other_location, Location) and
+                self.query_path == other_location.query_path and
+                self.visit_counter < other_location.visit_counter)
 
     def __str__(self):
         """Return a human-readable str representation of the Location object."""

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -328,6 +328,11 @@ class Location(BaseLocation):
         mark_name = u'__'.join(self.query_path) + u'___' + six.text_type(self.visit_counter)
         return (mark_name, self.field)
 
+    def is_revisited_at(self, other_location):
+        """Return True if other_location is a revisit of this location, and False otherwise."""
+        # Note that FoldScopeLocation objects cannot revisit Location objects, or each other.
+        return isinstance(other_location, Location) and self.query_path == other_location.query_path
+
     def __str__(self):
         """Return a human-readable str representation of the Location object."""
         return u'Location({}, {}, {})'.format(self.query_path, self.field, self.visit_counter)

--- a/graphql_compiler/compiler/ir_lowering_gremlin/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/__init__.py
@@ -37,7 +37,7 @@ def lower_ir(ir_blocks, query_metadata_table, type_equivalence_hints=None):
     Returns:
         list of IR blocks suitable for outputting as Gremlin
     """
-    sanity_check_ir_blocks_from_frontend(ir_blocks)
+    sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table)
 
     ir_blocks = lower_context_field_existence(ir_blocks)
     ir_blocks = optimize_boolean_expression_comparisons(ir_blocks)

--- a/graphql_compiler/compiler/ir_lowering_match/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_match/__init__.py
@@ -55,7 +55,7 @@ def lower_ir(ir_blocks, query_metadata_table, type_equivalence_hints=None):
     Returns:
         MatchQuery object containing the IR blocks organized in a MATCH-like structure
     """
-    sanity_check_ir_blocks_from_frontend(ir_blocks)
+    sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table)
 
     # Construct the mapping of each location to its corresponding GraphQL type.
     location_types = {

--- a/graphql_compiler/compiler/ir_sanity_checks.py
+++ b/graphql_compiler/compiler/ir_sanity_checks.py
@@ -8,7 +8,7 @@ from .blocks import (Backtrack, CoerceType, ConstructResult, Filter, Fold, MarkL
 from .ir_lowering_common import extract_folds_from_ir_blocks
 
 
-def sanity_check_ir_blocks_from_frontend(ir_blocks):
+def sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table):
     """Assert that IR blocks originating from the frontend do not have nonsensical structure.
 
     Args:
@@ -30,6 +30,43 @@ def sanity_check_ir_blocks_from_frontend(ir_blocks):
     _sanity_check_mark_location_preceding_optional_traverse(ir_blocks)
     _sanity_check_every_location_is_marked(ir_blocks)
     _sanity_check_coerce_type_outside_of_fold(ir_blocks)
+    _sanity_check_all_marked_locations_are_registered(ir_blocks, query_metadata_table)
+    _sanity_check_registered_locations_parent_locations(query_metadata_table)
+
+
+def _sanity_check_registered_locations_parent_locations(query_metadata_table):
+    """Assert that all registered locations' parent locations are also registered."""
+    for _, location_info in query_metadata_table.registered_locations:
+        if location_info.parent_location is not None:
+            # Make sure the parent_location is also registered.
+            # If the location is not registered, the following line will raise an error.
+            query_metadata_table.get_location_info(location_info.parent_location)
+
+
+def _sanity_check_all_marked_locations_are_registered(ir_blocks, query_metadata_table):
+    """Assert that all locations in MarkLocation blocks have registered and valid metadata."""
+    # Grab all the registered locations, then make sure that:
+    # - Any location that appears in a MarkLocation block is also registered.
+    # - There are no registered locations that do not appear in a MarkLocation block.
+    registered_locations = {
+        location
+        for location, _ in query_metadata_table.registered_locations
+    }
+
+    ir_encountered_locations = {
+        block.location
+        for block in ir_blocks
+        if isinstance(block, MarkLocation)
+    }
+
+    unregistered_locations = ir_encountered_locations - registered_locations
+    unencountered_locations = registered_locations - ir_encountered_locations
+    if unregistered_locations:
+        raise AssertionError(u'IR blocks unexpectedly contain locations not registered in the '
+                             u'QueryMetadataTable: {}'.format(unregistered_locations))
+    if unencountered_locations:
+        raise AssertionError(u'QueryMetadataTable unexpectedly contains registered locations that '
+                             u'never appear in the IR blocks: {}'.format(unencountered_locations))
 
 
 def _sanity_check_fold_scope_locations_are_unique(ir_blocks):
@@ -139,34 +176,33 @@ def _sanity_check_mark_location_preceding_optional_traverse(ir_blocks):
 
 def _sanity_check_every_location_is_marked(ir_blocks):
     """Ensure that every new location is marked with a MarkLocation block."""
-    # Exactly one MarkLocation block is found between a QueryRoot / Traverse / Recurse block,
-    # and the first subsequent Traverse, Recurse, Backtrack or ConstructResult block.
+    # Exactly one MarkLocation block is found between any block that starts an interval of blocks
+    # that all affect the same query position, and the first subsequent block that affects a
+    # different position in the query. Such intervals include the following examples:
+    # - from Fold to Unfold
+    # - from QueryRoot to Traverse/Recurse
+    # - from one Traverse to the next Traverse
+    # - from Traverse to Backtrack
     found_start_block = False
-    found_fold_block = False
     mark_location_blocks = 0
 
-    for block in ir_blocks:
-        if isinstance(block, Fold):
-            found_fold_block = True
-        # Don't need to check for mark locations within a fold traversal
-        if found_fold_block:
-            if isinstance(block, Unfold):
-                found_fold_block = False
-        else:
-            # Terminate started intervals before opening new ones.
-            end_interval_types = (Backtrack, ConstructResult, Recurse, Traverse)
-            if isinstance(block, end_interval_types) and found_start_block:
-                found_start_block = False
-                if mark_location_blocks != 1:
-                    raise AssertionError(u'Expected 1 MarkLocation block between traversals, '
-                                         u'found: {} {}'.format(mark_location_blocks, ir_blocks))
+    start_interval_types = (QueryRoot, Traverse, Recurse, Fold)
+    end_interval_types = (Backtrack, ConstructResult, Recurse, Traverse, Unfold)
 
-            # Now consider opening new intervals or processing MarkLocation blocks.
-            if isinstance(block, MarkLocation):
-                mark_location_blocks += 1
-            elif isinstance(block, (QueryRoot, Traverse, Recurse)):
-                found_start_block = True
-                mark_location_blocks = 0
+    for block in ir_blocks:
+        # Terminate started intervals before opening new ones.
+        if isinstance(block, end_interval_types) and found_start_block:
+            found_start_block = False
+            if mark_location_blocks != 1:
+                raise AssertionError(u'Expected 1 MarkLocation block between traversals, '
+                                     u'found: {} {}'.format(mark_location_blocks, ir_blocks))
+
+        # Now consider opening new intervals or processing MarkLocation blocks.
+        if isinstance(block, MarkLocation):
+            mark_location_blocks += 1
+        elif isinstance(block, start_interval_types):
+            found_start_block = True
+            mark_location_blocks = 0
 
 
 def _sanity_check_coerce_type_outside_of_fold(ir_blocks):

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -35,6 +35,10 @@ class QueryMetadataTable(object):
                                  u'Note that FoldScopeLocation objects cannot be root locations. '
                                  u'Got: {} {}'.format(type(root_location).__name__, root_location))
 
+        if len(root_location.query_path) != 1 or root_location.visit_counter != 1:
+            raise AssertionError(u'Expected a root location with a query path of length 1, and a '
+                                 u'visit counter of 1, but received: {}'.format(root_location))
+
         self._root_location = root_location  # Location, the root location of the entire query
         self._locations = dict()             # dict, Location/FoldScopeLocation -> LocationInfo
         self._inputs = dict()                # dict, input name -> input info namedtuple


### PR DESCRIPTION
This PR includes QueryMetadataTable in the IR sanity checks, allowing cross-checking of the IR versus the data recorded in the metadata table. It also adds some more sanity-checks in the QueryMetadataTable itself, and strengthens one of the existing sanity-checks to account for the fact that `MarkLocation` blocks now also appear between `Fold` and `Unfold` blocks.