### PR TITLE
Keep the @macro_edge_target in the macro descriptor

### DIFF
--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -160,6 +160,9 @@ def get_and_validate_macro_edge_info(schema, ast, macro_edge_args,
     #   sufficient for the macro, and the macro args' types match the inferred types of the
     #   runtime parameters in the macro.
 
+    # TODO(bojanserafimov): After compiling the macro, read the type at the target from the location
+    #                       info in the metadata table, and record it in the macro descriptor.
+
     _validate_class_selection_ast(
         get_only_selection_from_ast(ast, GraphQLInvalidMacroError), macro_defn_ast)
     class_name = get_ast_field_name(macro_defn_ast)
@@ -177,6 +180,7 @@ def _make_macro_edge_descriptor(macro_definition_ast, macro_edge_args):
     directives_to_remove = {
         directive.name
         for directive in MACRO_EDGE_DIRECTIVES
+        if directive.name != MacroEdgeTargetDirective.name
     }
     new_ast = remove_directives_from_ast(macro_definition_ast, directives_to_remove)
 


### PR DESCRIPTION
If we remove the `@macro_edge_target` directive we permanently lose information on where the user code should be pasted inside the macro.