### PR TITLE
Change import style to isort multiline output mode 5.

### DIFF
--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -4,8 +4,10 @@
 import six
 
 from .compiler_entities import BasicBlock, Expression, MarkerBlock
-from .helpers import (FoldScopeLocation, ensure_unicode_string, safe_quoted_string,
-                      validate_edge_direction, validate_marked_location, validate_safe_string)
+from .helpers import (
+    FoldScopeLocation, ensure_unicode_string, safe_quoted_string, validate_edge_direction,
+    validate_marked_location, validate_safe_string
+)
 
 
 class QueryRoot(BasicBlock):

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -62,26 +62,31 @@ from collections import namedtuple
 from graphql.error import GraphQLSyntaxError
 from graphql.language.ast import Field, InlineFragment
 from graphql.language.parser import parse
-from graphql.type.definition import (GraphQLInterfaceType, GraphQLList, GraphQLObjectType,
-                                     GraphQLUnionType)
+from graphql.type.definition import (
+    GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLUnionType
+)
 from graphql.validation import validate
 import six
 
 from . import blocks, expressions
 from ..exceptions import GraphQLCompilationError, GraphQLParsingError, GraphQLValidationError
 from ..schema import DIRECTIVES
-from .context_helpers import (has_encountered_output_source, is_in_fold_scope, is_in_optional_scope,
-                              validate_context_for_visiting_vertex_field)
-from .directive_helpers import (get_local_filter_directives, get_unique_directives,
-                                validate_property_directives, validate_root_vertex_directives,
-                                validate_vertex_directives,
-                                validate_vertex_field_directive_in_context,
-                                validate_vertex_field_directive_interactions)
+from .context_helpers import (
+    has_encountered_output_source, is_in_fold_scope, is_in_optional_scope,
+    validate_context_for_visiting_vertex_field
+)
+from .directive_helpers import (
+    get_local_filter_directives, get_unique_directives, validate_property_directives,
+    validate_root_vertex_directives, validate_vertex_directives,
+    validate_vertex_field_directive_in_context, validate_vertex_field_directive_interactions
+)
 from .filters import process_filter_directive
-from .helpers import (FoldScopeLocation, Location, get_ast_field_name, get_edge_direction_and_name,
-                      get_field_type_from_schema, get_uniquely_named_objects_by_name,
-                      get_vertex_field_type, invert_dict, is_vertex_field_name,
-                      strip_non_null_from_type, validate_output_name, validate_safe_string)
+from .helpers import (
+    FoldScopeLocation, Location, get_ast_field_name, get_edge_direction_and_name,
+    get_field_type_from_schema, get_uniquely_named_objects_by_name, get_vertex_field_type,
+    invert_dict, is_vertex_field_name, strip_non_null_from_type, validate_output_name,
+    validate_safe_string
+)
 from .metadata import LocationInfo, QueryMetadataTable
 
 

--- a/graphql_compiler/compiler/directive_helpers.py
+++ b/graphql_compiler/compiler/directive_helpers.py
@@ -6,8 +6,10 @@ import six
 
 from ..exceptions import GraphQLCompilationError
 from .filters import is_filter_with_outer_scope_vertex_field_operator
-from .helpers import (FilterOperationInfo, get_ast_field_name, get_ast_field_name_or_none,
-                      get_vertex_field_type, is_vertex_field_type)
+from .helpers import (
+    FilterOperationInfo, get_ast_field_name, get_ast_field_name_or_none, get_vertex_field_type,
+    is_vertex_field_type
+)
 
 
 ALLOWED_DUPLICATED_DIRECTIVES = frozenset({'filter'})

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -5,9 +5,11 @@ import six
 from ..exceptions import GraphQLCompilationError
 from ..schema import GraphQLDate, GraphQLDateTime
 from .compiler_entities import Expression
