### PR TITLE
Release v1.8.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Current development version
 
+## v1.8.3
+
+- Explicit support for Python 3.7. Earlier compiler versions also worked on 3.7, but now we also run tests in 3.7 to confirm. [#148](https://github.com/kensho-technologies/graphql-compiler/pull/148)
+- Bug fix for compilation error when using `has_edge_degree` and `between` filtering in the same scope. [#146](https://github.com/kensho-technologies/graphql-compiler/pull/146)
+- Exposed additional query metadata that describes `@recurse` and `@filter` directives encountered in the query. [#141](https://github.com/kensho-technologies/graphql-compiler/pull/141/files)
+
+Thanks to `gurer-kensho` for the contribution.
+
 ## v1.8.2
 
 - Fix overly strict type check on `@recurse` directives involving a union type. [#131](https://github.com/kensho-technologies/graphql-compiler/pull/131)

--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -19,7 +19,7 @@ from .schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal  # noqa
 
 
 __package_name__ = 'graphql-compiler'
-__version__ = '1.8.2'
+__version__ = '1.8.3'
 
 
 def graphql_to_match(schema, graphql_query, parameters, type_equivalence_hints=None):

--- a/scripts/make_new_release.sh
+++ b/scripts/make_new_release.sh
@@ -14,8 +14,8 @@ if [ ! -f "./requirements.txt" ] || [ ! -f "./CHANGELOG.md" ]; then
     exit 1
 fi
 
-# Clean up old release artifacts.
-rm -r build/ dist/
+# Clean up old release artifacts. Ignore errors since these directories might not exist.
+rm -r build/ dist/ || true
 
 # Build the source distribution.
 python setup.py sdist


### PR DESCRIPTION
TL;DR of changes:
- Explicit support for Python 3.7. Earlier compiler versions also worked on 3.7, but now we also run tests in 3.7 to confirm. [#148](https://github.com/kensho-technologies/graphql-compiler/pull/148)
- Bug fix for compilation error when using `has_edge_degree` and `between` filtering in the same scope. [#146](https://github.com/kensho-technologies/graphql-compiler/pull/146)
- Exposed additional query metadata that describes `@recurse` and `@filter` directives encountered in the query. [#141](https://github.com/kensho-technologies/graphql-compiler/pull/141/files)

Full shortlog:
```
$ git shortlog v1.8.2..HEAD
Gurer Ozen (1):
      Amend metadata table for "explain" support. (#141)

Jeremy Meulemans (2):
      Add scaffolding for SQL backend without implementation. (#143)
      Bumping pytest version to fix unresolvable pluggy dependency (#151)

Predrag Gruevski (13):
      Separate out the lint/static analysis run from unit tests in Travis. (#134)
      Make the README file appear on the PyPI project page. (#133)
      Change import style to isort multiline output mode 5. (#135)
      Expose location parent-child and location revisit relationships in metadata. (#136)
      Explicitly enable flake8 errors that are disabled by default. (#140)
      Fix bad equality checking in Traverse and Recurse blocks, fix tests. (#139)
      Add __slots__ class property to all compiler IR entities. (#138)
      Use metadata to decide when to mark locations prior to optional traversals (#137)
      Specify long description content type, to make PyPI show the description. (#149)
      Add python 3.7 to the Travis testing matrix (#148)
      Use pipenv for local development, instead of requirements files. (#147)
      Fix TypeError due to None sub-expression in BinaryComposition (#146)
      Release v1.8.3.
```