### PR TITLE
Amend metadata table for "explain" support.

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -87,7 +87,7 @@ from .helpers import (
     invert_dict, is_vertex_field_name, strip_non_null_from_type, validate_output_name,
     validate_safe_string
 )
-from .metadata import LocationInfo, QueryMetadataTable
+from .metadata import ExplainRecurseInfo, LocationInfo, QueryMetadataTable
 
 
 # LocationStackEntry contains the following:
@@ -487,6 +487,8 @@ def _compile_vertex_ast(schema, current_schema_type, ast,
                                                edge_name,
                                                recurse_depth,
                                                within_optional_scope=within_optional_scope))
+            query_metadata_table.record_explain_info(location,
+                                                     ExplainRecurseInfo(depth=recurse_depth))
         else:
             basic_blocks.append(blocks.Traverse(edge_direction, edge_name,
                                                 optional=edge_traversal_is_optional,
@@ -665,7 +667,7 @@ def _compile_ast_node_to_ir(schema, current_schema_type, ast, location, context)
     # step 1: apply local filter, if any
     for filter_operation_info in filter_operations:
         basic_blocks.append(
-            process_filter_directive(filter_operation_info, context))
+            process_filter_directive(filter_operation_info, location, context))
 
     if location.field is not None:
         # The location is at a property, compile the property data following P-steps.

--- a/graphql_compiler/tests/test_explain_info.py
+++ b/graphql_compiler/tests/test_explain_info.py
@@ -1,0 +1,57 @@
+# Copyright 2018-present Kensho Technologies, LLC.
+
+from . import test_input_data
+from ..compiler.compiler_frontend import OutputMetadata, graphql_to_ir
+from ..compiler.helpers import Location
+from ..compiler.metadata import ExplainFilterInfo, ExplainRecurseInfo
+from .test_helpers import get_schema
+
+
+def check_explain_info(graphql_test, expected):
+    """Verify query produces expected explain infos."""
+    schema = get_schema()
+    ir_and_metadata = graphql_to_ir(schema, graphql_test().graphql_input)
+    meta = ir_and_metadata.query_metadata_table
+    for loc, eis in expected:
+        assert meta.get_explain_infos(loc) == eis
+    assert len(expected) == len(meta._explain_infos)
+
+
+def test_filter():
+    check_explain_info(test_input_data.traverse_filter_and_output,
+                       [
+                           (Location(('Animal', 'out_Animal_ParentOf'), None, 1),
+                            [ExplainFilterInfo(field_name='out_Animal_ParentOf',
+                                               op_name='name_or_alias',
+                                               args=['$wanted'])]),
+                       ])
+
+
+def test_filters():
+    check_explain_info(test_input_data.complex_optional_traversal_variables,
+                       [
+                           (Location(('Animal',), None, 1),
+                            [ExplainFilterInfo(field_name='name',
+                                               op_name='=',
+                                               args=['$animal_name'])]),
+                           (Location(('Animal', 'in_Animal_ParentOf', 'out_Animal_FedAt'), None, 1),
+                            [ExplainFilterInfo(field_name='name',
+                                               op_name='=',
+                                               args=['%parent_fed_at_event']),
+                             ExplainFilterInfo(field_name='event_date',
+                                               op_name='between',
+                                               args=['%other_child_fed_at', '%parent_fed_at'])]),
+                       ])
+
+
+def test_fold():
+    check_explain_info(test_input_data.coercion_filters_and_multiple_outputs_within_fold_scope,
+                       [])
+
+
+def test_recurse():
+    check_explain_info(test_input_data.simple_recurse,
+                       [
+                           (Location(('Animal',), None, 1),
+                            [ExplainRecurseInfo(depth=1)]),
+                       ])


### PR DESCRIPTION
* QueryMetadataTable.get_explain_infos() returns information required for explain analysis.
It is in the form of a list of ExplainInfo objects.

* ExplainFilterInfo provides:
  - op_name: Operation is useful to estimate complexity, i.e. == is faster than between.
  - field_name: For checking if the field has index or not.
  - args: If there are $args, we can check the size of user provided input.

* ExplainRecurseInfo provides the recursion depth for now.