### PR TITLE
Fix bad equality checking in Traverse and Recurse blocks, fix tests.

### DIFF
--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -225,7 +225,8 @@ class Traverse(BasicBlock):
         Returns:
             new Traverse object
         """
-        super(Traverse, self).__init__(direction, edge_name, optional=optional)
+        super(Traverse, self).__init__(
+            direction, edge_name, optional=optional, within_optional_scope=within_optional_scope)
         self.direction = direction
         self.edge_name = edge_name
         self.optional = optional
@@ -235,22 +236,21 @@ class Traverse(BasicBlock):
 
     def validate(self):
         """Ensure that the Traverse block is valid."""
-        if not isinstance(self.within_optional_scope, bool):
-            raise TypeError(u'Expected bool within_optional_scope, got: {} '
-                            u'{}'.format(type(self.within_optional_scope).__name__,
-                                         self.within_optional_scope))
-
         if not isinstance(self.direction, six.string_types):
             raise TypeError(u'Expected string direction, got: {} {}'.format(
                 type(self.direction).__name__, self.direction))
 
         validate_edge_direction(self.direction)
+        validate_safe_string(self.edge_name)
 
         if not isinstance(self.optional, bool):
             raise TypeError(u'Expected bool optional, got: {} {}'.format(
                 type(self.optional).__name__, self.optional))
 
-        validate_safe_string(self.edge_name)
+        if not isinstance(self.within_optional_scope, bool):
+            raise TypeError(u'Expected bool within_optional_scope, got: {} '
+                            u'{}'.format(type(self.within_optional_scope).__name__,
+                                         self.within_optional_scope))
 
     def get_field_name(self):
         """Return the field name corresponding to the edge being traversed."""
@@ -307,7 +307,8 @@ class Recurse(BasicBlock):
         Returns:
             new Recurse object
         """
-        super(Recurse, self).__init__(direction, edge_name, depth)
+        super(Recurse, self).__init__(
+            direction, edge_name, depth, within_optional_scope=within_optional_scope)
         self.direction = direction
         self.edge_name = edge_name
         self.depth = depth

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -433,9 +433,7 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
         edge_traversal_is_recursive = recurse_directive is not None
 
         # This is true for any vertex expanded within an @optional scope.
-        # Currently @optional is not allowed within @optional.
-        # This will need to change if nested @optionals have to be supported.
-        within_optional_scope = 'optional' in context and not edge_traversal_is_optional
+        within_optional_scope = 'optional' in context
 
         if edge_traversal_is_optional:
             # Entering an optional block!

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -3004,13 +3004,13 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
-            blocks.Traverse('in', 'Animal_ParentOf'),
+            blocks.Traverse('in', 'Animal_ParentOf', within_optional_scope=True),
             blocks.MarkLocation(grandchild_location),
             blocks.Backtrack(child_location),
             blocks.EndOptional(),
