### PR TITLE
Expose location parent-child and location revisit relationships in metadata.

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -964,7 +964,7 @@ def graphql_to_ir(schema, graphql_string, type_equivalence_hints=None):
         - ir_blocks: a list of IR basic block objects
         - input_metadata: a dict of expected input parameters (string) -> inferred GraphQL type
         - output_metadata: a dict of output name (string) -> OutputMetadata object
-        - location_types: a dict of location objects -> GraphQL type objects at that location
+        - query_metadata_table: a QueryMetadataTable object containing location metadata
 
     Raises flavors of GraphQLError in the following cases:
         - if the query is invalid GraphQL (GraphQLParsingError);

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -41,6 +41,13 @@ class QueryMetadataTable(object):
 
         self._root_location = root_location  # Location, the root location of the entire query
         self._locations = dict()             # dict, Location/FoldScopeLocation -> LocationInfo
+        self._revisit_origins = dict()       # dict, revisiting Location -> revisit origin, i.e.
+                                             #       the first Location with that query path
+        self._revisits = dict()              # dict, revisit origin Location -> set of Locations
+                                             #       for which that Location is the revisit origin
+        self._child_locations = dict()       # dict, Location/FoldScopeLocation -> set of Location
+                                             #       and FoldScopeLocation objects that are directly
+                                             #       descended from it
         self._inputs = dict()                # dict, input name -> input info namedtuple
         self._outputs = dict()               # dict, output name -> output info namedtuple
         self._tags = dict()                  # dict, tag name -> tag info namedtuple
@@ -72,6 +79,8 @@ class QueryMetadataTable(object):
                 raise AssertionError(u'All locations other than the root location and its revisits '
                                      u'must have a parent location, but received a location with '
                                      u'no parent: {} {}'.format(location, location_info))
+        else:
+            self._child_locations.setdefault(location_info.parent_location, set()).add(location)
 
         self._locations[location] = location_info
 
@@ -84,6 +93,13 @@ class QueryMetadataTable(object):
         # might still be holding on to the original info object, therefore registering stale data.
         # This function ensures that the latest metadata on the location is always used instead.
         revisited_location = location.revisit()
+
+        # If "location" is itself a revisit, then we point "revisited_location" to "location"'s
+        # revisit origin. If "location" is not a revisit, then it itself is the revisit origin.
+        revisit_origin = self._revisit_origins.get(location, location)
+        self._revisit_origins[revisited_location] = revisit_origin
+        self._revisits.setdefault(revisit_origin, set()).add(revisited_location)
+
         self.register_location(revisited_location, self.get_location_info(location))
         return revisited_location
 
@@ -110,6 +126,13 @@ class QueryMetadataTable(object):
             raise AssertionError(u'Attempted to get the location info of an unregistered location: '
                                  u'{}'.format(location))
         return location_info
+
+    def get_child_locations(self, location):
+        """Yield an iterable of child locations for a given Location/FoldScopeLocation object."""
+        self.get_location_info(location)  # purely to check for location validity
+
+        for child_location in self._child_locations.get(location, []):
+            yield child_location
 
     @property
     def registered_locations(self):

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -134,6 +134,27 @@ class QueryMetadataTable(object):
         for child_location in self._child_locations.get(location, []):
             yield child_location
 
+    def get_all_revisits(self, location):
+        """Yield an iterable of locations that revisit that location or another of its revisits."""
+        self.get_location_info(location)  # purely to check for location validity
+
+        for revisit_location in self._revisits.get(location, []):
+            yield revisit_location
+
+    def get_revisit_origin(self, location):
+        """Return the original location that this location revisits, or None if it isn't a revisit.
+
+        Args:
+            location: Location/FoldScopeLocation object whose revisit origin to get
+
+        Returns:
+            Location object representing the first location with the same query path as the given
+            location. Returns the given location itself if that location is the first one with
+            that query path. Guaranteed to return the input location if it is a FoldScopeLocation.
+        """
+        self.get_location_info(location)  # purely to check for location validity
+        return self._revisit_origins.get(location, location)
+
     @property
     def registered_locations(self):
         """Return an iterable of (location, location_info) tuples for all registered locations."""

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -41,16 +41,21 @@ class QueryMetadataTable(object):
 
         self._root_location = root_location  # Location, the root location of the entire query
         self._locations = dict()             # dict, Location/FoldScopeLocation -> LocationInfo
-        self._revisit_origins = dict()       # dict, revisiting Location -> revisit origin, i.e.
-                                             #       the first Location with that query path
-        self._revisits = dict()              # dict, revisit origin Location -> set of Locations
-                                             #       for which that Location is the revisit origin
-        self._child_locations = dict()       # dict, Location/FoldScopeLocation -> set of Location
-                                             #       and FoldScopeLocation objects that are directly
-                                             #       descended from it
         self._inputs = dict()                # dict, input name -> input info namedtuple
         self._outputs = dict()               # dict, output name -> output info namedtuple
         self._tags = dict()                  # dict, tag name -> tag info namedtuple
+
+        # dict, revisiting Location -> revisit origin, i.e. the first Location with that query path
+        self._revisit_origins = dict()
+
+        # dict, revisit origin Location -> set of Locations for which
+        #       that Location is the revisit origin
+        self._revisits = dict()
+
+        # dict, Location/FoldScopeLocation -> set of Location and FoldScopeLocation objects
+        #       that are directly descended from it
+        self._child_locations = dict()
+
         self.register_location(root_location, root_location_info)
 
     @property

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -34,8 +34,15 @@ def check_test_data(test_case, test_data, expected_blocks, expected_location_typ
     test_case.assertEqual(
         expected_location_types,
         get_comparable_location_types(compilation_results.query_metadata_table))
+
+    all_child_locations = compute_child_locations(expected_blocks)
+    for parent_location, child_locations in six.iteritems(all_child_locations):
+        for child_location in child_locations:
+            child_info = compilation_results.query_metadata_table.get_location_info(child_location)
+            test_case.assertEqual(parent_location, child_info.parent_location)
+
     test_case.assertEqual(
-        compute_child_locations(expected_blocks),
+        all_child_locations,
         get_comparable_child_locations(compilation_results.query_metadata_table))
 
 
@@ -49,13 +56,13 @@ def get_comparable_location_types(query_metadata_table):
 
 def get_comparable_child_locations(query_metadata_table):
     """Return the dict of location -> set of child locations for each location in the query."""
-    all_locations = {
+    all_locations_with_possible_children = {
         location: set(query_metadata_table.get_child_locations(location))
         for location, _ in query_metadata_table.registered_locations
     }
     return {
         location: child_locations
-        for location, child_locations in six.iteritems(all_locations)
+        for location, child_locations in six.iteritems(all_locations_with_possible_children)
         if child_locations
     }
 


### PR DESCRIPTION
This PR allows metadata consumers to walk location parent-child and location revisit relationships in both directions, and thereby reconstruct the full type tree and the full location tree of the query.

This info will come in very handy for static query analysis and cost estimation.