### PR TITLE
Add a few core macro edge validation steps.

### DIFF
--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -6,8 +6,8 @@ from .macro_edge import make_macro_edge_definition
 
 MacroRegistry = namedtuple(
     'MacroRegistry', (
-        'macro_edges',  # Dict[str, Dict[str, MacroEdgeDefinition]] mapping:
-                        # class name -> (macro edge name -> MacroEdgeDefinition)
+        'macro_edges',  # Dict[str, Dict[str, MacroEdgeDescriptor]] mapping:
+                        # class name -> (macro edge name -> MacroEdgeDescriptor)
         # Any other macro types we may add in the future go here.
     )
 )

--- a/graphql_compiler/macros/macro_edge/__init__.py
+++ b/graphql_compiler/macros/macro_edge/__init__.py
@@ -3,7 +3,7 @@ from graphql.language.parser import parse
 
 from ...exceptions import GraphQLInvalidMacroError
 from .helpers import get_directives_for_ast
-from .validation import get_and_validate_macro_edge_components
+from .validation import get_and_validate_macro_edge_info
 
 
 def make_macro_edge_definition(schema, macro_edge_graphql, macro_edge_args,
@@ -46,7 +46,7 @@ def make_macro_edge_definition(schema, macro_edge_graphql, macro_edge_args,
 
     macro_directives = get_directives_for_ast(definition_ast)
 
-    class_name, macro_edge_name, macro_edge_descriptor = get_and_validate_macro_edge_components(
+    class_name, macro_edge_name, macro_edge_descriptor = get_and_validate_macro_edge_info(
         schema, definition_ast, macro_directives, macro_edge_args,
         type_equivalence_hints=type_equivalence_hints)
 

--- a/graphql_compiler/macros/macro_edge/__init__.py
+++ b/graphql_compiler/macros/macro_edge/__init__.py
@@ -6,7 +6,7 @@ from .helpers import get_directives_for_ast
 from .validation import get_and_validate_macro_edge_info
 
 
-def make_macro_edge_definition(schema, macro_edge_graphql, macro_edge_args,
+def make_macro_edge_descriptor(schema, macro_edge_graphql, macro_edge_args,
                                type_equivalence_hints=None):
     """Validate the GraphQL macro edge definition, and return it in a form suitable for storage.
 

--- a/graphql_compiler/macros/macro_edge/directives.py
+++ b/graphql_compiler/macros/macro_edge/directives.py
@@ -1,0 +1,33 @@
+from graphql import DirectiveLocation, GraphQLDirective
+
+
+MacroEdgeDirective = GraphQLDirective(
+    name='macro_edge',
+    locations=[
+        DirectiveLocation.FIELD,
+    ]
+)
+
+
+MacroEdgeDefinitionDirective = GraphQLDirective(
+    name='macro_edge_definition',
+    locations=[
+        DirectiveLocation.FIELD,
+    ]
+)
+
+
+MacroEdgeTargetDirective = GraphQLDirective(
+    name='macro_edge_target',
+    locations=[
+        DirectiveLocation.FIELD,
+        DirectiveLocation.INLINE_FRAGMENT,
+    ]
+)
+
+
+MACRO_EDGE_DIRECTIVES = (
+    MacroEdgeDirective,
+    MacroEdgeDefinitionDirective,
+    MacroEdgeTargetDirective,
+)

--- a/graphql_compiler/macros/macro_edge/directives.py
+++ b/graphql_compiler/macros/macro_edge/directives.py
@@ -1,3 +1,4 @@
+# Copyright 2019-present Kensho Technologies, LLC.
 from graphql import DirectiveLocation, GraphQLDirective
 
 

--- a/graphql_compiler/macros/macro_edge/helpers.py
+++ b/graphql_compiler/macros/macro_edge/helpers.py
@@ -133,7 +133,7 @@ def omit_ast_from_ast_selections(ast, ast_to_omit):
 
     Returns:
         GraphQL library AST object, equivalent to the input one, with all instances of
-        the named directives omitted. If the specified AST does not appear in the input AST,
+        the specified AST omitted. If the specified AST does not appear in the input AST,
         the returned object is the exact same object as the input.
     """
     if not isinstance(ast, (Field, InlineFragment, OperationDefinition)):

--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -1,7 +1,8 @@
+# Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
 from ...exceptions import GraphQLInvalidMacroError
-from .directives import MacroEdgeDirective, MacroEdgeDefinitionDirective, MacroEdgeTargetDirective
+from .directives import MacroEdgeDefinitionDirective, MacroEdgeDirective, MacroEdgeTargetDirective
 from .helpers import get_only_selection_from_ast
 
 
@@ -82,7 +83,7 @@ def get_and_validate_macro_edge_info(schema, ast, macro_directives, macro_edge_a
         if macro_directive.arguments is not None:
             raise GraphQLInvalidMacroError(
                 u'Required macro edge directive "@{}" unexpectedly contained arguments even though '
-                u'it is not supposed to contain any. Unexpected arguments:'
+                u'it is not supposed to contain any. Unexpected arguments: {}'
                 .format(directive_definition.name, macro_directive.arguments))
 
         macro_edge_sub_asts[directive_definition.name] = macro_ast

--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -89,7 +89,7 @@ def get_and_validate_macro_edge_info(schema, ast, macro_directives, macro_edge_a
         macro_edge_sub_asts[directive_definition.name] = macro_ast
 
     # TODO(predrag): Required further validation:
-    # - the target directive AST is within the definition directive AST;
+    # - the target directive AST is either the same as, or within the definition directive AST;
     # - the macro edge directive AST is not within the definition directive AST;
     # - the macro edge directive and the definition directive ASTs are directly within the
     #   top-level selection, and that selection contains no ASTs other than these two;

--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -1,0 +1,113 @@
+from collections import namedtuple
+
+from ...exceptions import GraphQLInvalidMacroError
+from .directives import MacroEdgeDirective, MacroEdgeDefinitionDirective, MacroEdgeTargetDirective
+from .helpers import get_only_selection_from_ast
+
+
+MacroEdgeDescriptor = namedtuple(
+    'MacroEdgeDescriptor', (
+        'expansion_ast',  # GraphQL AST object defining how the macro edge should be expanded
+        'macro_args',     # Dict[str, Any] containing any arguments that the macro requires
+    )
+)
+
+
+def get_and_validate_macro_edge_info(schema, ast, macro_directives, macro_edge_args,
+                                     type_equivalence_hints=None):
+    """Return a tuple of ASTs with the three parts of a macro edge given the directive mapping.
+
+    Args:
+        schema: GraphQL schema object, created using the GraphQL library
+        ast: GraphQL library AST OperationDefinition object, describing the GraphQL that is defining
+             the macro edge.
+        macro_directives: Dict[str, List[Tuple[AST object, Directive]]], mapping the name of an
+                          encountered directive to a list of its appearances, each described by
+                          a tuple containing the AST with that directive and the directive object
+                          itself.
+        macro_edge_args: dict mapping strings to any type, containing any arguments the macro edge
+                         requires in order to function.
+        type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
+                                *****
+                                Be very careful with this option, as bad input here will
+                                lead to incorrect output queries being generated.
+                                *****
+
+    Returns:
+        tuple (class name for macro, name of macro edge, MacroEdgeDescriptor),
+        where the first two values are strings and the last one is a MacroEdgeDescriptor object
+    """
+    if ast.directives is not None:
+        directive_names = [directive.name.value for directive in ast.directives]
+        raise GraphQLInvalidMacroError(
+            u'Unexpectedly found directives at the top level of the GraphQL input. '
+            u'This is not supported. Directives: {}'.format(directive_names))
+
+    if ast.variable_definitions is not None:
+        raise GraphQLInvalidMacroError(
+            u'Unexpectedly found variable definitions at the top level of the GraphQL input. '
+            u'This is not supported. Variable definitions: {}'.format(ast.variable_definitions))
+
+    unique_and_parameterless_directives_to_check = (
+        MacroEdgeDirective,
+        MacroEdgeDefinitionDirective,
+        MacroEdgeTargetDirective,
+    )
+    macro_edge_sub_asts = {}
+
+    for directive_definition in unique_and_parameterless_directives_to_check:
+        macro_data = macro_directives.get(directive_definition.name, None)
+        if not macro_data:
+            raise GraphQLInvalidMacroError(
+                u'Required macro edge directive "@{}" was not found anywhere within the supplied '
+                u'macro edge definition GraphQL.'.format(directive_definition.name))
+
+        if len(macro_data) > 1:
+            raise GraphQLInvalidMacroError(
+                u'Required macro edge directive "@{}" was unexpectedly present more than once in '
+                u'the supplied macro edge definition GraphQL. It was found {} times.'
+                .format(directive_definition.name, len(macro_data)))
+
+        macro_ast, macro_directive = macro_data[0]
+        if macro_directive.arguments is not None:
+            raise GraphQLInvalidMacroError(
+                u'Required macro edge directive "@{}" unexpectedly contained arguments even though '
+                u'it is not supposed to contain any. Unexpected arguments:'
+                .format(directive_definition.name, macro_directive.arguments))
+
+        macro_edge_sub_asts[directive_definition.name] = macro_ast
+
+    # TODO(predrag): Required further validation:
+    # - the target directive AST is within the definition directive AST;
+    # - the macro edge directive AST is not within the definition directive AST;
+    # - the macro edge directive and the definition directive ASTs are directly within the
+    #   top-level selection, and that selection contains no ASTs other than these two;
+    # - the macro edge directive AST contains no other directives;
+    # - the macro definition directive AST contains only @filter/@fold directives together with
+    #   the target directive;
+    # - the macro edge does not shadow an existing edge;
+    # - after adding an output, the macro compiles successfully, the macro args and necessary and
+    #   sufficient for the macro, and the macro args' types match the inferred types of the
+    #   runtime parameters in the macro.
+
+    class_name = get_only_selection_from_ast(ast).name.value
+    macro_edge_name = macro_edge_sub_asts[MacroEdgeDirective.name].name.value
+
+    _make_macro_edge_descriptor()
+
+    return class_name, macro_edge_name
+
+
+def _make_macro_edge_descriptor():
+    """Not implemented yet."""
+    raise NotImplementedError()


### PR DESCRIPTION
More validation + tests to come in upcoming PRs.

I also renamed `MacroEdgeDefinition` to `MacroEdgeDescriptor`, to avoid confusion with the `@macro_edge_definition` directive.