### PR TITLE
Move test_macro_expansion_errors to test_macro_validation

### DIFF
--- a/graphql_compiler/tests/test_macro_validation.py
+++ b/graphql_compiler/tests/test_macro_validation.py
@@ -6,7 +6,7 @@ from ..macros import create_macro_registry, register_macro_edge
 from .test_helpers import get_schema
 
 
-class MacroExpansionErrorsTests(unittest.TestCase):
+class MacroValidationTests(unittest.TestCase):
     def setUp(self):
         """Disable max diff limits for all tests."""
         self.maxDiff = None


### PR DESCRIPTION
Moving because the file `test_macro_expansion_errors.py` should check for invalid usage of macros, not invalid definitions