### PR TITLE
Fix TypeError due to None sub-expression in BinaryComposition

### DIFF
--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -664,8 +664,8 @@ class BinaryComposition(Expression):
         _validate_operator_name(self.operator, BinaryComposition.SUPPORTED_OPERATORS)
 
         if not isinstance(self.left, Expression):
-            raise TypeError(u'Expected Expression left, got: {} {}'.format(
-                type(self.left).__name__, self.left))
+            raise TypeError(u'Expected Expression left, got: {} {} {}'.format(
+                type(self.left).__name__, self.left, self))
 
         if not isinstance(self.right, Expression):
             raise TypeError(u'Expected Expression right, got: {} {}'.format(

--- a/graphql_compiler/compiler/ir_lowering_match/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_match/__init__.py
@@ -117,8 +117,7 @@ def lower_ir(ir_blocks, query_metadata_table, type_equivalence_hints=None):
         match_query, complex_optional_roots, location_to_optional_roots)
     compound_match_query = prune_non_existent_outputs(compound_match_query)
     compound_match_query = collect_filters_to_first_location_occurrence(compound_match_query)
-    compound_match_query = lower_context_field_expressions(
-        compound_match_query)
+    compound_match_query = lower_context_field_expressions(compound_match_query)
 
     compound_match_query = truncate_repeated_single_step_traversals_in_sub_queries(
         compound_match_query)

--- a/graphql_compiler/compiler/ir_lowering_match/optional_traversal.py
+++ b/graphql_compiler/compiler/ir_lowering_match/optional_traversal.py
@@ -497,14 +497,15 @@ def _update_context_field_expression(present_locations, expression):
         if isinstance(lower_bound, ContextField) or isinstance(upper_bound, ContextField):
             raise AssertionError(u'Found BetweenClause with ContextFields as lower/upper bounds. '
                                  u'This should never happen: {}'.format(expression))
+        return expression
     elif isinstance(expression, (OutputContextField, FoldedOutputContextField)):
         raise AssertionError(u'Found unexpected expression of type {}. This should never happen: '
                              u'{}'.format(type(expression).__name__, expression))
     elif isinstance(expression, no_op_blocks):
         return expression
-    else:
-        raise AssertionError(u'Found unexpected expression of type {}. This should never happen: '
-                             u'{}'.format(type(expression).__name__, expression))
+
+    raise AssertionError(u'Found unhandled expression of type {}. This should never happen: '
+                         u'{}'.format(type(expression).__name__, expression))
 
 
 def _lower_non_existent_context_field_filters(match_traversals, visitor_fn):

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2203,6 +2203,18 @@ class CompilerTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_match, expected_gremlin)
 
+    def test_has_edge_degree_op_filter_with_optional_and_other_filter(self):
+        test_data = test_input_data.has_edge_degree_op_filter_with_optional_and_other_filter()
+
+        expected_match = '''
+
+        '''
+        expected_gremlin = '''
+
+        '''
+
+        check_test_data(self, test_data, expected_match, expected_gremlin)
+
     def test_has_edge_degree_op_filter_with_fold(self):
         test_data = test_input_data.has_edge_degree_op_filter_with_fold()
 

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -1275,6 +1275,8 @@ def has_edge_degree_op_filter_with_optional_and_other_filter():
         'related_event': OutputMetadata(type=GraphQLString, optional=True),
     }
     expected_input_metadata = {
+        'uuid_lower_bound': GraphQLID,
+        'uuid_upper_bound': GraphQLID,
         'number_of_edges': GraphQLInt,
     }
 

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -1253,7 +1253,7 @@ def has_edge_degree_op_filter_with_optional():
         type_equivalence_hints=None)
 
 
-def has_edge_degree_op_filter_with_optional_and_other_filter():
+def has_edge_degree_op_filter_with_optional_and_between():
     graphql_input = '''{
         Animal {
             name @output(out_name: "animal_name")

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -1253,6 +1253,38 @@ def has_edge_degree_op_filter_with_optional():
         type_equivalence_hints=None)
 
 
+def has_edge_degree_op_filter_with_optional_and_other_filter():
+    graphql_input = '''{
+        Animal {
+            name @output(out_name: "animal_name")
+            uuid @filter(op_name: "between", value: ["$uuid_lower_bound","$uuid_upper_bound"])
+
+            in_Animal_ParentOf @optional
+                               @filter(op_name: "has_edge_degree", value: ["$number_of_edges"]) {
+                out_Entity_Related {
+                    ... on Event {
+                        name @output(out_name: "related_event")
+                    }
+                }
+            }
+        }
+    }
+    '''
+    expected_output_metadata = {
+        'animal_name': OutputMetadata(type=GraphQLString, optional=False),
+        'related_event': OutputMetadata(type=GraphQLString, optional=True),
+    }
+    expected_input_metadata = {
+        'number_of_edges': GraphQLInt,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
 def has_edge_degree_op_filter_with_fold():
     graphql_input = '''{
         Species {

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -2238,8 +2238,8 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
-    def test_has_edge_degree_op_filter_with_optional_and_other_filter(self):
-        test_data = test_input_data.has_edge_degree_op_filter_with_optional_and_other_filter()
+    def test_has_edge_degree_op_filter_with_optional_and_between(self):
+        test_data = test_input_data.has_edge_degree_op_filter_with_optional_and_between()
 
         base_location = helpers.Location(('Animal',))
         parent_location = base_location.navigate_to_subpath('in_Animal_ParentOf')

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -2326,7 +2326,6 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
-
     def test_has_edge_degree_op_filter_with_fold(self):
         test_data = test_input_data.has_edge_degree_op_filter_with_fold()
 


### PR DESCRIPTION
Fixes #145.

The issue was a missing `return` statement in the IR lowering code, on a branch that specifically handles lowering of `BetweenClause` expressions. This was not previously caught by unit tests since we didn't have a test that specifically tests combining `between` and `has_edge_degree` filters in the same scope.