-            blocks.Backtrack(base_location, True),
+            blocks.Backtrack(base_location, optional=True),
             blocks.MarkLocation(revisited_base_location),
             blocks.ConstructResult({
                 'grandchild_name': expressions.TernaryConditional(
@@ -3026,7 +3026,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString),
+                    base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
         expected_location_types = {
@@ -3054,13 +3054,13 @@ class IrGenerationTests(unittest.TestCase):
                 expressions.Variable('$wanted', GraphQLString)
             )),
             blocks.MarkLocation(base_location),
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
-            blocks.Traverse('in', 'Animal_ParentOf'),
+            blocks.Traverse('in', 'Animal_ParentOf', within_optional_scope=True),
             blocks.MarkLocation(grandchild_location),
             blocks.Backtrack(child_location),
             blocks.EndOptional(),
-            blocks.Backtrack(base_location, True),
+            blocks.Backtrack(base_location, optional=True),
             blocks.MarkLocation(revisited_base_location),
             blocks.ConstructResult({
                 'grandchild_name': expressions.TernaryConditional(
@@ -3076,7 +3076,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString),
+                    base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
         expected_location_types = {
@@ -3100,16 +3100,16 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
-            blocks.Traverse('out', 'Animal_ParentOf'),
+            blocks.Traverse('out', 'Animal_ParentOf', within_optional_scope=True),
             blocks.MarkLocation(spouse_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(spouse_species),
             blocks.Backtrack(spouse_location),
             blocks.Backtrack(child_location),
             blocks.EndOptional(),
-            blocks.Backtrack(base_location, True),
+            blocks.Backtrack(base_location, optional=True),
             blocks.MarkLocation(revisited_base_location),
             blocks.ConstructResult({
                 'spouse_and_self_name': expressions.TernaryConditional(
@@ -3119,7 +3119,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'animal_name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString
+                    base_location.navigate_to_field('name'), GraphQLString
                 ),
                 'spouse_species': expressions.TernaryConditional(
                     expressions.ContextFieldExistence(spouse_species),
@@ -3159,13 +3159,13 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_location),
             blocks.Traverse('in', 'Animal_ParentOf'),
             blocks.MarkLocation(child_location),
-            blocks.Traverse('out', 'Animal_ParentOf', True),
+            blocks.Traverse('out', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(spouse_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(spouse_species),
             blocks.Backtrack(spouse_location),
             blocks.EndOptional(),
-            blocks.Backtrack(child_location, True),
+            blocks.Backtrack(child_location, optional=True),
             blocks.MarkLocation(revisited_child_location),
             blocks.Backtrack(base_location),
             blocks.ConstructResult({
@@ -3176,7 +3176,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'animal_name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString
+                    base_location.navigate_to_field('name'), GraphQLString
                 ),
                 'spouse_and_self_species': expressions.TernaryConditional(
                     expressions.ContextFieldExistence(spouse_species),
@@ -3218,21 +3218,21 @@ class IrGenerationTests(unittest.TestCase):
                 expressions.Variable('$wanted', GraphQLString)
             )),
             blocks.MarkLocation(base_location),
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
-            blocks.Traverse('out', 'Animal_ParentOf'),
+            blocks.Traverse('out', 'Animal_ParentOf', within_optional_scope=True),
             blocks.MarkLocation(spouse_location),
             blocks.Backtrack(child_location),
             blocks.EndOptional(),
-            blocks.Backtrack(base_location, True),
+            blocks.Backtrack(base_location, optional=True),
             blocks.MarkLocation(revisited_base_location),
-            blocks.Traverse('out', 'Animal_ParentOf', True),
+            blocks.Traverse('out', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(parent_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(parent_species_location),
             blocks.Backtrack(parent_location),
             blocks.EndOptional(),
-            blocks.Backtrack(revisited_base_location, True),
+            blocks.Backtrack(revisited_base_location, optional=True),
             blocks.MarkLocation(re_revisited_base_location),
             blocks.ConstructResult({
                 'spouse_and_self_name': expressions.TernaryConditional(
@@ -3242,7 +3242,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'animal_name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString
+                    base_location.navigate_to_field('name'), GraphQLString
                 ),
                 'parent_name': expressions.TernaryConditional(
                     expressions.ContextFieldExistence(parent_location),
@@ -3294,22 +3294,22 @@ class IrGenerationTests(unittest.TestCase):
                 expressions.Variable('$wanted', GraphQLString)
             )),
             blocks.MarkLocation(base_location),
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
             blocks.EndOptional(),
-            blocks.Backtrack(base_location, True),
+            blocks.Backtrack(base_location, optional=True),
             blocks.MarkLocation(revisited_base_location),
-            blocks.Traverse('out', 'Animal_ParentOf', True),
+            blocks.Traverse('out', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(parent_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(parent_species_location),
             blocks.Backtrack(parent_location),
             blocks.EndOptional(),
-            blocks.Backtrack(revisited_base_location, True),
+            blocks.Backtrack(revisited_base_location, optional=True),
             blocks.MarkLocation(re_revisited_base_location),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString
+                    base_location.navigate_to_field('name'), GraphQLString
                 ),
                 'parent_name': expressions.TernaryConditional(
                     expressions.ContextFieldExistence(parent_location),
@@ -3356,10 +3356,10 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_location),
             blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(parent_location),
-            blocks.Traverse('out', 'Entity_Related'),
+            blocks.Traverse('out', 'Entity_Related', within_optional_scope=True),
             blocks.CoerceType({'Animal'}),
             blocks.MarkLocation(entity_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(species_location),
             blocks.Backtrack(entity_location),
             blocks.Backtrack(parent_location),
@@ -3405,7 +3405,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(parent_location),
             blocks.Traverse('out', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(grandparent_location),
-            blocks.Traverse('out', 'Animal_FedAt'),
+            blocks.Traverse('out', 'Animal_FedAt', within_optional_scope=True),
             blocks.MarkLocation(fed_at_location),
             blocks.Backtrack(grandparent_location),
             blocks.EndOptional(),
@@ -3461,7 +3461,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_location),
             blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
-            blocks.Traverse('in', 'Animal_ParentOf'),
+            blocks.Traverse('in', 'Animal_ParentOf', within_optional_scope=True),
             blocks.MarkLocation(grandchild_location),
             blocks.Backtrack(child_location),
             blocks.EndOptional(),
@@ -3553,7 +3553,7 @@ class IrGenerationTests(unittest.TestCase):
 
             blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(other_child_location),
-            blocks.Traverse('out', 'Animal_FedAt'),
+            blocks.Traverse('out', 'Animal_FedAt', within_optional_scope=True),
             blocks.MarkLocation(other_child_fed_at_location),
             blocks.Backtrack(other_child_location),
             blocks.EndOptional(),
@@ -3658,7 +3658,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_location),
             blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
-            blocks.Recurse('out', 'Animal_ParentOf', 3),
+            blocks.Recurse('out', 'Animal_ParentOf', 3, within_optional_scope=True),
             blocks.MarkLocation(self_and_ancestor_location),
             blocks.Backtrack(child_location),
             blocks.EndOptional(),
@@ -3702,16 +3702,16 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
-            blocks.Traverse('in', 'Animal_ParentOf'),
+            blocks.Traverse('in', 'Animal_ParentOf', within_optional_scope=True),
             blocks.MarkLocation(grandchild_location),
             blocks.Backtrack(child_location),
-            blocks.Traverse('out', 'Animal_FedAt'),
+            blocks.Traverse('out', 'Animal_FedAt', within_optional_scope=True),
             blocks.MarkLocation(child_fed_at_location),
             blocks.Backtrack(child_location),
             blocks.EndOptional(),
-            blocks.Backtrack(base_location, True),
+            blocks.Backtrack(base_location, optional=True),
             blocks.MarkLocation(revisited_base_location),
             blocks.ConstructResult({
                 'grandchild_name': expressions.TernaryConditional(
@@ -3733,7 +3733,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString),
+                    base_location.navigate_to_field('name'), GraphQLString),
             }),
         ]
         expected_location_types = {
@@ -3843,7 +3843,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.MarkLocation(base_location),
             blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(parent_location),
-            blocks.Traverse('in', 'Animal_ParentOf'),
+            blocks.Traverse('in', 'Animal_ParentOf', within_optional_scope=True),
             blocks.MarkLocation(grandparent_location),
             blocks.Backtrack(parent_location),
             blocks.EndOptional(),
@@ -3900,7 +3900,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.Unfold(),
             blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(parent_location),
-            blocks.Traverse('in', 'Animal_ParentOf'),
+            blocks.Traverse('in', 'Animal_ParentOf', within_optional_scope=True),
             blocks.MarkLocation(grandparent_location),
             blocks.Backtrack(parent_location),
             blocks.EndOptional(),
@@ -4021,18 +4021,18 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
-            blocks.Traverse('out', 'Animal_ParentOf', True),
+            blocks.Traverse('out', 'Animal_ParentOf', optional=True, within_optional_scope=True),
             blocks.MarkLocation(spouse_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(spouse_species_location),
             blocks.Backtrack(spouse_location),
             blocks.EndOptional(),
-            blocks.Backtrack(child_location, True),
+            blocks.Backtrack(child_location, optional=True),
             blocks.MarkLocation(revisited_child_location),
             blocks.EndOptional(),
-            blocks.Backtrack(base_location, True),
+            blocks.Backtrack(base_location, optional=True),
             blocks.MarkLocation(revisited_base_location),
             blocks.ConstructResult({
                 'spouse_and_self_name': expressions.TernaryConditional(
@@ -4042,7 +4042,7 @@ class IrGenerationTests(unittest.TestCase):
                     expressions.NullLiteral
                 ),
                 'animal_name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString
+                    base_location.navigate_to_field('name'), GraphQLString
                 ),
                 'spouse_species': expressions.TernaryConditional(
                     expressions.ContextFieldExistence(spouse_species_location),
@@ -4093,47 +4093,47 @@ class IrGenerationTests(unittest.TestCase):
         expected_blocks = [
             blocks.QueryRoot({'Animal'}),
             blocks.MarkLocation(base_location),
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(child_location),
 
-            blocks.Traverse('in', 'Animal_ParentOf', True),
+            blocks.Traverse('in', 'Animal_ParentOf', optional=True, within_optional_scope=True),
             blocks.MarkLocation(grandchild_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(grandchild_species_location),
             blocks.Backtrack(grandchild_location),
             blocks.EndOptional(),
-            blocks.Backtrack(child_location, True),
+            blocks.Backtrack(child_location, optional=True),
             blocks.MarkLocation(revisited_child_location),
 
-            blocks.Traverse('in', 'Entity_Related', optional=True),
+            blocks.Traverse('in', 'Entity_Related', optional=True, within_optional_scope=True),
             blocks.CoerceType({'Animal'}),
             blocks.MarkLocation(child_related_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(child_related_species_location),
             blocks.Backtrack(child_related_location),
             blocks.EndOptional(),
-            blocks.Backtrack(revisited_child_location, True),
+            blocks.Backtrack(revisited_child_location, optional=True),
             blocks.MarkLocation(re_revisited_child_location),
 
             blocks.EndOptional(),
-            blocks.Backtrack(base_location, True),
+            blocks.Backtrack(base_location, optional=True),
             blocks.MarkLocation(revisited_base_location),
             blocks.Traverse('out', 'Animal_ParentOf', optional=True),
             blocks.MarkLocation(parent_location),
-            blocks.Traverse('out', 'Animal_ParentOf', optional=True),
+            blocks.Traverse('out', 'Animal_ParentOf', optional=True, within_optional_scope=True),
             blocks.MarkLocation(grandparent_location),
-            blocks.Traverse('out', 'Animal_OfSpecies'),
+            blocks.Traverse('out', 'Animal_OfSpecies', within_optional_scope=True),
             blocks.MarkLocation(grandparent_species_location),
             blocks.Backtrack(grandparent_location),
             blocks.EndOptional(),
-            blocks.Backtrack(parent_location, True),
+            blocks.Backtrack(parent_location, optional=True),
             blocks.MarkLocation(revisited_parent_location),
             blocks.EndOptional(),
             blocks.Backtrack(revisited_base_location, optional=True),
             blocks.MarkLocation(re_revisited_base_location),
             blocks.ConstructResult({
                 'animal_name': expressions.OutputContextField(
-                        base_location.navigate_to_field('name'), GraphQLString),
+                    base_location.navigate_to_field('name'), GraphQLString),
                 'child_name': expressions.TernaryConditional(
                     expressions.ContextFieldExistence(child_location),
                     expressions.OutputContextField(


### PR DESCRIPTION
`Traverse` and `Recurse` blocks weren't including all of their fields in equality checks, so some of the test data for IR generation was incomplete and implicitly wrong. I don't think generated queries were affected, since the compiler's behavior was correct.

I also removed a stale comment from before we supported nested `@optional` directives, and tweaked a piece of code that assumed that situation would never occur.