### PR TITLE
Refactor schema graph to use GraphQL types 

### DIFF
--- a/graphql_compiler/schema_generation/graphql_schema.py
+++ b/graphql_compiler/schema_generation/graphql_schema.py
@@ -3,17 +3,15 @@ from collections import OrderedDict
 from itertools import chain
 
 from graphql.type import (
-    GraphQLBoolean, GraphQLField, GraphQLFloat, GraphQLInt, GraphQLInterfaceType, GraphQLList,
-    GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType
+    GraphQLField, GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLSchema,
+    GraphQLUnionType
 )
 import six
 
-from ..schema import (
-    DIRECTIVES, EXTENDED_META_FIELD_DEFINITIONS, GraphQLDate, GraphQLDateTime, GraphQLDecimal
-)
+from ..schema import DIRECTIVES, EXTENDED_META_FIELD_DEFINITIONS
 from .exceptions import EmptySchemaError
 from .schema_properties import (
-    EDGE_DESTINATION_PROPERTY_NAME, EDGE_SOURCE_PROPERTY_NAME, ORIENTDB_BASE_VERTEX_CLASS_NAME,
+    EDGE_DESTINATION_PROPERTY_NAME, EDGE_SOURCE_PROPERTY_NAME, ORIENTDB_BASE_VERTEX_CLASS_NAME
 )
 
 

--- a/graphql_compiler/schema_generation/graphql_schema.py
+++ b/graphql_compiler/schema_generation/graphql_schema.py
@@ -15,13 +15,6 @@ from .schema_properties import (
 )
 
 
-def _property_descriptor_to_graphql_type(property_obj):
-    if property_obj.type == GraphQLList:
-        return GraphQLList(property_obj.qualifier)
-    else:
-        return property_obj.type
-
-
 def _get_referenced_type_equivalences(graphql_types, type_equivalence_hints):
     """Filter union types with no edges from the type equivalence hints dict."""
     referenced_types = set()
