### PR TITLE
Add schema_without_macros to macro_registry

### DIFF
--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -95,7 +95,7 @@ def get_schema_with_macros(macro_registry):
        macros but on types they are not defined at should fail schema validation with
        the schema generated from this function.
     3. This function is total -- A macro registry with all macros inserted by using
-       register_macro_edge should not fail to create a graphql schema with macros.
+       register_macro_edge should not fail to create a GraphQL schema with macros.
 
     Args:
         macro_registry: MacroRegistry object containing a schema and macro descriptors

--- a/graphql_compiler/tests/test_macro_expansion.py
+++ b/graphql_compiler/tests/test_macro_expansion.py
@@ -3,9 +3,8 @@ import unittest
 
 import pytest
 
-from ..compiler.subclass import compute_subclass_sets
 from ..macros import perform_macro_expansion
-from .test_helpers import compare_graphql, get_schema, get_test_macro_registry
+from .test_helpers import compare_graphql, get_test_macro_registry
 
 
 class MacroExpansionTests(unittest.TestCase):

--- a/graphql_compiler/tests/test_macro_expansion.py
+++ b/graphql_compiler/tests/test_macro_expansion.py
@@ -12,14 +12,7 @@ class MacroExpansionTests(unittest.TestCase):
     def setUp(self):
         """Disable max diff limits for all tests."""
         self.maxDiff = None
-        self.schema = get_schema()
         self.macro_registry = get_test_macro_registry()
-        self.type_equivalence_hints = {
-            self.schema.get_type('Event'): self.schema.get_type(
-                'Union__BirthEvent__Event__FeedingEvent'),
-        }
-        self.subclass_sets = compute_subclass_sets(
-            self.schema, type_equivalence_hints=self.type_equivalence_hints)
 
     def test_macro_edge_basic(self):
         query = '''{
@@ -42,8 +35,7 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -82,8 +74,7 @@ class MacroExpansionTests(unittest.TestCase):
             'net_worth_upper_bound': 5,
         }
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -123,8 +114,7 @@ class MacroExpansionTests(unittest.TestCase):
             'net_worth_upper_bound': 5,
         }
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -153,8 +143,7 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -181,8 +170,7 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -209,8 +197,7 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -237,8 +224,7 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -271,8 +257,7 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'croissant'
         }
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -303,8 +288,7 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'croissant'
         }
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -331,8 +315,7 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'Nate',
         }
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -364,8 +347,7 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'Nate',
         }
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -399,8 +381,7 @@ class MacroExpansionTests(unittest.TestCase):
             'num_parents': 0,
         }
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -431,8 +412,7 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -467,8 +447,7 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -499,8 +478,7 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -537,7 +515,6 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(
-            self.schema, self.macro_registry, query, args, subclass_sets=self.subclass_sets)
+        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)

--- a/graphql_compiler/tests/test_macro_expansion_errors.py
+++ b/graphql_compiler/tests/test_macro_expansion_errors.py
@@ -3,10 +3,9 @@ import unittest
 
 import pytest
 
-from ..compiler.subclass import compute_subclass_sets
 from ..exceptions import GraphQLCompilationError
 from ..macros import perform_macro_expansion
-from .test_helpers import get_schema, get_test_macro_registry
+from .test_helpers import get_test_macro_registry
 
 
 class MacroExpansionTests(unittest.TestCase):

--- a/graphql_compiler/tests/test_macro_expansion_errors.py
+++ b/graphql_compiler/tests/test_macro_expansion_errors.py
@@ -13,14 +13,7 @@ class MacroExpansionTests(unittest.TestCase):
     def setUp(self):
         """Disable max diff limits for all tests."""
         self.maxDiff = None
-        self.schema = get_schema()
         self.macro_registry = get_test_macro_registry()
-        self.type_equivalence_hints = {
-            self.schema.get_type('Event'): self.schema.get_type(
-                'Union__BirthEvent__Event__FeedingEvent'),
-        }
-        self.subclass_sets = compute_subclass_sets(
-            self.schema, type_equivalence_hints=self.type_equivalence_hints)
 
     def test_macro_edge_duplicate_edge_traversal(self):
         query = '''{
@@ -36,8 +29,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.schema, self.macro_registry, query, args,
-                                    subclass_sets=self.subclass_sets)
+            perform_macro_expansion(self.macro_registry, query, args)
 
     def test_macro_edge_duplicate_macro_traversal(self):
         query = '''{
@@ -53,8 +45,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.schema, self.macro_registry, query, args,
-                                    subclass_sets=self.subclass_sets)
+            perform_macro_expansion(self.macro_registry, query, args)
 
     def test_macro_edge_target_coercion_invalid_1(self):
         query = '''{
@@ -69,8 +60,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.schema, self.macro_registry, query, args,
-                                    subclass_sets=self.subclass_sets)
+            perform_macro_expansion(self.macro_registry, query, args)
 
     @pytest.mark.skip(reason='not implemented')
     def test_macro_edge_invalid_coercion_2(self):
