### PR TITLE
Deduplicate parsing and validation code, fix a schema/type checking bug.

### DIFF
--- a/graphql_compiler/ast_manipulation.py
+++ b/graphql_compiler/ast_manipulation.py
@@ -1,7 +1,10 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from graphql.language.ast import InlineFragment
+from graphql.error import GraphQLSyntaxError
+from graphql.language.ast import Document, InlineFragment
+from graphql.language.parser import parse
 
 from .schema import TYPENAME_META_FIELD_NAME
+from .exceptions import GraphQLCompilationError, GraphQLParsingError, GraphQLValidationError
 
 
 def get_ast_field_name(ast):
@@ -27,3 +30,42 @@ def get_human_friendly_ast_field_name(ast):
     if isinstance(ast, InlineFragment):
         return 'type coercion to {}'.format(ast.type_condition)
     return get_ast_field_name(ast)
+
+
+def _preprocess_graphql_string(graphql_string):
+    """Apply any necessary preprocessing to the input GraphQL string, returning the new version."""
+    # HACK(predrag): Workaround for graphql-core issue, to avoid needless errors:
+    #                https://github.com/graphql-python/graphql-core/issues/98
+    return graphql_string + '\n'
+
+
+def safe_parse_graphql(graphql_string):
+    """Return an AST representation of the given GraphQL input, avoiding known land mines."""
+    graphql_string = _preprocess_graphql_string(graphql_string)
+    try:
+        ast = parse(graphql_string)
+    except GraphQLSyntaxError as e:
+        raise GraphQLParsingError(e)
+
+    return ast
+
+
+def get_only_query_definition(document_ast, desired_error_type):
+    """Assert that the Document AST contains only a single definition for a query, and return it."""
+    if not isinstance(document_ast, Document) or not document_ast.definitions:
+        raise AssertionError(u'Received an unexpected value for "document_ast": {}'
+                             .format(document_ast))
+
+    if len(document_ast.definitions) != 1:
+        raise desired_error_type(
+            u'Encountered multiple definitions within GraphQL input. This is not supported.'
+            u'{}'.format(document_ast.definitions))
+
+    definition_ast = document_ast.definitions[0]
+    if definition_ast.operation != 'query':
+        raise desired_error_type(
+            u'Expected a GraphQL document with a single query definition, but instead found a '
+            u'but instead found a "{}" operation. This is not supported.'
+            .format(definition_ast.operation))
+
+    return definition_ast

--- a/graphql_compiler/ast_manipulation.py
+++ b/graphql_compiler/ast_manipulation.py
@@ -3,8 +3,8 @@ from graphql.error import GraphQLSyntaxError
 from graphql.language.ast import Document, InlineFragment
 from graphql.language.parser import parse
 
+from .exceptions import GraphQLParsingError
 from .schema import TYPENAME_META_FIELD_NAME
-from .exceptions import GraphQLCompilationError, GraphQLParsingError, GraphQLValidationError
 
 
 def get_ast_field_name(ast):

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -62,15 +62,13 @@ from collections import namedtuple
 from graphql import (
     GraphQLInt, GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLUnionType
 )
-from graphql.error import GraphQLSyntaxError
 from graphql.language.ast import Field, InlineFragment
-from graphql.language.parser import parse
 from graphql.validation import validate
 import six
 
 from . import blocks, expressions