@@ -75,11 +68,13 @@ def _get_fields_for_class(schema_graph, graphql_types, field_type_overrides, hid
     """Return a dict from field name to GraphQL field type, for the specified graph class."""
     properties = schema_graph.get_element_by_class_name(cls_name).properties
 
-    result = {
-        property_name: _property_descriptor_to_graphql_type(property_obj)
-        for property_name, property_obj in six.iteritems(properties)
-        if property_obj.type is not None
-    }
+    result = {}
+    for property_name, property_obj in properties.items():
+        if property_obj.type is not None:
+            if property_obj.type == GraphQLList:
+                result[property_name] = GraphQLList(property_obj.qualifier)
+            else:
+                result[property_name] = property_obj.type
 
     # Add edge GraphQL fields (edges to other vertex classes).
     schema_element = schema_graph.get_element_by_class_name(cls_name)

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -1,6 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from itertools import chain
 
+from graphql.type import GraphQLList
 import six
 
 from .exceptions import IllegalSchemaStateError, InvalidClassError, InvalidPropertyError
@@ -18,8 +19,8 @@ def _validate_non_abstract_edge_has_defined_endpoint_types(class_name, propertie
     edge_source = properties.get(EDGE_SOURCE_PROPERTY_NAME, None)
     edge_destination = properties.get(EDGE_DESTINATION_PROPERTY_NAME, None)
     has_defined_endpoint_types = all((
-        edge_source is not None,
-        edge_destination is not None,
+        edge_source is not None and edge_source.type == GraphQLList,
+        edge_destination is not None and edge_destination.type == GraphQLList,
     ))
     if not has_defined_endpoint_types:
         raise IllegalSchemaStateError(u'Found a non-abstract edge class with undefined or illegal '

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -6,19 +6,9 @@ import six
 from .exceptions import IllegalSchemaStateError, InvalidClassError, InvalidPropertyError
 from .schema_properties import (
     COLLECTION_PROPERTY_TYPES, EDGE_DESTINATION_PROPERTY_NAME, EDGE_SOURCE_PROPERTY_NAME,
-    ILLEGAL_PROPERTY_NAME_PREFIXES, ORIENTDB_BASE_EDGE_CLASS_NAME, ORIENTDB_BASE_VERTEX_CLASS_NAME,
-    PROPERTY_TYPE_LINK_ID, PropertyDescriptor, parse_default_property_value,
-    validate_supported_property_type_id, PROPERTY_TYPE_BOOLEAN_ID, PROPERTY_TYPE_DATE_ID,
-    PROPERTY_TYPE_DATETIME_ID, PROPERTY_TYPE_DECIMAL_ID, PROPERTY_TYPE_DOUBLE_ID,
-    PROPERTY_TYPE_EMBEDDED_LIST_ID, PROPERTY_TYPE_EMBEDDED_SET_ID, PROPERTY_TYPE_FLOAT_ID,
-    PROPERTY_TYPE_INTEGER_ID, PROPERTY_TYPE_STRING_ID, ORIENDB_TO_GRAPHQL_TYPE_DICT
-)
-from graphql.type import (
-    GraphQLBoolean, GraphQLField, GraphQLFloat, GraphQLInt, GraphQLInterfaceType, GraphQLList,
-    GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType
-)
-from ..schema import (
-    DIRECTIVES, EXTENDED_META_FIELD_DEFINITIONS, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+    ILLEGAL_PROPERTY_NAME_PREFIXES, ORIENDB_TO_GRAPHQL_TYPE_DICT, ORIENTDB_BASE_EDGE_CLASS_NAME,
+    ORIENTDB_BASE_VERTEX_CLASS_NAME, PROPERTY_TYPE_LINK_ID, PropertyDescriptor,
+    parse_default_property_value, validate_supported_property_type_id
 )
 from .utils import toposort_classes
 
@@ -63,7 +53,6 @@ def _validate_collections_have_default_values(class_name, property_name,
         if property_descriptor.default is None:
             raise IllegalSchemaStateError(u'Class "{}" has a property "{}" of collection type with '
                                           u'no default value.'.format(class_name, property_name))
-
 
 
 def _get_superclasses_from_class_definition(class_definition):
@@ -623,8 +612,7 @@ class SchemaGraph(object):
                                          u'endpoint types: {}'.format(edge_element))
 
             from_class_name = edge_element.properties[EDGE_SOURCE_PROPERTY_NAME].qualifier
-            to_class_name = (edge_element.properties[
-                                 EDGE_DESTINATION_PROPERTY_NAME].qualifier)
+            to_class_name = edge_element.properties[EDGE_DESTINATION_PROPERTY_NAME].qualifier
 
             edge_schema_element = self._elements[edge_class_name]
 

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -3,14 +3,11 @@ from collections import namedtuple
 import datetime
 import time
 
+from graphql.type import GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLList, GraphQLString
 import six
-from graphql.type import (
-    GraphQLBoolean, GraphQLField, GraphQLFloat, GraphQLInt, GraphQLInterfaceType, GraphQLList,
-    GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType
-)
-from ..schema import (
-    DIRECTIVES, EXTENDED_META_FIELD_DEFINITIONS, GraphQLDate, GraphQLDateTime, GraphQLDecimal
-)
+
+from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
+
 
 EDGE_SOURCE_PROPERTY_NAME = 'out'
 EDGE_DESTINATION_PROPERTY_NAME = 'in'

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -193,7 +193,7 @@ def parse_default_property_value(property_name, property_type_id, default_value_
 #   - qualifier: one of three possible types:
 #        - string, the string name of the class to which it points if the property is a link.
 #        - GraphQLScalarType, the type of its elements if the property is a collection.
-#        - None, for all other property types.
+#        - None, for all other properties.
 #   - default: the default value for the property, used when a record is inserted without an
 #              explicit value for this property. Set to None if no default is given in the schema.
 PropertyDescriptor = namedtuple('PropertyDescriptor',

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -192,14 +192,11 @@ def parse_default_property_value(property_name, property_type_id, default_value_
 
 
 # A way to describe a property's type and associated information:
-#   - type_id: int, the OrientDB property type ID -- can be made human-readable
-#              using the above PROPERTY_TYPE_ID_TO_NAME map.
-#   - qualifier: dependent on the type_id
-#        - For Link properties, string -- the name of the class to which the Link points.
-#        - For EmbeddedSet and EmbeddedList, either:
-#              - int, the property type ID of the native OrientDB type, if the data in
-#                the collection is of a built-in OrientDB type, or
-#              - string, the name of the non-graph class representing the data in the collection.
+#   - type: GraphQLType, the GraphQL type of the property.
+#   - qualifier: dependent on the property type
+#        - If the property type is a GraphQLList, string or GraphQLScalarType. If the property is
+#          a link, then it will be the string name of the class to which it points. If the
+#          property it is a collection, it will be the GraphQLScalarType of its elements.
 #        - For all other property types, None.
 #   - default: the default value for the property, used when a record is inserted without an
 #              explicit value for this property. Set to None if no default is given in the schema.

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -193,11 +193,10 @@ def parse_default_property_value(property_name, property_type_id, default_value_
 
 # A way to describe a property's type and associated information:
 #   - type: GraphQLType, the GraphQL type of the property.
-#   - qualifier: dependent on the property type
-#        - If the property type is a GraphQLList, string or GraphQLScalarType. If the property is
-#          a link, then it will be the string name of the class to which it points. If the
-#          property it is a collection, it will be the GraphQLScalarType of its elements.
-#        - For all other property types, None.
+#   - qualifier: one of three possible types:
+#        - string, the string name of the class to which it points if the property is a link.
+#        - GraphQLScalarType, the type of its elements if the property is a collection.
+#        - None, for all other property types.
 #   - default: the default value for the property, used when a record is inserted without an
 #              explicit value for this property. Set to None if no default is given in the schema.
 PropertyDescriptor = namedtuple('PropertyDescriptor',

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -4,7 +4,13 @@ import datetime
 import time
 
 import six
-
+from graphql.type import (
+    GraphQLBoolean, GraphQLField, GraphQLFloat, GraphQLInt, GraphQLInterfaceType, GraphQLList,
+    GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType
+)
+from ..schema import (
+    DIRECTIVES, EXTENDED_META_FIELD_DEFINITIONS, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+)
 
 EDGE_SOURCE_PROPERTY_NAME = 'out'
 EDGE_DESTINATION_PROPERTY_NAME = 'in'
@@ -87,6 +93,20 @@ PROPERTY_TYPE_ID_TO_NAME = {
     PROPERTY_TYPE_DATE_ID: PROPERTY_TYPE_DATE_NAME,
     PROPERTY_TYPE_DECIMAL_ID: PROPERTY_TYPE_DECIMAL_NAME,
     PROPERTY_TYPE_ANY_ID: PROPERTY_TYPE_ANY_NAME,
+}
+
+ORIENDB_TO_GRAPHQL_TYPE_DICT = {
+    PROPERTY_TYPE_BOOLEAN_ID: GraphQLBoolean,
+    PROPERTY_TYPE_DATE_ID: GraphQLDate,
+    PROPERTY_TYPE_DATETIME_ID: GraphQLDateTime,
+    PROPERTY_TYPE_DECIMAL_ID: GraphQLDecimal,
+    PROPERTY_TYPE_DOUBLE_ID: GraphQLFloat,
+    PROPERTY_TYPE_EMBEDDED_SET_ID: GraphQLList,
+    PROPERTY_TYPE_EMBEDDED_LIST_ID: GraphQLList,
+    PROPERTY_TYPE_FLOAT_ID: GraphQLFloat,
+    PROPERTY_TYPE_INTEGER_ID: GraphQLInt,
+    PROPERTY_TYPE_LINK_ID: GraphQLList,
+    PROPERTY_TYPE_STRING_ID: GraphQLString,
 }
 
 ORIENTDB_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
@@ -184,4 +204,4 @@ def parse_default_property_value(property_name, property_type_id, default_value_
 #   - default: the default value for the property, used when a record is inserted without an
 #              explicit value for this property. Set to None if no default is given in the schema.
 PropertyDescriptor = namedtuple('PropertyDescriptor',
-                                ('type_id', 'qualifier', 'default'))
+                                ('type', 'qualifier', 'default'))

--- a/graphql_compiler/tests/test_schema_generation.py
+++ b/graphql_compiler/tests/test_schema_generation.py
@@ -10,8 +10,8 @@ from graphql_compiler import get_graphql_schema_from_orientdb_schema_data
 from ..schema_generation.graphql_schema import _get_union_type_name
 from ..schema_generation.schema_graph import SchemaGraph
 from ..schema_generation.schema_properties import (
-    ORIENTDB_BASE_EDGE_CLASS_NAME, ORIENTDB_BASE_VERTEX_CLASS_NAME, PROPERTY_TYPE_EMBEDDED_LIST_ID,
-    PROPERTY_TYPE_EMBEDDED_SET_ID, PROPERTY_TYPE_LINK_ID, PROPERTY_TYPE_STRING_ID
+    ORIENTDB_BASE_EDGE_CLASS_NAME, ORIENTDB_BASE_VERTEX_CLASS_NAME, PROPERTY_TYPE_EMBEDDED_SET_ID,
+    PROPERTY_TYPE_LINK_ID, PROPERTY_TYPE_STRING_ID
 )
 
 
@@ -188,7 +188,6 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         schema_graph = SchemaGraph(schema_data)
         person_lives_in_edge = schema_graph.get_element_by_class_name('Person_LivesIn')
         in_property = person_lives_in_edge.properties['in']
-        print(in_property)
         self.assertEqual(in_property.type, GraphQLList)
         self.assertEqual(in_property.qualifier, 'Location')
         out_property = person_lives_in_edge.properties['out']

--- a/graphql_compiler/tests/test_schema_generation.py
+++ b/graphql_compiler/tests/test_schema_generation.py
@@ -66,21 +66,6 @@ BABY_SCHEMA_DATA = frozendict({
     'properties': [],
 })
 
-
-DATA_POINT_SCHEMA_DATA = frozendict({
-    'name': 'DataPoint',
-    'abstract': True,
-    'properties': [
-        {
-            'name': 'data_source',
-            'type': PROPERTY_TYPE_EMBEDDED_LIST_ID,
-            'linkedClass': 'ExternalSource',
-            'defaultValue': '[]'
-        }
-
-    ]
-})
-
 PERSON_LIVES_IN_EDGE_SCHEMA_DATA = frozendict({
     'name': 'Person_LivesIn',
     'abstract': False,
@@ -177,7 +162,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         ]
         schema_graph = SchemaGraph(schema_data)
         name_property = schema_graph.get_element_by_class_name('Entity').properties['name']
-        self.assertEqual(name_property.type_id, PROPERTY_TYPE_STRING_ID)
+        self.assertEqual(name_property.type, GraphQLString)
 
     def test_native_orientdb_collection_property(self):
         schema_data = [
@@ -187,21 +172,9 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         ]
         schema_graph = SchemaGraph(schema_data)
         alias_property = schema_graph.get_element_by_class_name('Person').properties['alias']
-        self.assertEqual(alias_property.type_id, PROPERTY_TYPE_EMBEDDED_SET_ID)
-        self.assertEqual(alias_property.qualifier, PROPERTY_TYPE_STRING_ID)
+        self.assertEqual(alias_property.type, GraphQLList)
+        self.assertEqual(alias_property.qualifier, GraphQLString)
         self.assertEqual(alias_property.default, set())
-
-    def test_class_collection_property(self):
-        schema_data = [
-            DATA_POINT_SCHEMA_DATA,
-            EXTERNAL_SOURCE_SCHEMA_DATA,
-        ]
-        schema_graph = SchemaGraph(schema_data)
-        friends_property = schema_graph.get_element_by_class_name('DataPoint').properties[
-            'data_source']
-        self.assertEqual(friends_property.type_id, PROPERTY_TYPE_EMBEDDED_LIST_ID)
-        self.assertEqual(friends_property.qualifier, 'ExternalSource')
-        self.assertEqual(friends_property.default, list())
 
     def test_link_property(self):
         schema_data = [
@@ -215,10 +188,11 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         schema_graph = SchemaGraph(schema_data)
         person_lives_in_edge = schema_graph.get_element_by_class_name('Person_LivesIn')
         in_property = person_lives_in_edge.properties['in']
-        self.assertEqual(in_property.type_id, PROPERTY_TYPE_LINK_ID)
+        print(in_property)
+        self.assertEqual(in_property.type, GraphQLList)
         self.assertEqual(in_property.qualifier, 'Location')
         out_property = person_lives_in_edge.properties['out']
-        self.assertEqual(out_property.type_id, PROPERTY_TYPE_LINK_ID)
+        self.assertEqual(out_property.type, GraphQLList)
         self.assertEqual(out_property.qualifier, 'Person')
 
     def test_parsed_class_fields(self):


### PR DESCRIPTION
Note that I removed all tests cases and code related to having collections of non-primitive data types. I found a comment in graphql_schema explaining that we don't currently support these. 

        # There are properties that are embedded collections of non-primitive types,
        # for example, ProxyEventSet.scalar_parameters.
        # The GraphQL compiler does not currently support these.