### PR TITLE
Make the SchemaGraph use GraphQL's type system

### DIFF
--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -267,6 +267,14 @@ GraphQLDecimal = GraphQLScalarType(
     parse_literal=_unused_function,  # We don't yet support parsing Decimal objects in literals.
 )
 
+GraphQLAny = GraphQLScalarType(
+    name='Any',
+    description= 'The `Any` scalar type is used to represent any field type not representable '
+                 'by any other GraphQL type.',
+    serialize=str,
+    parse_value=_unused_function,
+    parse_literal=_unused_function,
+)
 
 DIRECTIVES = (
     FilterDirective,

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -269,8 +269,8 @@ GraphQLDecimal = GraphQLScalarType(
 
 GraphQLAny = GraphQLScalarType(
     name='Any',
-    description='The `Any` scalar type is used to represent any field type not representable '
-                'by any other GraphQL type.',
+    description='The `Any` scalar type is used to represent a scalar type not representable '
+                'by any other GraphQLScalar type.',
     serialize=str,
     parse_value=_unused_function,
     parse_literal=_unused_function,

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -269,8 +269,8 @@ GraphQLDecimal = GraphQLScalarType(
 
 GraphQLAny = GraphQLScalarType(
     name='Any',
-    description= 'The `Any` scalar type is used to represent any field type not representable '
-                 'by any other GraphQL type.',
+    description='The `Any` scalar type is used to represent any field type not representable '
+                'by any other GraphQL type.',
     serialize=str,
     parse_value=_unused_function,
     parse_literal=_unused_function,

--- a/graphql_compiler/schema_generation/graphql_schema.py
+++ b/graphql_compiler/schema_generation/graphql_schema.py
@@ -66,6 +66,7 @@ def _get_fields_for_class(schema_graph, graphql_types, field_type_overrides, hid
     """Return a dict from field name to GraphQL field type, for the specified graph class."""
     properties = schema_graph.get_element_by_class_name(cls_name).properties
 
+    # Add leaf GraphQL fields (class properties).
     result = {
         property_name: property.type
         for property_name, property in six.iteritems(properties)

--- a/graphql_compiler/schema_generation/graphql_schema.py
+++ b/graphql_compiler/schema_generation/graphql_schema.py
@@ -67,9 +67,17 @@ def _get_fields_for_class(schema_graph, graphql_types, field_type_overrides, hid
     properties = schema_graph.get_element_by_class_name(cls_name).properties
 
     # Add leaf GraphQL fields (class properties).
+    all_properties = {
+        property_name: property_obj.type
+        for property_name, property_obj in six.iteritems(properties)
+    }
+
+    # Filter collections of classes. They are currently not supported.
     result = {
-        property_name: property.type
-        for property_name, property in six.iteritems(properties)
+        property_name: graphql_type
+        for property_name, graphql_type in six.iteritems(all_properties)
+        if not (isinstance(graphql_type, GraphQLList) and
+                isinstance(graphql_type.of_type, GraphQLObjectType))
     }
 
     # Add edge GraphQL fields (edges to other vertex classes).

--- a/graphql_compiler/schema_generation/graphql_schema.py
+++ b/graphql_compiler/schema_generation/graphql_schema.py
@@ -3,21 +3,14 @@ from collections import OrderedDict
 from itertools import chain
 
 from graphql.type import (
-    GraphQLBoolean, GraphQLField, GraphQLFloat, GraphQLInt, GraphQLInterfaceType, GraphQLList,
-    GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType
+    GraphQLField, GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLSchema,
+    GraphQLUnionType
 )
 import six
 
-from ..schema import (
-    DIRECTIVES, EXTENDED_META_FIELD_DEFINITIONS, GraphQLDate, GraphQLDateTime, GraphQLDecimal
-)
+from ..schema import DIRECTIVES, EXTENDED_META_FIELD_DEFINITIONS
 from .exceptions import EmptySchemaError
-from .schema_properties import (
-    ORIENTDB_BASE_VERTEX_CLASS_NAME, PROPERTY_TYPE_BOOLEAN_ID, PROPERTY_TYPE_DATE_ID,
-    PROPERTY_TYPE_DATETIME_ID, PROPERTY_TYPE_DECIMAL_ID, PROPERTY_TYPE_DOUBLE_ID,
-    PROPERTY_TYPE_EMBEDDED_LIST_ID, PROPERTY_TYPE_EMBEDDED_SET_ID, PROPERTY_TYPE_FLOAT_ID,
-    PROPERTY_TYPE_INTEGER_ID, PROPERTY_TYPE_STRING_ID
-)
+from .schema_properties import ORIENTDB_BASE_VERTEX_CLASS_NAME
 
 
 def _get_referenced_type_equivalences(graphql_types, type_equivalence_hints):
@@ -60,41 +53,6 @@ def _validate_overriden_fields_are_not_defined_in_superclasses(class_to_field_ty
                             .format(field_name, class_name, superclass_name))
 
 
-def _property_descriptor_to_graphql_type(property_obj):
-    """Return the best GraphQL type representation for an OrientDB property descriptor."""
-    property_type = property_obj.type_id
-    scalar_types = {
-        PROPERTY_TYPE_BOOLEAN_ID: GraphQLBoolean,
-        PROPERTY_TYPE_DATE_ID: GraphQLDate,
-        PROPERTY_TYPE_DATETIME_ID: GraphQLDateTime,
-        PROPERTY_TYPE_DECIMAL_ID: GraphQLDecimal,
-        PROPERTY_TYPE_DOUBLE_ID: GraphQLFloat,
-        PROPERTY_TYPE_FLOAT_ID: GraphQLFloat,
-        PROPERTY_TYPE_INTEGER_ID: GraphQLInt,
-        PROPERTY_TYPE_STRING_ID: GraphQLString,
-    }
-
-    result = scalar_types.get(property_type, None)
-    if result:
-        return result
-
-    mapping_types = {
-        PROPERTY_TYPE_EMBEDDED_SET_ID: GraphQLList,
-        PROPERTY_TYPE_EMBEDDED_LIST_ID: GraphQLList,
-    }
-    wrapping_type = mapping_types.get(property_type, None)
-    if wrapping_type:
-        linked_property_obj = property_obj.qualifier
-        # There are properties that are embedded collections of non-primitive types,
-        # for example, ProxyEventSet.scalar_parameters.
-        # The GraphQL compiler does not currently support these.
-        if linked_property_obj in scalar_types:
-            return wrapping_type(scalar_types[linked_property_obj])
-
-    # We weren't able to represent this property in GraphQL, so we'll hide it instead.
-    return None
-
-
 def _get_union_type_name(type_names_to_union):
     """Construct a unique union type name based on the type names being unioned."""
     if not type_names_to_union:
@@ -108,15 +66,9 @@ def _get_fields_for_class(schema_graph, graphql_types, field_type_overrides, hid
     """Return a dict from field name to GraphQL field type, for the specified graph class."""
     properties = schema_graph.get_element_by_class_name(cls_name).properties
 
-    # Add leaf GraphQL fields (class properties).
-    all_properties = {
-        property_name: _property_descriptor_to_graphql_type(property_obj)
-        for property_name, property_obj in six.iteritems(properties)
-    }
     result = {
-        property_name: graphql_representation
-        for property_name, graphql_representation in six.iteritems(all_properties)
-        if graphql_representation is not None
+        property_name: property.type
+        for property_name, property in six.iteritems(properties)
     }
 
     # Add edge GraphQL fields (edges to other vertex classes).

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -1,6 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from abc import ABCMeta, abstractmethod
 from itertools import chain
+from functools import lru_cache
 
 from funcy.py3 import lsplit
 from graphql.type import (
@@ -662,6 +663,8 @@ class SchemaGraph(object):
                                          'a graph class. Only non-graph classes are allowed in '
                                          'collections.'
                                          .format(class_name, property_definition))
+                # Don't include the fields and implemented intefaces, this information is already
+                # stored in the SchemaGraph.
                 maybe_graphql_type = GraphQLList(GraphQLObjectType(linked_class, {}, []))
         elif type_id in scalar_types:
             maybe_graphql_type = scalar_types[type_id]
@@ -776,3 +779,4 @@ def _get_default_value(class_name, property_definition):
                                           .format(class_name, property_definition))
 
     return default_value
+

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -6,11 +6,10 @@ from funcy.py3 import lsplit
 from graphql.type import (
     GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString
 )
-import six
-
 from graphql_compiler.schema_generation.schema_properties import (
     EDGE_DESTINATION_PROPERTY_NAME, EDGE_END_NAMES, EDGE_SOURCE_PROPERTY_NAME
 )
+import six
 
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .exceptions import IllegalSchemaStateError, InvalidClassError, InvalidPropertyError

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -623,10 +623,10 @@ class SchemaGraph(object):
                                      u'more than once, this is not allowed!'
                                      .format(property_name, class_name))
 
-            graphql_type = self._try_get_graphql_type(property_definition)
-            if graphql_type:
+            maybe_graphql_type = self._try_get_graphql_type(property_definition)
+            if maybe_graphql_type:
                 default_value = _get_default_value(class_name, property_definition)
-                property_descriptor = PropertyDescriptor(graphql_type, default_value)
+                property_descriptor = PropertyDescriptor(maybe_graphql_type, default_value)
                 property_name_to_descriptor[property_name] = property_descriptor
         return property_name_to_descriptor
 
@@ -647,17 +647,17 @@ class SchemaGraph(object):
             PROPERTY_TYPE_STRING_ID: GraphQLString,
         }
 
-        qraphql_type = None
+        maybe_graphql_type = None
         if type_id in COLLECTION_PROPERTY_TYPES:
             if linked_type:
                 if linked_type in scalar_types:
-                    qraphql_type = GraphQLList(scalar_types[linked_type])
+                    maybe_graphql_type = GraphQLList(scalar_types[linked_type])
             elif linked_class:
-                qraphql_type = GraphQLList(GraphQLObjectType(linked_class, {}, []))
+                maybe_graphql_type = GraphQLList(GraphQLObjectType(linked_class, {}, []))
         elif type_id in scalar_types:
-            qraphql_type = scalar_types[type_id]
+            maybe_graphql_type = scalar_types[type_id]
 
-        return qraphql_type
+        return maybe_graphql_type
 
     def _validate_non_link_definition(self, class_name, property_definition):
         """Validate that a non-link OrientDB property definition is property constructed."""

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -1,7 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from abc import ABCMeta, abstractmethod
 from itertools import chain
-from functools import lru_cache
 
 from funcy.py3 import lsplit
 from graphql.type import (

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -3,24 +3,18 @@ from abc import ABCMeta, abstractmethod
 from itertools import chain
 
 from funcy.py3 import lsplit
-from graphql.type import (
-    GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString
-)
+from graphql.type import GraphQLList, GraphQLObjectType
 import six
 
 from graphql_compiler.schema_generation.schema_properties import (
     EDGE_DESTINATION_PROPERTY_NAME, EDGE_END_NAMES, EDGE_SOURCE_PROPERTY_NAME
 )
 
-from ..schema import GraphQLAny, GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .exceptions import IllegalSchemaStateError, InvalidClassError, InvalidPropertyError
 from .schema_properties import (
     COLLECTION_PROPERTY_TYPES, ILLEGAL_PROPERTY_NAME_PREFIXES, ORIENTDB_BASE_EDGE_CLASS_NAME,
-    ORIENTDB_BASE_VERTEX_CLASS_NAME, PROPERTY_TYPE_ANY_ID, PROPERTY_TYPE_BOOLEAN_ID,
-    PROPERTY_TYPE_DATE_ID, PROPERTY_TYPE_DATETIME_ID, PROPERTY_TYPE_DECIMAL_ID,
-    PROPERTY_TYPE_DOUBLE_ID, PROPERTY_TYPE_FLOAT_ID, PROPERTY_TYPE_INTEGER_ID,
-    PROPERTY_TYPE_LONG_ID, PROPERTY_TYPE_LINK_ID, PROPERTY_TYPE_STRING_ID, PropertyDescriptor,
-    parse_default_property_value, get_graphql_scalar_type
+    ORIENTDB_BASE_VERTEX_CLASS_NAME, PROPERTY_TYPE_LINK_ID, PropertyDescriptor,
+    get_graphql_scalar_type, parse_default_property_value
 )
 from .utils import toposort_classes
 

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -6,10 +6,11 @@ from funcy.py3 import lsplit
 from graphql.type import (
     GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString
 )
+import six
+
 from graphql_compiler.schema_generation.schema_properties import (
     EDGE_DESTINATION_PROPERTY_NAME, EDGE_END_NAMES, EDGE_SOURCE_PROPERTY_NAME
 )
-import six
 
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .exceptions import IllegalSchemaStateError, InvalidClassError, InvalidPropertyError
@@ -778,4 +779,3 @@ def _get_default_value(class_name, property_definition):
                                           .format(class_name, property_definition))
 
     return default_value
-

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -679,9 +679,11 @@ class SchemaGraph(object):
         linked_type = property_definition.get('linkedType', None)
 
         validate_supported_property_type_id(name, type_id)
+
         if type_id == PROPERTY_TYPE_LINK_ID:
-            raise AssertionError(u'Found a property of type Link on a non-edge class: '
-                                 u'{} {}'.format(name, class_name))
+            raise AssertionError(u'Found a improperly named property of type Link: '
+                                 u'{} {}. Links must be named either "in" or "out"'.
+                                 format(name, class_name))
         elif type_id in COLLECTION_PROPERTY_TYPES:
             if linked_class is not None and linked_type is not None:
                 raise AssertionError(u'Property "{}" unexpectedly has both a linked class and '

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -14,7 +14,7 @@ from .exceptions import IllegalSchemaStateError, InvalidClassError, InvalidPrope
 from .schema_properties import (
     COLLECTION_PROPERTY_TYPES, ILLEGAL_PROPERTY_NAME_PREFIXES, ORIENTDB_BASE_EDGE_CLASS_NAME,
     ORIENTDB_BASE_VERTEX_CLASS_NAME, PROPERTY_TYPE_LINK_ID, PropertyDescriptor,
-    get_graphql_scalar_type, parse_default_property_value
+    get_graphql_scalar_type_or_raise, parse_default_property_value
 )
 from .utils import toposort_classes
 
@@ -640,7 +640,7 @@ class SchemaGraph(object):
                                      u'a linked type: {}'.format(name, property_definition))
             elif linked_type is not None and linked_class is None:
                 # No linked class, must be a linked native OrientDB type.
-                inner_type = get_graphql_scalar_type(name + ' inner type', linked_type)
+                inner_type = get_graphql_scalar_type_or_raise(name + ' inner type', linked_type)
                 graphql_type = GraphQLList(inner_type)
             elif linked_class is not None and linked_type is None:
                 # No linked type, must be a linked non-graph user-defined type.
@@ -661,7 +661,7 @@ class SchemaGraph(object):
                                      u'neither a linked class nor a linked type: '
                                      u'{}'.format(name, property_definition))
         else:
-            graphql_type = get_graphql_scalar_type(name, type_id)
+            graphql_type = get_graphql_scalar_type_or_raise(name, type_id)
 
         return graphql_type
 

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -663,7 +663,7 @@ class SchemaGraph(object):
                                          'a graph class. Only non-graph classes are allowed in '
                                          'collections.'
                                          .format(class_name, property_definition))
-                # Don't include the fields and implemented intefaces, this information is already
+                # Don't include the fields and implemented interfaces, this information is already
                 # stored in the SchemaGraph.
                 maybe_graphql_type = GraphQLList(GraphQLObjectType(linked_class, {}, []))
         elif type_id in scalar_types:

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -631,7 +631,7 @@ class SchemaGraph(object):
         return property_name_to_descriptor
 
     def _try_get_graphql_type(self, property_definition):
-        """Return the GraphQLType corresponding to the non-link property definition."""
+        """Return the GraphQLType corresponding to the non-link property definition or None."""
         type_id = property_definition['type']
         linked_class = property_definition.get('linkedClass', None)
         linked_type = property_definition.get('linkedType', None)
@@ -655,12 +655,12 @@ class SchemaGraph(object):
             elif linked_class:
                 qraphql_type = GraphQLList(GraphQLObjectType(linked_class, {}, []))
         elif type_id in scalar_types:
-            if type_id in scalar_types:
-                qraphql_type = scalar_types[type_id]
+            qraphql_type = scalar_types[type_id]
 
         return qraphql_type
 
     def _validate_non_link_definition(self, class_name, property_definition):
+        """Validate that a non-link OrientDB property definition is property constructed."""
         name = property_definition['name']
         type_id = property_definition['type']
         linked_class = property_definition.get('linkedClass', None)
@@ -751,6 +751,7 @@ def _get_class_fields(class_definition):
 
 
 def _get_default_value(class_name, property_definition):
+    """Return the default value of the OrientDB property."""
     default_value = None
     default_value_string = property_definition.get('defaultValue', None)
     if default_value_string is not None:

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -616,13 +616,13 @@ class SchemaGraph(object):
                                      u'more than once, this is not allowed!'
                                      .format(property_name, class_name))
 
-            graphql_type = self.get_graphql_type(class_name, property_definition)
+            graphql_type = self._get_graphql_type(class_name, property_definition)
             default_value = _get_default_value(class_name, property_definition)
             property_descriptor = PropertyDescriptor(graphql_type, default_value)
             property_name_to_descriptor[property_name] = property_descriptor
         return property_name_to_descriptor
 
-    def get_graphql_type(self, class_name, property_definition):
+    def _get_graphql_type(self, class_name, property_definition):
         """Return the GraphQLType corresponding to the non-link property definition."""
         name = property_definition['name']
         type_id = property_definition['type']
@@ -632,8 +632,8 @@ class SchemaGraph(object):
         graphql_type = None
         if type_id == PROPERTY_TYPE_LINK_ID:
             raise AssertionError(u'Found a improperly named property of type Link: '
-                                 u'{} {}. Links must be named either "in" or "out"'.
-                                 format(name, class_name))
+                                 u'{} {}. Links must be named either "in" or "out"'
+                                 .format(name, class_name))
         elif type_id in COLLECTION_PROPERTY_TYPES:
             if linked_class is not None and linked_type is not None:
                 raise AssertionError(u'Property "{}" unexpectedly has both a linked class and '

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -672,7 +672,7 @@ class SchemaGraph(object):
         return maybe_graphql_type
 
     def _validate_non_link_definition(self, class_name, property_definition):
-        """Validate that a non-link OrientDB property definition is property constructed."""
+        """Validate that a non-link OrientDB property definition is properly defined."""
         name = property_definition['name']
         type_id = property_definition['type']
         linked_class = property_definition.get('linkedClass', None)

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -1,5 +1,10 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
+from ..schema import GraphQLAny, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+from graphql.type import (
+    GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString
+)
+
 import datetime
 import time
 
@@ -90,16 +95,30 @@ PROPERTY_TYPE_ID_TO_NAME = {
     PROPERTY_TYPE_ANY_ID: PROPERTY_TYPE_ANY_NAME,
 }
 
+ORIENTDB_TO_GRAPHQL_SCALARS = {
+    PROPERTY_TYPE_ANY_ID: GraphQLAny,
+    PROPERTY_TYPE_BOOLEAN_ID: GraphQLBoolean,
+    PROPERTY_TYPE_DATE_ID: GraphQLDate,
+    PROPERTY_TYPE_DATETIME_ID: GraphQLDateTime,
+    PROPERTY_TYPE_DECIMAL_ID: GraphQLDecimal,
+    PROPERTY_TYPE_DOUBLE_ID: GraphQLFloat,
+    PROPERTY_TYPE_FLOAT_ID: GraphQLFloat,
+    PROPERTY_TYPE_INTEGER_ID: GraphQLInt,
+    PROPERTY_TYPE_LONG_ID: GraphQLInt,
+    PROPERTY_TYPE_STRING_ID: GraphQLString,
+}
+
+
 ORIENTDB_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 ORIENTDB_DATE_FORMAT = '%Y-%m-%d'
 
 
-def validate_supported_property_type_id(property_name, property_type_id):
+def get_graphql_scalar_type(property_name, property_type_id):
     """Ensure that the given property type_id is supported by the graph."""
-    if property_type_id not in PROPERTY_TYPE_ID_TO_NAME:
+    if property_type_id not in ORIENTDB_TO_GRAPHQL_SCALARS:
         raise AssertionError(u'Property "{}" has unsupported property type id: '
                              u'{}'.format(property_name, property_type_id))
-
+    return ORIENTDB_TO_GRAPHQL_SCALARS[property_type_id]
 
 def _parse_bool_default_value(property_name, default_value_string):
     """Parse and return the default value for a boolean property."""

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -111,8 +111,8 @@ ORIENTDB_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 ORIENTDB_DATE_FORMAT = '%Y-%m-%d'
 
 
-def get_graphql_scalar_type(property_name, property_type_id):
-    """Return the matching GraphQLScalarType for the OrientDB property type_id."""
+def get_graphql_scalar_type_or_raise(property_name, property_type_id):
+    """Return the matching GraphQLScalarType for the property type id, asserting it exists."""
     if property_type_id not in ORIENTDB_TO_GRAPHQL_SCALARS:
         raise AssertionError(u'Property "{}" has unsupported property type id: '
                              u'{}'.format(property_name, property_type_id))

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -1,14 +1,12 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
-from ..schema import GraphQLAny, GraphQLDate, GraphQLDateTime, GraphQLDecimal
-from graphql.type import (
-    GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString
-)
-
 import datetime
 import time
 
+from graphql.type import GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLString
 import six
+
+from ..schema import GraphQLAny, GraphQLDate, GraphQLDateTime, GraphQLDecimal
 
 
 EDGE_SOURCE_PROPERTY_NAME = 'out'
@@ -114,11 +112,12 @@ ORIENTDB_DATE_FORMAT = '%Y-%m-%d'
 
 
 def get_graphql_scalar_type(property_name, property_type_id):
-    """Ensure that the given property type_id is supported by the graph."""
+    """Return the matching scalar GraphQLScalarType for the OrientDB property type_id."""
     if property_type_id not in ORIENTDB_TO_GRAPHQL_SCALARS:
         raise AssertionError(u'Property "{}" has unsupported property type id: '
                              u'{}'.format(property_name, property_type_id))
     return ORIENTDB_TO_GRAPHQL_SCALARS[property_type_id]
+
 
 def _parse_bool_default_value(property_name, default_value_string):
     """Parse and return the default value for a boolean property."""

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -112,7 +112,7 @@ ORIENTDB_DATE_FORMAT = '%Y-%m-%d'
 
 
 def get_graphql_scalar_type(property_name, property_type_id):
-    """Return the matching scalar GraphQLScalarType for the OrientDB property type_id."""
+    """Return the matching GraphQLScalarType for the OrientDB property type_id."""
     if property_type_id not in ORIENTDB_TO_GRAPHQL_SCALARS:
         raise AssertionError(u'Property "{}" has unsupported property type id: '
                              u'{}'.format(property_name, property_type_id))

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -173,16 +173,7 @@ def parse_default_property_value(property_name, property_type_id, default_value_
 
 
 # A way to describe a property's type and associated information:
-#   - type_id: int, the OrientDB property type ID -- can be made human-readable
-#              using the above PROPERTY_TYPE_ID_TO_NAME map.
-#   - qualifier: dependent on the type_id
-#        - For Link properties, string -- the name of the class to which the Link points.
-#        - For EmbeddedSet and EmbeddedList, either:
-#              - int, the property type ID of the native OrientDB type, if the data in
-#                the collection is of a built-in OrientDB type, or
-#              - string, the name of the non-graph class representing the data in the collection.
-#        - For all other property types, None.
+#   - type_id: GraphQLType, the type of this property
 #   - default: the default value for the property, used when a record is inserted without an
 #              explicit value for this property. Set to None if no default is given in the schema.
-PropertyDescriptor = namedtuple('PropertyDescriptor',
-                                ('type_id', 'qualifier', 'default'))
+PropertyDescriptor = namedtuple('PropertyDescriptor', ('type', 'default'))

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -173,7 +173,7 @@ def parse_default_property_value(property_name, property_type_id, default_value_
 
 
 # A way to describe a property's type and associated information:
-#   - type_id: GraphQLType, the type of this property
+#   - type: GraphQLType, the type of this property
 #   - default: the default value for the property, used when a record is inserted without an
 #              explicit value for this property. Set to None if no default is given in the schema.
 PropertyDescriptor = namedtuple('PropertyDescriptor', ('type', 'default'))

--- a/graphql_compiler/tests/test_schema_generation.py
+++ b/graphql_compiler/tests/test_schema_generation.py
@@ -2,7 +2,7 @@
 import unittest
 
 from frozendict import frozendict
-from graphql.type import GraphQLList, GraphQLString
+from graphql.type import GraphQLList, GraphQLObjectType, GraphQLString
 import six
 
 from .. import get_graphql_schema_from_orientdb_schema_data
@@ -169,14 +169,14 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         self.assertEqual({'Entity', ORIENTDB_BASE_VERTEX_CLASS_NAME},
                          schema_graph.get_inheritance_set('Entity'))
 
-    def test_parse_property(self):
+    def test_parsed_property(self):
         schema_data = [
             BASE_VERTEX_SCHEMA_DATA,
             ENTITY_SCHEMA_DATA,
         ]
         schema_graph = SchemaGraph(schema_data)
         name_property = schema_graph.get_element_by_class_name('Entity').properties['name']
-        self.assertEqual(name_property.type_id, PROPERTY_TYPE_STRING_ID)
+        self.assertTrue(name_property.type.is_same_type(GraphQLString))
 
     def test_native_orientdb_collection_property(self):
         schema_data = [
@@ -186,8 +186,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         ]
         schema_graph = SchemaGraph(schema_data)
         alias_property = schema_graph.get_element_by_class_name('Person').properties['alias']
-        self.assertEqual(alias_property.type_id, PROPERTY_TYPE_EMBEDDED_SET_ID)
-        self.assertEqual(alias_property.qualifier, PROPERTY_TYPE_STRING_ID)
+        self.assertTrue(alias_property.type.is_same_type(GraphQLList(GraphQLString)))
         self.assertEqual(alias_property.default, set())
 
     def test_class_collection_property(self):
@@ -198,8 +197,8 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         schema_graph = SchemaGraph(schema_data)
         friends_property = schema_graph.get_element_by_class_name('DataPoint').properties[
             'data_source']
-        self.assertEqual(friends_property.type_id, PROPERTY_TYPE_EMBEDDED_LIST_ID)
-        self.assertEqual(friends_property.qualifier, 'ExternalSource')
+        self.assertTrue(friends_property.type.is_same_type(
+            GraphQLList(GraphQLObjectType('ExternalSource', {}))))
         self.assertEqual(friends_property.default, list())
 
     def test_link_parsing(self):

--- a/graphql_compiler/tests/test_schema_generation.py
+++ b/graphql_compiler/tests/test_schema_generation.py
@@ -76,8 +76,8 @@ DATA_POINT_SCHEMA_DATA = frozendict({
             'linkedClass': 'ExternalSource',
             'defaultValue': '[]'
         }
-
-    ]
+    ],
+    'superClass': 'V',
 })
 
 PERSON_LIVES_IN_EDGE_SCHEMA_DATA = frozendict({
@@ -191,6 +191,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
 
     def test_class_collection_property(self):
         schema_data = [
+            BASE_VERTEX_SCHEMA_DATA,
             DATA_POINT_SCHEMA_DATA,
             EXTERNAL_SOURCE_SCHEMA_DATA,
         ]


### PR DESCRIPTION
Changed the SchemaGraph's type system from OrientDB's type system to GraphQL's type system. Added GraphQLAny GraphScalarType in order to be able to represent the OrientDBAnyType. Except for OrientDB embedded lists and sets, (which both get mapped to GraphQLList), there is a one-to-one between the currently supported OrientDB types and a GraphQLType. 