-from ..ast_manipulation import get_ast_field_name
-from ..exceptions import GraphQLCompilationError, GraphQLParsingError, GraphQLValidationError
+from ..ast_manipulation import get_ast_field_name, get_only_query_definition, safe_parse_graphql
+from ..exceptions import GraphQLCompilationError, GraphQLValidationError
 from ..schema import COUNT_META_FIELD_NAME, DIRECTIVES, is_vertex_field_name
 from .context_helpers import (
     get_context_fold_info, get_optional_scope_or_none, has_encountered_output_source,
@@ -890,13 +888,6 @@ def _compile_output_step(outputs):
     return blocks.ConstructResult(output_fields)
 
 
-def _preprocess_graphql_string(graphql_string):
-    """Apply any necessary preprocessing to the input GraphQL string, returning the new version."""
-    # HACK(predrag): Workaround for graphql-core issue, to avoid needless errors:
-    #                https://github.com/graphql-python/graphql-core/issues/98
-    return graphql_string + '\n'
-
-
 def _validate_schema_and_ast(schema, ast):
     """Validate the supplied graphql schema and ast.
 
@@ -1018,20 +1009,13 @@ def graphql_to_ir(schema, graphql_string, type_equivalence_hints=None):
 
     In the case of implementation bugs, could also raise ValueError, TypeError, or AssertionError.
     """
-    graphql_string = _preprocess_graphql_string(graphql_string)
-    try:
-        ast = parse(graphql_string)
-    except GraphQLSyntaxError as e:
-        raise GraphQLParsingError(e)
+    ast = safe_parse_graphql(graphql_string)
 
     validation_errors = _validate_schema_and_ast(schema, ast)
 
     if validation_errors:
         raise GraphQLValidationError(u'String does not validate: {}'.format(validation_errors))
 
-    if len(ast.definitions) != 1:
-        raise AssertionError(u'Unsupported graphql string with multiple definitions, should have '
-                             u'been caught in validation: \n{}\n{}'.format(graphql_string, ast))
-    base_ast = ast.definitions[0]
+    base_ast = get_only_query_definition(ast, GraphQLValidationError)
 
     return _compile_root_ast_to_ir(schema, base_ast, type_equivalence_hints=type_equivalence_hints)

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -1,7 +1,8 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
-from ..ast_manipulation import safe_parse_graphql
+from ..ast_manipulation import get_only_query_definition, safe_parse_graphql
+from ..exceptions import GraphQLInvalidMacroError
 from .macro_edge import make_macro_edge_descriptor
 
 
@@ -85,6 +86,6 @@ def perform_macro_expansion(schema, macro_registry, graphql_with_macro, graphql_
     """
     query_ast = safe_parse_graphql(graphql_with_macro)
 
-    definition_ast = get_only_query_definition(root_ast, GraphQLInvalidMacroError)
+    definition_ast = get_only_query_definition(query_ast, GraphQLInvalidMacroError)
 
-    raise NotImplementedError()
+    raise NotImplementedError(definition_ast)

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
+from ..ast_manipulation import safe_parse_graphql
 from .macro_edge import make_macro_edge_descriptor
 
 
@@ -82,4 +83,8 @@ def perform_macro_expansion(schema, macro_registry, graphql_with_macro, graphql_
         its new args, after macro expansion. If the input GraphQL query contained no macros,
         the returned values are guaranteed to be identical to the input query and args.
     """
+    query_ast = safe_parse_graphql(graphql_with_macro)
+
+    definition_ast = get_only_query_definition(root_ast, GraphQLInvalidMacroError)
+
     raise NotImplementedError()

--- a/graphql_compiler/macros/macro_edge/__init__.py
+++ b/graphql_compiler/macros/macro_edge/__init__.py
@@ -1,8 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from graphql.language.parser import parse
-
+from ...ast_manipulation import get_only_query_definition, safe_parse_graphql
 from ...exceptions import GraphQLInvalidMacroError
-from .helpers import get_directives_for_ast
 from .validation import get_and_validate_macro_edge_info
 
 
@@ -35,19 +33,12 @@ def make_macro_edge_descriptor(schema, macro_edge_graphql, macro_edge_args,
         tuple (class name, macro edge name, MacroEdgeDescriptor) suitable for inclusion into the
         GraphQL macro registry
     """
-    root_ast = parse(macro_edge_graphql)
+    root_ast = safe_parse_graphql(macro_edge_graphql)
 
-    if len(root_ast.definitions) != 1:
-        raise GraphQLInvalidMacroError(
-            u'Encountered multiple definitions within GraphQL edge macro. This is not supported.'
-            u'{}'.format(root_ast.definitions))
-
-    definition_ast = root_ast.definitions[0]
-
-    macro_directives = get_directives_for_ast(definition_ast)
+    definition_ast = get_only_query_definition(root_ast, GraphQLInvalidMacroError)
 
     class_name, macro_edge_name, macro_edge_descriptor = get_and_validate_macro_edge_info(
-        schema, definition_ast, macro_directives, macro_edge_args,
+        schema, definition_ast, macro_edge_args,
         type_equivalence_hints=type_equivalence_hints)
 
     return class_name, macro_edge_name, macro_edge_descriptor

--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -148,7 +148,7 @@ def get_and_validate_macro_edge_info(schema, ast, macro_edge_args,
     _validate_macro_ast_with_macro_directives(schema, ast, macro_directives)
 
     macro_defn_ast, macro_defn_directive = macro_directives[MacroEdgeDefinitionDirective.name][0]
-    macro_target_ast, _ = macro_directives[MacroEdgeTargetDirective.name][0]
+    # macro_target_ast, _ = macro_directives[MacroEdgeTargetDirective.name][0]
 
     # TODO(predrag): Required further validation:
     # - the macro definition directive AST contains only @filter/@fold directives together with

--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -3,27 +3,19 @@ from collections import namedtuple
 from copy import copy
 from itertools import chain
 
-from graphql.language.ast import OperationDefinition
 from graphql.validation import validate
 
 from ...ast_manipulation import get_ast_field_name, get_human_friendly_ast_field_name
 from ...exceptions import GraphQLInvalidMacroError
 from ...schema import VERTEX_FIELD_PREFIXES, is_vertex_field_name
-from .directives import MacroEdgeDefinitionDirective, MacroEdgeTargetDirective
-from .helpers import get_only_selection_from_ast
+from .directives import (
+    MACRO_EDGE_DIRECTIVES, MacroEdgeDefinitionDirective, MacroEdgeTargetDirective
+)
+from .helpers import get_directives_for_ast, get_only_selection_from_ast, remove_directives_from_ast
 
 
 def _validate_macro_ast_with_macro_directives(schema, ast, macro_directives):
     """Raise errors if the macro uses the macro directives incorrectly or is otherwise invalid."""
-    if not isinstance(ast, OperationDefinition):
-        raise AssertionError(u'Unexpectedly got an AST that was not an OperationDefinition: {}'
-                             .format(ast))
-
-    if ast.operation != 'query':
-        raise GraphQLInvalidMacroError(
-            u'Unexpectedly got an AST operation that was not parsed as a "query", '
-            u'but instead was a "{}": {}'.format(ast.operation, ast))
-
     if ast.directives:
         directive_names = [directive.name.value for directive in ast.directives]
         raise GraphQLInvalidMacroError(
@@ -43,7 +35,7 @@ def _validate_macro_ast_with_macro_directives(schema, ast, macro_directives):
         schema_with_macro_directives._directives, required_macro_directives))
     # pylint: enable=protected-access
 
-    validation_errors = validate(schema, ast)
+    validation_errors = validate(schema_with_macro_directives, ast)
     if validation_errors:
         raise GraphQLInvalidMacroError(
             u'Macro edge failed validation: {}'.format(validation_errors))
@@ -112,13 +104,16 @@ def _validate_macro_edge_name_for_class_name(schema, class_name, macro_edge_name
 
 MacroEdgeDescriptor = namedtuple(
     'MacroEdgeDescriptor', (
-        'expansion_ast',  # GraphQL AST object defining how the macro edge should be expanded
-        'macro_args',     # Dict[str, Any] containing any arguments that the macro requires
+        'expansion_selection_set',  # GraphQL SelectionSet object defining how the macro edge
+                                    # should be expanded starting from its base type. These
+                                    # selections must be merged (on both endpoints of the
+                                    # macro edge) with the user-supplied GraphQL input.
+        'macro_args',               # Dict[str, Any] containing any arguments required by the macro
     )
 )
 
 
-def get_and_validate_macro_edge_info(schema, ast, macro_directives, macro_edge_args,
+def get_and_validate_macro_edge_info(schema, ast, macro_edge_args,
                                      type_equivalence_hints=None):
     """Return a tuple with the three parts of information that uniquely describe a macro edge.
 
@@ -126,10 +121,6 @@ def get_and_validate_macro_edge_info(schema, ast, macro_directives, macro_edge_a
         schema: GraphQL schema object, created using the GraphQL library
         ast: GraphQL library AST OperationDefinition object, describing the GraphQL that is defining
              the macro edge.
-        macro_directives: Dict[str, List[Tuple[AST object, Directive]]], mapping the name of an
-                          encountered directive to a list of its appearances, each described by
-                          a tuple containing the AST with that directive and the directive object
-                          itself.
         macro_edge_args: dict mapping strings to any type, containing any arguments the macro edge
                          requires in order to function.
         type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
@@ -152,32 +143,38 @@ def get_and_validate_macro_edge_info(schema, ast, macro_directives, macro_edge_a
         tuple (class name for macro, name of macro edge, MacroEdgeDescriptor),
         where the first two values are strings and the last one is a MacroEdgeDescriptor object
     """
+    macro_directives = get_directives_for_ast(ast)
+
     _validate_macro_ast_with_macro_directives(schema, ast, macro_directives)
 
     macro_defn_ast, macro_defn_directive = macro_directives[MacroEdgeDefinitionDirective.name][0]
-    # macro_target_ast, _ = macro_directives[MacroEdgeTargetDirective.name][0]
+    macro_target_ast, _ = macro_directives[MacroEdgeTargetDirective.name][0]
 
     # TODO(predrag): Required further validation:
     # - the macro definition directive AST contains only @filter/@fold directives together with
     #   the target directive;
+    # - the macro target is not within a @fold;
     # - after adding an output, the macro compiles successfully, the macro args and necessary and
     #   sufficient for the macro, and the macro args' types match the inferred types of the
     #   runtime parameters in the macro.
 
-    class_ast = get_only_selection_from_ast(ast)
-    class_name = get_ast_field_name(class_ast)
-
-    _validate_class_selection_ast(class_ast, macro_defn_ast)
-
+    _validate_class_selection_ast(get_only_selection_from_ast(ast), macro_defn_ast)
+    class_name = get_ast_field_name(macro_defn_ast)
     macro_edge_name = macro_defn_directive.arguments['name'].value
 
     _validate_macro_edge_name_for_class_name(schema, class_name, macro_edge_name)
 
-    _make_macro_edge_descriptor()
+    descriptor = _make_macro_edge_descriptor(macro_defn_ast, macro_edge_args)
 
-    return class_name, macro_edge_name
+    return class_name, macro_edge_name, descriptor
 
 
-def _make_macro_edge_descriptor():
-    """Not implemented yet."""
-    raise NotImplementedError()
+def _make_macro_edge_descriptor(macro_definition_ast, macro_edge_args):
+    """Remove all macro edge directives from the AST, and return a MacroEdgeDescriptor."""
+    directives_to_remove = {
+        directive.name
+        for directive in MACRO_EDGE_DIRECTIVES
+    }
+    new_ast = remove_directives_from_ast(macro_definition_ast, directives_to_remove)
+
+    return MacroEdgeDescriptor(new_ast.selection_set, macro_edge_args)


### PR DESCRIPTION
Moved a bunch of parsing code out of the `compiler_frontend.py` file, and deduplicated the "find me the only query definition within the root AST" function, since it was in use in several places.

Also fixed a type checking bug that was complaining on every macro.

There's a bit more validation that needs to happen, but this is enough so that the next PR can add the initial macro expansion code, up to but not including the "merge the source and target selections" code. @bojanserafimov leaving that logic up to you, I will leave it unimplemented as we discussed.