### PR TITLE
Stop hidding classes

### DIFF
--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -179,7 +179,6 @@ def get_graphql_schema_from_orientdb_schema_data(schema_data, class_to_field_typ
     Returns:
         tuple of (GraphQL schema object, GraphQL type equivalence hints dict).
         The tuple is of type (GraphQLSchema, GraphQLUnionType).
-        We hide classes with no properties in the schema since they're not representable in GraphQL.
     """
     if class_to_field_type_overrides is None:
         class_to_field_type_overrides = dict()

--- a/graphql_compiler/schema_generation/graphql_schema.py
+++ b/graphql_compiler/schema_generation/graphql_schema.py
@@ -221,7 +221,6 @@ def get_graphql_schema_from_schema_graph(schema_graph, class_to_field_type_overr
     Returns:
         tuple of (GraphQL schema object, GraphQL type equivalence hints dict).
         The tuple is of type (GraphQLSchema, GraphQLUnionType).
-        We hide classes with no properties in the schema since they're not representable in GraphQL.
     """
     _validate_overriden_fields_are_not_defined_in_superclasses(class_to_field_type_overrides,
                                                                schema_graph)

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -183,6 +183,5 @@ class IntegrationTests(TestCase):
             "Event": {"event_date": GraphQLDateTime}
         }
         schema, _ = get_graphql_schema_from_orientdb_schema_data(schema_data, type_overrides)
-        print(print_schema(schema))
         compare_ignoring_whitespace(self, SCHEMA_TEXT, print_schema(schema), None)
 # pylint: enable=no-member

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -183,5 +183,6 @@ class IntegrationTests(TestCase):
             "Event": {"event_date": GraphQLDateTime}
         }
         schema, _ = get_graphql_schema_from_orientdb_schema_data(schema_data, type_overrides)
+        print(print_schema(schema))
         compare_ignoring_whitespace(self, SCHEMA_TEXT, print_schema(schema), None)
 # pylint: enable=no-member

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -40,7 +40,7 @@ SCHEMA_TEXT = '''
 
     directive @fold on FIELD
 
-    type Animal implements Entity, UniquelyIdentifiable {
+    type Animal implements Entity, UniquelyIdentifiable, V {
       _x_count: Int
       alias: [String]
       birthday: Date
@@ -60,7 +60,7 @@ SCHEMA_TEXT = '''
       uuid: ID
     }
 
-    type BirthEvent implements Entity, UniquelyIdentifiable {
+    type BirthEvent implements Entity, UniquelyIdentifiable, V {
       _x_count: Int
       alias: [String]
       description: String
@@ -91,7 +91,7 @@ SCHEMA_TEXT = '''
       uuid: ID
     }
 
-    type Event implements Entity, UniquelyIdentifiable {
+    type Event implements Entity, UniquelyIdentifiable, V {
       _x_count: Int
       alias: [String]
       description: String
@@ -105,7 +105,7 @@ SCHEMA_TEXT = '''
       uuid: ID
     }
 
-    type FeedingEvent implements Entity, UniquelyIdentifiable {
+    type FeedingEvent implements Entity, UniquelyIdentifiable, V {
       _x_count: Int
       alias: [String]
       description: String
@@ -120,7 +120,7 @@ SCHEMA_TEXT = '''
       uuid: ID
     }
 
-    type Food implements Entity, UniquelyIdentifiable {
+    type Food implements Entity, UniquelyIdentifiable, V {
       _x_count: Int
       alias: [String]
       description: String
@@ -131,7 +131,7 @@ SCHEMA_TEXT = '''
       uuid: ID
     }
 
-    type FoodOrSpecies implements Entity, UniquelyIdentifiable {
+    type FoodOrSpecies implements Entity, UniquelyIdentifiable, V {
       _x_count: Int
       alias: [String]
       description: String
@@ -142,7 +142,7 @@ SCHEMA_TEXT = '''
       uuid: ID
     }
 
-    type Location implements Entity, UniquelyIdentifiable {
+    type Location implements Entity, UniquelyIdentifiable, V {
       _x_count: Int
       alias: [String]
       description: String
@@ -164,9 +164,10 @@ SCHEMA_TEXT = '''
       Location: Location
       Species: Species
       UniquelyIdentifiable: UniquelyIdentifiable
+      V: V
     }
 
-    type Species implements Entity, UniquelyIdentifiable {
+    type Species implements Entity, UniquelyIdentifiable, V {
       _x_count: Int
       alias: [String]
       description: String
@@ -187,6 +188,10 @@ SCHEMA_TEXT = '''
     interface UniquelyIdentifiable {
       _x_count: Int
       uuid: ID
+    }
+
+    interface V {
+      _x_count: Int
     }
 '''
 


### PR DESCRIPTION
Classes all have at least one filed, (__x__count). There is no need to hide them. I assume that whoever wrote the hidden classes stuff did it to deal with the fact that classes with no properties have no valid graphql rep. 