### PR TITLE
Add different setup function for each kind

### DIFF
--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -311,13 +311,9 @@ class SchemaGraph(object):
         # Initialize the _vertex_class_names, _edge_class_names, and _non_graph_class_names sets.
         self._split_classes_by_kind(class_name_to_definition)
 
-        kind_to_class_names = {
-            NonGraphElement: self._non_graph_class_names,
-            VertexType: self._vertex_class_names,
-            EdgeType: self._edge_class_names,
-        }
-        for kind, class_names in six.iteritems(kind_to_class_names):
-            self._set_up_schema_elements_of_kind(class_name_to_definition, kind, class_names)
+        self._set_up_non_graph_elements(class_name_to_definition)
+        self._set_up_edge_elements(class_name_to_definition)
+        self._set_up_vertex_elements(class_name_to_definition)
 
         # Initialize the connections that show which schema classes can be connected to
         # which other schema classes, then freeze all schema elements.
@@ -503,9 +499,9 @@ class SchemaGraph(object):
         self._edge_class_names = frozenset(self._edge_class_names)
         self._non_graph_class_names = frozenset(self._non_graph_class_names)
 
-    def _set_up_schema_elements_of_kind(self, class_name_to_definition, kind_cls, class_names):
-        """Load all schema classes of the given kind. Used as part of __init__."""
-        for class_name in class_names:
+    def _set_up_non_graph_elements(self, class_name_to_definition):
+        """Load all NonGraphElements. Used as part of __init__."""
+        for class_name in self._non_graph_class_names:
             class_definition = class_name_to_definition[class_name]
             class_fields = _get_class_fields(class_definition)
             abstract = _is_abstract(class_definition)
@@ -516,11 +512,54 @@ class SchemaGraph(object):
                 _get_link_and_non_link_properties(inherited_property_definitions))
 
             property_name_to_descriptor = self._get_link_properties(
-                class_name, class_name_to_definition, link_property_definitions, abstract, kind_cls)
+                class_name, class_name_to_definition, link_property_definitions, abstract,
+                NonGraphElement)
             property_name_to_descriptor.update(self._get_non_link_properties(
                 class_name, class_name_to_definition, non_link_property_definitions))
 
-            self._elements[class_name] = kind_cls(
+            self._elements[class_name] = NonGraphElement(
+                class_name, abstract, property_name_to_descriptor, class_fields)
+
+    def _set_up_edge_elements(self, class_name_to_definition):
+        """Load all EdgeTypes. Used as part of __init__."""
+        for class_name in self._edge_class_names:
+            class_definition = class_name_to_definition[class_name]
+            class_fields = _get_class_fields(class_definition)
+            abstract = _is_abstract(class_definition)
+
+            inherited_property_definitions = _get_inherited_property_definitions(
+                self._inheritance_sets[class_name], class_name_to_definition)
+            link_property_definitions, non_link_property_definitions = (
+                _get_link_and_non_link_properties(inherited_property_definitions))
+
+            property_name_to_descriptor = self._get_link_properties(
+                class_name, class_name_to_definition, link_property_definitions, abstract,
+                EdgeType)
+            property_name_to_descriptor.update(self._get_non_link_properties(
+                class_name, class_name_to_definition, non_link_property_definitions))
+
+            self._elements[class_name] = EdgeType(
+                class_name, abstract, property_name_to_descriptor, class_fields)
+
+    def _set_up_vertex_elements(self, class_name_to_definition):
+        """Load all VertexTypes. Used as part of __init__."""
+        for class_name in self._vertex_class_names:
+            class_definition = class_name_to_definition[class_name]
+            class_fields = _get_class_fields(class_definition)
+            abstract = _is_abstract(class_definition)
+
+            inherited_property_definitions = _get_inherited_property_definitions(
+                self._inheritance_sets[class_name], class_name_to_definition)
+            link_property_definitions, non_link_property_definitions = (
+                _get_link_and_non_link_properties(inherited_property_definitions))
+
+            property_name_to_descriptor = self._get_link_properties(
+                class_name, class_name_to_definition, link_property_definitions, abstract,
+                VertexType)
+            property_name_to_descriptor.update(self._get_non_link_properties(
+                class_name, class_name_to_definition, non_link_property_definitions))
+
+            self._elements[class_name] = VertexType(
                 class_name, abstract, property_name_to_descriptor, class_fields)
 
     def _get_link_properties(self, class_name, class_name_to_definition,


### PR DESCRIPTION
Eliminated _get_element_properties method and added a setup function for each different element kind.

This PR helps setup the next PR on removing link properties and adding root_in_connection and root_out_connection fields for EdgeTypes . Since I plan on making the EdgeType constructor different from the constructor of other SchemaElements, I decided that it'd be best if I had a separate setup method for each SchemaElement kind. By removing the _get_element_properties method and bringing the _get_link_properties method one scope up, I also set myself nicely to remove link properties. 