-from .helpers import (STANDARD_DATE_FORMAT, STANDARD_DATETIME_FORMAT, FoldScopeLocation, Location,
-                      ensure_unicode_string, is_graphql_type, is_vertex_field_name,
-                      safe_quoted_string, strip_non_null_from_type, validate_safe_string)
+from .helpers import (
+    STANDARD_DATE_FORMAT, STANDARD_DATETIME_FORMAT, FoldScopeLocation, Location,
+    ensure_unicode_string, is_graphql_type, is_vertex_field_name, safe_quoted_string,
+    strip_non_null_from_type, validate_safe_string
+)
 
 
 # Since MATCH uses $-prefixed keywords to indicate special values,

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -7,8 +7,10 @@ from graphql.type.definition import is_leaf_type
 
 from . import blocks, expressions
 from ..exceptions import GraphQLCompilationError, GraphQLValidationError
-from .helpers import (get_uniquely_named_objects_by_name, is_vertex_field_name,
-                      is_vertex_field_type, strip_non_null_from_type, validate_safe_string)
+from .helpers import (
+    get_uniquely_named_objects_by_name, is_vertex_field_name, is_vertex_field_type,
+    strip_non_null_from_type, validate_safe_string
+)
 
 
 def scalar_leaf_only(operator):

--- a/graphql_compiler/compiler/ir_lowering_common.py
+++ b/graphql_compiler/compiler/ir_lowering_common.py
@@ -2,10 +2,12 @@
 """Language-independent IR lowering and optimization functions."""
 import six
 
-from .blocks import (ConstructResult, EndOptional, Filter, Fold, MarkLocation, Recurse, Traverse,
-                     Unfold)
-from .expressions import (BinaryComposition, ContextField, ContextFieldExistence, FalseLiteral,
-                          NullLiteral, TrueLiteral)
+from .blocks import (
+    ConstructResult, EndOptional, Filter, Fold, MarkLocation, Recurse, Traverse, Unfold
+)
+from .expressions import (
+    BinaryComposition, ContextField, ContextFieldExistence, FalseLiteral, NullLiteral, TrueLiteral
+)
 from .helpers import validate_safe_string
 
 

--- a/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
@@ -16,11 +16,13 @@ from ...exceptions import GraphQLCompilationError
 from ...schema import GraphQLDate, GraphQLDateTime
 from ..blocks import Backtrack, CoerceType, ConstructResult, Filter, MarkLocation, Traverse
 from ..compiler_entities import Expression
-from ..expressions import (BinaryComposition, FoldedOutputContextField, Literal, LocalField,
-                           NullLiteral)
-from ..helpers import (STANDARD_DATE_FORMAT, STANDARD_DATETIME_FORMAT, FoldScopeLocation,
-                       get_only_element_from_collection, strip_non_null_from_type,
-                       validate_safe_string)
+from ..expressions import (
+    BinaryComposition, FoldedOutputContextField, Literal, LocalField, NullLiteral
+)
+from ..helpers import (
+    STANDARD_DATE_FORMAT, STANDARD_DATETIME_FORMAT, FoldScopeLocation,
+    get_only_element_from_collection, strip_non_null_from_type, validate_safe_string
+)
 from ..ir_lowering_common import extract_folds_from_ir_blocks
 
 

--- a/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
@@ -11,8 +11,10 @@ to simplify the final code generation step.
 import six
 
 from ..blocks import Backtrack, CoerceType, MarkLocation, QueryRoot
-from ..expressions import (BinaryComposition, ContextField, ContextFieldExistence, FalseLiteral,
-                           FoldedOutputContextField, Literal, TernaryConditional, TrueLiteral)
+from ..expressions import (
+    BinaryComposition, ContextField, ContextFieldExistence, FalseLiteral, FoldedOutputContextField,
+    Literal, TernaryConditional, TrueLiteral
+)
 from ..helpers import FoldScopeLocation
 from .utils import convert_coerce_type_to_instanceof_filter
 

--- a/graphql_compiler/compiler/ir_lowering_match/optional_traversal.py
+++ b/graphql_compiler/compiler/ir_lowering_match/optional_traversal.py
@@ -4,12 +4,15 @@ from functools import partial
 import six
 
 from ..blocks import ConstructResult, Filter, Traverse
