### PR TITLE
 Reserve out_name namespace for compiler internal use

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ This query returns the name of each `Animal` in the graph, in a column named `an
 - `@output` can only be applied to property fields.
 - The value provided for `out_name` may only consist of upper or lower case letters
   (`A-Z`, `a-z`), or underscores (`_`).
+- The value provided for `out_name` cannot be prefixed with `___` (three underscores). This
+namespace is reserved for compiler internal use.
 - For any given query, all `out_name` values must be unique. In other words, output columns must
   have unique names.
 

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -81,7 +81,7 @@ from .filters import process_filter_directive
 from .helpers import (FoldScopeLocation, Location, get_ast_field_name, get_edge_direction_and_name,
                       get_field_type_from_schema, get_uniquely_named_objects_by_name,
                       get_vertex_field_type, invert_dict, is_vertex_field_name,
-                      strip_non_null_from_type, validate_safe_string, validate_output_name)
+                      strip_non_null_from_type, validate_output_name, validate_safe_string)
 from .metadata import LocationInfo, QueryMetadataTable
 
 

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -81,7 +81,7 @@ from .filters import process_filter_directive
 from .helpers import (FoldScopeLocation, Location, get_ast_field_name, get_edge_direction_and_name,
                       get_field_type_from_schema, get_uniquely_named_objects_by_name,
                       get_vertex_field_type, invert_dict, is_vertex_field_name,
-                      strip_non_null_from_type, validate_safe_string)
+                      strip_non_null_from_type, validate_safe_string, validate_output_name)
 from .metadata import LocationInfo, QueryMetadataTable
 
 
@@ -279,6 +279,7 @@ def _compile_property_ast(schema, current_schema_type, ast, location,
             raise GraphQLCompilationError(u'Cannot reuse output name: '
                                           u'{}, {}'.format(output_name, context))
         validate_safe_string(output_name)
+        validate_output_name(output_name)
 
         graphql_type = strip_non_null_from_type(current_schema_type)
         if is_in_fold_scope(context):

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -194,7 +194,7 @@ def validate_safe_string(value):
 
 
 def validate_output_name(value):
-    """Ensure that the provided string is valid for use an an output name."""
+    """Ensure that the provided string is valid for use as an output name."""
     internal_name_prefix = u'___'
     if value.startswith(internal_name_prefix):
         raise GraphQLCompilationError(

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -193,6 +193,14 @@ def validate_safe_string(value):
         raise GraphQLCompilationError(u'Encountered illegal characters in string: {}'.format(value))
 
 
+def validate_output_name(value):
+    """Ensure that the provided string is valid for use an an output name."""
+    internal_name_prefix = u'___'
+    if value.startswith(internal_name_prefix):
+        raise GraphQLCompilationError(
+            u'The prefix "___" (three underscores) for output names is reserved by the compiler.')
+
+
 def validate_edge_direction(edge_direction):
     """Ensure the provided edge direction is either "in" or "out"."""
     if not isinstance(edge_direction, six.string_types):

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -370,12 +370,19 @@ class IrGenerationErrorTests(unittest.TestCase):
             }
         }''')
 
+        output_with_reserved_name = (GraphQLCompilationError, '''{
+            Animal @filter(op_name: "name_or_alias", value: ["$animal_name"]) {
+                name @output(out_name: "___animal_name")
+            }
+        }''')
+
         for expected_error, graphql in (output_on_vertex_field,
                                         output_without_name,
                                         output_with_duplicated_name,
                                         output_with_illegal_name,
                                         output_with_empty_name,
-                                        output_with_name_starting_with_digit):
+                                        output_with_name_starting_with_digit,
+                                        output_with_reserved_name):
             with self.assertRaises(expected_error):
                 graphql_to_ir(self.schema, graphql)
 
@@ -1243,3 +1250,14 @@ class IrGenerationErrorTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             graphql_to_ir(self.schema, valid_graphql_input,
                           type_equivalence_hints=invalid_type_equivalence_hints)
+
+    def test_reserved_internal_name_output_error(self):
+        """Ensure TypeError is raised when the hints are non-invertible."""
+        valid_graphql_input = '''{
+            Animal {
+                name @output(out_name: "___animal_name")
+            }
+        }'''
+        with self.assertRaises(GraphQLCompilationError):
+            graphql_to_ir(self.schema, valid_graphql_input,
+                          type_equivalence_hints={})

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -1250,14 +1250,3 @@ class IrGenerationErrorTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             graphql_to_ir(self.schema, valid_graphql_input,
                           type_equivalence_hints=invalid_type_equivalence_hints)
-
-    def test_reserved_internal_name_output_error(self):
-        """Ensure TypeError is raised when the hints are non-invertible."""
-        valid_graphql_input = '''{
-            Animal {
-                name @output(out_name: "___animal_name")
-            }
-        }'''
-        with self.assertRaises(GraphQLCompilationError):
-            graphql_to_ir(self.schema, valid_graphql_input,
-                          type_equivalence_hints={})


### PR DESCRIPTION
This will allow for compiler internal only names to be used as output without the risk of conflicting with a user supplied `out_name`. This comes up with the SQL backend with columns that are needed in intermediate results, but that aren't included in the final output.