@@ -86,8 +76,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.schema, self.macro_registry, query, args,
-                                    subclass_sets=self.subclass_sets)
+            perform_macro_expansion(self.macro_registry, query, args)
 
     @pytest.mark.skip(reason='not implemented')
     def test_macro_edge_nonexistent(self):
@@ -101,8 +90,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.schema, self.macro_registry, query, args,
-                                    subclass_sets=self.subclass_sets)
+            perform_macro_expansion(self.macro_registry, query, args)
 
     @pytest.mark.skip(reason='not implemented')
     def test_macro_edge_target_on_union_type(self):
@@ -118,5 +106,4 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.schema, self.macro_registry, query, args,
-                                    subclass_sets=self.subclass_sets)
+            perform_macro_expansion(self.macro_registry, query, args)

--- a/graphql_compiler/tests/test_macro_validation.py
+++ b/graphql_compiler/tests/test_macro_validation.py
@@ -5,7 +5,7 @@ import pytest
 
 from ..exceptions import GraphQLInvalidArgumentError, GraphQLInvalidMacroError
 from ..macros import register_macro_edge
-from .test_helpers import get_empty_test_macro_registry, get_schema
+from .test_helpers import get_empty_test_macro_registry
 
 
 class MacroValidationTests(unittest.TestCase):
@@ -478,8 +478,7 @@ class MacroValidationTests(unittest.TestCase):
         macro_registry = get_empty_test_macro_registry()
         register_macro_edge(macro_registry, query, args)
         with self.assertRaises(AssertionError):
-            register_macro_edge(macro_registry, self.schema, query_on_subclass,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query_on_subclass, args)
 
         # Try registering on the subclass first
         macro_registry = get_empty_test_macro_registry()

--- a/graphql_compiler/tests/test_macro_validation.py
+++ b/graphql_compiler/tests/test_macro_validation.py
@@ -4,19 +4,14 @@ import unittest
 import pytest
 
 from ..exceptions import GraphQLInvalidArgumentError, GraphQLInvalidMacroError
-from ..macros import create_macro_registry, register_macro_edge
-from .test_helpers import get_schema
+from ..macros import register_macro_edge
+from .test_helpers import get_empty_test_macro_registry, get_schema
 
 
 class MacroValidationTests(unittest.TestCase):
     def setUp(self):
         """Disable max diff limits for all tests."""
         self.maxDiff = None
