### PR TITLE
Ignore unsupported properties in SchemaGraph.

### DIFF
--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -616,7 +616,7 @@ class SchemaGraph(object):
                                      .format(property_name, class_name))
 
             maybe_graphql_type = self._try_get_graphql_type(class_name, property_definition)
-            if maybe_graphql_type is None:
+            if maybe_graphql_type is not None:
                 default_value = _get_default_value(class_name, property_definition)
                 property_descriptor = PropertyDescriptor(maybe_graphql_type, default_value)
                 property_name_to_descriptor[property_name] = property_descriptor
@@ -641,7 +641,7 @@ class SchemaGraph(object):
             elif linked_type is not None and linked_class is None:
                 # No linked class, must be a linked native OrientDB type.
                 maybe_inner_type = try_get_graphql_scalar_type(name + ' inner type', linked_type)
-                if maybe_inner_type is None:
+                if maybe_inner_type is not None:
                     maybe_graphql_type = GraphQLList(maybe_inner_type)
             elif linked_class is not None and linked_type is None:
                 # No linked type, must be a linked non-graph user-defined type.

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -616,14 +616,14 @@ class SchemaGraph(object):
                                      .format(property_name, class_name))
 
             maybe_graphql_type = self._try_get_graphql_type(class_name, property_definition)
-            if maybe_graphql_type:
+            if maybe_graphql_type is None:
                 default_value = _get_default_value(class_name, property_definition)
                 property_descriptor = PropertyDescriptor(maybe_graphql_type, default_value)
                 property_name_to_descriptor[property_name] = property_descriptor
         return property_name_to_descriptor
 
     def _try_get_graphql_type(self, class_name, property_definition):
-        """Return the GraphQLType corresponding to the non-link property definition or None."""
+        """Return the matching GraphQLType for the non-link property or None if none exists."""
         name = property_definition['name']
         type_id = property_definition['type']
         linked_class = property_definition.get('linkedClass', None)
@@ -641,7 +641,7 @@ class SchemaGraph(object):
             elif linked_type is not None and linked_class is None:
                 # No linked class, must be a linked native OrientDB type.
                 maybe_inner_type = try_get_graphql_scalar_type(name + ' inner type', linked_type)
-                if maybe_inner_type:
+                if maybe_inner_type is None:
                     maybe_graphql_type = GraphQLList(maybe_inner_type)
             elif linked_class is not None and linked_type is None:
                 # No linked type, must be a linked non-graph user-defined type.

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -2,6 +2,7 @@
 from collections import namedtuple
 import datetime
 import time
+import warnings
 
 from graphql.type import GraphQLBoolean, GraphQLFloat, GraphQLInt, GraphQLString
 import six
@@ -111,12 +112,12 @@ ORIENTDB_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 ORIENTDB_DATE_FORMAT = '%Y-%m-%d'
 
 
-def get_graphql_scalar_type_or_raise(property_name, property_type_id):
-    """Return the matching GraphQLScalarType for the property type id, asserting it exists."""
+def try_get_graphql_scalar_type(property_name, property_type_id):
+    """Return the matching GraphQLScalarType for the property type id or None."""
     if property_type_id not in ORIENTDB_TO_GRAPHQL_SCALARS:
-        raise AssertionError(u'Property "{}" has unsupported property type id: '
-                             u'{}'.format(property_name, property_type_id))
-    return ORIENTDB_TO_GRAPHQL_SCALARS[property_type_id]
+        warnings.warn(u'Ignoring property "{}" with unsupported property type id: 'u'{}'
+                      .format(property_name, property_type_id))
+    return ORIENTDB_TO_GRAPHQL_SCALARS.get(property_type_id, None)
 
 
 def _parse_bool_default_value(property_name, default_value_string):

--- a/graphql_compiler/schema_generation/schema_properties.py
+++ b/graphql_compiler/schema_generation/schema_properties.py
@@ -113,11 +113,12 @@ ORIENTDB_DATE_FORMAT = '%Y-%m-%d'
 
 
 def try_get_graphql_scalar_type(property_name, property_type_id):
-    """Return the matching GraphQLScalarType for the property type id or None."""
-    if property_type_id not in ORIENTDB_TO_GRAPHQL_SCALARS:
+    """Return the matching GraphQLScalarType for the property type id or None if none exists."""
+    maybe_graphql_type = ORIENTDB_TO_GRAPHQL_SCALARS.get(property_type_id, None)
+    if not maybe_graphql_type:
         warnings.warn(u'Ignoring property "{}" with unsupported property type id: 'u'{}'
                       .format(property_name, property_type_id))
-    return ORIENTDB_TO_GRAPHQL_SCALARS.get(property_type_id, None)
+    return maybe_graphql_type
 
 
 def _parse_bool_default_value(property_name, default_value_string):


### PR DESCRIPTION
Instead of requiring all properties to have supported types, I ignore those that don't and issue a warning. Next PR will focus on removing GraphQLAny type. 