-from ..expressions import (BinaryComposition, ContextField, FoldedOutputContextField, Literal,
-                           LocalField, OutputContextField, TernaryConditional, TrueLiteral,
-                           UnaryTransformation, Variable)
+from ..expressions import (
+    BinaryComposition, ContextField, FoldedOutputContextField, Literal, LocalField,
+    OutputContextField, TernaryConditional, TrueLiteral, UnaryTransformation, Variable
+)
 from ..match_query import MatchQuery, MatchStep
-from .utils import (BetweenClause, CompoundMatchQuery, construct_optional_traversal_tree,
-                    expression_list_to_conjunction, filter_edge_field_non_existence)
+from .utils import (
+    BetweenClause, CompoundMatchQuery, construct_optional_traversal_tree,
+    expression_list_to_conjunction, filter_edge_field_non_existence
+)
 
 
 def _prune_traverse_using_omitted_locations(match_traversal, omitted_locations,

--- a/graphql_compiler/compiler/ir_lowering_match/utils.py
+++ b/graphql_compiler/compiler/ir_lowering_match/utils.py
@@ -5,8 +5,10 @@ import itertools
 import six
 
 from ..blocks import Filter
-from ..expressions import (BinaryComposition, Expression, Literal, LocalField, NullLiteral,
-                           SelectEdgeContextField, TrueLiteral, UnaryTransformation, ZeroLiteral)
+from ..expressions import (
+    BinaryComposition, Expression, Literal, LocalField, NullLiteral, SelectEdgeContextField,
+    TrueLiteral, UnaryTransformation, ZeroLiteral
+)
 from ..helpers import Location, get_only_element_from_collection, is_vertex_field_name
 
 

--- a/graphql_compiler/compiler/ir_sanity_checks.py
+++ b/graphql_compiler/compiler/ir_sanity_checks.py
@@ -3,8 +3,10 @@
 
 from funcy.py2 import pairwise
 
-from .blocks import (Backtrack, CoerceType, ConstructResult, Filter, Fold, MarkLocation,
-                     OutputSource, QueryRoot, Recurse, Traverse, Unfold)
+from .blocks import (
+    Backtrack, CoerceType, ConstructResult, Filter, Fold, MarkLocation, OutputSource, QueryRoot,
+    Recurse, Traverse, Unfold
+)
 from .ir_lowering_common import extract_folds_from_ir_blocks
 
 

--- a/graphql_compiler/compiler/match_query.py
+++ b/graphql_compiler/compiler/match_query.py
@@ -3,8 +3,10 @@
 
 from collections import namedtuple
 
-from .blocks import (Backtrack, CoerceType, ConstructResult, Filter, Fold, GlobalOperationsStart,
-                     MarkLocation, OutputSource, QueryRoot, Recurse, Traverse, Unfold)
+from .blocks import (
+    Backtrack, CoerceType, ConstructResult, Filter, Fold, GlobalOperationsStart, MarkLocation,
+    OutputSource, QueryRoot, Recurse, Traverse, Unfold
+)
 from .ir_lowering_common import extract_folds_from_ir_blocks
 
 

--- a/graphql_compiler/compiler/workarounds/orientdb_eval_scheduling.py
+++ b/graphql_compiler/compiler/workarounds/orientdb_eval_scheduling.py
@@ -11,8 +11,9 @@ This workaround doesn't work in OrientDB <2.2.17 due to another bug.
 The workaround should fix the problem starting with OrientDB 2.2.18.
 """
 from ..blocks import Filter
-from ..expressions import (BinaryComposition, ContextField, ContextFieldExistence, NullLiteral,
-                           TernaryConditional)
+from ..expressions import (
+    BinaryComposition, ContextField, ContextFieldExistence, NullLiteral, TernaryConditional
+)
 
 
 def workaround_lowering_pass(ir_blocks):

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -4,8 +4,10 @@ from datetime import date, datetime
 from decimal import Decimal
 
 import arrow
-from graphql import (DirectiveLocation, GraphQLArgument, GraphQLDirective, GraphQLInt, GraphQLList,
-                     GraphQLNonNull, GraphQLScalarType, GraphQLString)
+from graphql import (
+    DirectiveLocation, GraphQLArgument, GraphQLDirective, GraphQLInt, GraphQLList, GraphQLNonNull,
+    GraphQLScalarType, GraphQLString
+)
 
 
 # Constraints:

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -4,10 +4,13 @@ import unittest
 from graphql import GraphQLString
 
 from ..compiler import emit_gremlin, emit_match
-from ..compiler.blocks import (Backtrack, ConstructResult, Filter, GlobalOperationsStart,
-                               MarkLocation, QueryRoot, Traverse)
-from ..compiler.expressions import (BinaryComposition, ContextField, LocalField, NullLiteral,
-                                    OutputContextField, TernaryConditional, Variable)
+from ..compiler.blocks import (
+    Backtrack, ConstructResult, Filter, GlobalOperationsStart, MarkLocation, QueryRoot, Traverse
+)
+from ..compiler.expressions import (
+    BinaryComposition, ContextField, LocalField, NullLiteral, OutputContextField,
+    TernaryConditional, Variable
+)
 from ..compiler.helpers import Location
 from ..compiler.ir_lowering_common import OutputContextVertex
 from ..compiler.ir_lowering_match.utils import CompoundMatchQuery, construct_where_filter_predicate

--- a/graphql_compiler/tests/test_ir_lowering.py
+++ b/graphql_compiler/tests/test_ir_lowering.py
@@ -5,12 +5,14 @@ import unittest
 from graphql import GraphQLString
 
 from ..compiler import ir_lowering_common, ir_lowering_gremlin, ir_lowering_match, ir_sanity_checks
-from ..compiler.blocks import (Backtrack, CoerceType, ConstructResult, EndOptional, Filter,
-                               MarkLocation, QueryRoot, Traverse)
-from ..compiler.expressions import (BinaryComposition, ContextField, ContextFieldExistence,
-                                    FalseLiteral, Literal, LocalField, NullLiteral,
-                                    OutputContextField, TernaryConditional, TrueLiteral,
-                                    UnaryTransformation, Variable, ZeroLiteral)
+from ..compiler.blocks import (
+    Backtrack, CoerceType, ConstructResult, EndOptional, Filter, MarkLocation, QueryRoot, Traverse
+)
+from ..compiler.expressions import (
+    BinaryComposition, ContextField, ContextFieldExistence, FalseLiteral, Literal, LocalField,
+    NullLiteral, OutputContextField, TernaryConditional, TrueLiteral, UnaryTransformation, Variable,
+    ZeroLiteral
+)
 from ..compiler.helpers import Location
 from ..compiler.ir_lowering_common import OutputContextVertex
 from ..compiler.ir_lowering_match.utils import BetweenClause, CompoundMatchQuery

--- a/scripts/generate_test_sql/animals.py
+++ b/scripts/generate_test_sql/animals.py
@@ -3,8 +3,10 @@ import random
 
 from .events import EVENT_NAMES_LIST
 from .species import FOOD_LIST, SPECIES_LIST
-from .utils import (create_edge_statement, create_name, create_vertex_statement,
-                    extract_base_name_and_label, get_random_date, get_random_net_worth, get_uuid)
+from .utils import (
+    create_edge_statement, create_name, create_vertex_statement, extract_base_name_and_label,
+    get_random_date, get_random_net_worth, get_uuid
+)
 
 
 NUM_INITIAL_ANIMALS = 20

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,6 @@ max-line-length = 100
 
 [isort]
 line_length = 100
-multi_line_output = 0
+multi_line_output = 5
 lines_after_imports = 2
 force_sort_within_sections = 1


### PR DESCRIPTION
Bring the GraphQL compiler project into sync with Kensho internal Python code style.