-        self.schema = get_schema()
-        self.type_equivalence_hints = {
-            self.schema.get_type('Event'): self.schema.get_type(
-                'Union__BirthEvent__Event__FeedingEvent'),
-        }
 
     def test_bad_operation_type(self):
         query = '''mutation {
@@ -30,10 +25,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_with_output_directive(self):
         query = '''{
@@ -47,10 +41,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_with_output_source_directive(self):
         query = '''{
@@ -64,10 +57,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_with_target_inside_fold(self):
         query = '''{
@@ -81,10 +73,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_with_target_outside_fold(self):
         query = '''{
@@ -104,9 +95,8 @@ class MacroValidationTests(unittest.TestCase):
         }
 
         # It should compile successfully
-        macro_registry = create_macro_registry()
-        register_macro_edge(macro_registry, self.schema, query,
-                            args, self.type_equivalence_hints)
+        macro_registry = get_empty_test_macro_registry()
+        register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_missing_target(self):
         query = '''{
@@ -120,10 +110,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_multiple_targets(self):
         query = '''{
@@ -137,10 +126,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_multiple_targets_2(self):
         query = '''{
@@ -154,10 +142,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_missing_definition(self):
         query = '''{
@@ -171,10 +158,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_invalid_definition(self):
         query = '''{
@@ -188,10 +174,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     @pytest.mark.skip(reason='not implemented')
     def test_macro_edge_invalid_target_directive(self):
@@ -208,10 +193,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_invalid_no_op_1(self):
         query = '''{
@@ -221,10 +205,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_invalid_no_op_2(self):
         query = '''{
@@ -238,10 +221,9 @@ class MacroValidationTests(unittest.TestCase):
             'color': 'green',
         }
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_missing_args(self):
         query = '''{
@@ -259,10 +241,9 @@ class MacroValidationTests(unittest.TestCase):
             'net_worth': 4,
         }
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidArgumentError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_extra_args(self):
         query = '''{
@@ -282,10 +263,9 @@ class MacroValidationTests(unittest.TestCase):
             'asdf': 5
         }
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidArgumentError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_incorrect_arg_types(self):
         query = '''{
@@ -306,10 +286,9 @@ class MacroValidationTests(unittest.TestCase):
             'color': 'green',
         }
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidArgumentError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_multiple_definitions(self):
         query = '''{
@@ -330,10 +309,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_duplicate_definition(self):
         query = '''{
@@ -347,12 +325,10 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
-        register_macro_edge(macro_registry, self.schema, query,
-                            args, self.type_equivalence_hints)
+        macro_registry = get_empty_test_macro_registry()
+        register_macro_edge(macro_registry, query, args)
         with self.assertRaises(AssertionError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_duplicating_real_edge_name(self):
         query = '''{
@@ -368,10 +344,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_duplicating_real_edge_name_at_target(self):
         query = '''{
@@ -387,10 +362,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     def test_macro_edge_duplicating_field_name(self):
         query = '''{
@@ -406,10 +380,9 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
+        macro_registry = get_empty_test_macro_registry()
         with self.assertRaises(GraphQLInvalidMacroError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     @pytest.mark.skip(reason='not implemented')
     def test_macro_edge_duplicate_definition_on_target(self):
@@ -438,12 +411,10 @@ class MacroValidationTests(unittest.TestCase):
         }'''
         args = {}
 
-        macro_registry = create_macro_registry()
-        register_macro_edge(macro_registry, self.schema, query,
-                            args, self.type_equivalence_hints)
+        macro_registry = get_empty_test_macro_registry()
+        register_macro_edge(macro_registry, query, args)
         with self.assertRaises(AssertionError):
-            register_macro_edge(macro_registry, self.schema, duplicate_query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, duplicate_query, args)
 
     @pytest.mark.skip(reason='not implemented')
     def test_macro_edge_dulpicate_definition_on_subclass(self):
@@ -468,20 +439,16 @@ class MacroValidationTests(unittest.TestCase):
         args = {}
 
         # Try registering on the superclass first
-        macro_registry = create_macro_registry()
-        register_macro_edge(macro_registry, self.schema, query,
-                            args, self.type_equivalence_hints)
+        macro_registry = get_empty_test_macro_registry()
+        register_macro_edge(macro_registry, query, args)
         with self.assertRaises(AssertionError):
-            register_macro_edge(macro_registry, self.schema, query_on_subclass,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query_on_subclass, args)
 
         # Try registering on the subclass first
-        macro_registry = create_macro_registry()
-        register_macro_edge(macro_registry, self.schema, query_on_subclass,
-                            args, self.type_equivalence_hints)
+        macro_registry = get_empty_test_macro_registry()
+        register_macro_edge(macro_registry, query_on_subclass, args)
         with self.assertRaises(AssertionError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)
 
     @pytest.mark.skip(reason='not implemented')
     def test_macro_edge_duplicate_definition_on_target_subclass(self):
@@ -508,17 +475,14 @@ class MacroValidationTests(unittest.TestCase):
         args = {}
 
         # Try registering on the superclass first
-        macro_registry = create_macro_registry()
-        register_macro_edge(macro_registry, self.schema, query,
-                            args, self.type_equivalence_hints)
+        macro_registry = get_empty_test_macro_registry()
+        register_macro_edge(macro_registry, query, args)
         with self.assertRaises(AssertionError):
             register_macro_edge(macro_registry, self.schema, query_on_subclass,
                                 args, self.type_equivalence_hints)
 
         # Try registering on the subclass first
-        macro_registry = create_macro_registry()
-        register_macro_edge(macro_registry, self.schema, query_on_subclass,
-                            args, self.type_equivalence_hints)
+        macro_registry = get_empty_test_macro_registry()
+        register_macro_edge(macro_registry, query_on_subclass, args)
         with self.assertRaises(AssertionError):
-            register_macro_edge(macro_registry, self.schema, query,
-                                args, self.type_equivalence_hints)
+            register_macro_edge(macro_registry, query, args)


### PR DESCRIPTION
Refactor to solidify the meaning of the type `macro_registry`. Macros can only valid based on a specific schema.