### PR TITLE
Move schema element linking to SchemaGraph

### DIFF
--- a/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
+++ b/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
@@ -434,7 +434,8 @@ def _try_get_base_connections(class_name, superclass_sets, links, abstract):
         base_connections.get(EDGE_DESTINATION_PROPERTY_NAME, None),
     )
 
-def _get_graphql_rep_of_non_graph_elements(non_graph_elements, inheritance_sets):
+
+def _get_graphql_rep_of_non_graph_elements(non_graph_elements, superclass_sets):
     """Return a dict mapping name to GraphQL Object for non graph elements without superclasses."""
     graphql_reps = {}
     for element_name, element in six.iteritems(non_graph_elements):

--- a/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
+++ b/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
@@ -76,7 +76,7 @@ def get_orientdb_schema_graph(schema_data):
     }
 
     non_graph_elements = _get_non_graph_elements(class_name_to_definition, superclass_sets)
-    inner_collection_objs = _get_graphql_rep_of_non_graph_elements(
+    inner_collection_objs = _get_graphql_representation_of_non_graph_elements(
         non_graph_elements, superclass_sets)
 
     elements = non_graph_elements
@@ -435,7 +435,7 @@ def _try_get_base_connections(class_name, superclass_sets, links, abstract):
     )
 
 
-def _get_graphql_rep_of_non_graph_elements(non_graph_elements, superclass_sets):
+def _get_graphql_representation_of_non_graph_elements(non_graph_elements, superclass_sets):
     """Return a dict mapping name to GraphQL Object for non graph elements without superclasses."""
     graphql_reps = {}
     for element_name, element in six.iteritems(non_graph_elements):

--- a/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
+++ b/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
@@ -8,7 +8,7 @@ import six
 from ..exceptions import IllegalSchemaStateError
 from ..schema_graph import (
     EdgeType, NonGraphElement, PropertyDescriptor, SchemaGraph, VertexType,
-    get_subclass_sets_from_inheritance_sets, link_schema_elements
+    get_subclass_sets_from_superclass_sets, link_schema_elements
 )
 from .schema_properties import (
     COLLECTION_PROPERTY_TYPES, EDGE_DESTINATION_PROPERTY_NAME, EDGE_END_NAMES,

--- a/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
+++ b/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
@@ -87,7 +87,7 @@ def get_orientdb_schema_graph(schema_data):
 
     # Initialize the connections that show which schema classes can be connected to
     # which other schema classes, then freeze all schema elements.
-    link_schema_elements(elements, inheritance_sets)
+    link_schema_elements(elements, superclass_sets)
     for element in six.itervalues(elements):
         element.freeze()
 

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -373,13 +373,6 @@ def get_subclass_sets_from_inheritance_sets(inheritance_sets):
     return subclass_sets
 
 
-# A way to describe a property's type and associated information:
-#   - type: GraphQLType, the type of this property
-#   - default: the default value for the property, used when a record is inserted without an
-#              explicit value for this property. Set to None if no default is given in the schema.
-PropertyDescriptor = namedtuple('PropertyDescriptor', ('type', 'default'))
-
-
 def link_schema_elements(elements, inheritance_sets):
     """For each edge, link the schema elements it connects to each other."""
     subclass_sets = get_subclass_sets_from_inheritance_sets(inheritance_sets)
@@ -406,3 +399,10 @@ def link_schema_elements(elements, inheritance_sets):
             to_schema_element = elements[to_class]
             edge_schema_element.out_connections.add(to_class)
             to_schema_element.in_connections.add(edge_class_name)
+
+
+# A way to describe a property's type and associated information:
+#   - type: GraphQLType, the type of this property
+#   - default: the default value for the property, used when a record is inserted without an
+#              explicit value for this property. Set to None if no default is given in the schema.
+PropertyDescriptor = namedtuple('PropertyDescriptor', ('type', 'default'))

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -373,9 +373,9 @@ def get_subclass_sets_from_superclass_sets(superclass_sets):
     return subclass_sets
 
 
-def link_schema_elements(elements, inheritance_sets):
+def link_schema_elements(elements, superclass_sets):
     """For each edge, link the schema elements it connects to each other."""
-    subclass_sets = get_subclass_sets_from_inheritance_sets(inheritance_sets)
+    subclass_sets = get_subclass_sets_from_superclass_sets(superclass_sets)
 
     for edge_class_name in _get_element_names_of_class(elements, EdgeType):
         edge_element = elements[edge_class_name]

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -349,7 +349,7 @@ def _validate_property_names(class_name, properties):
 
 
 def _get_element_names_of_class(elements, cls):
-    """Return a frozenset of the names of the elements are instances of the class."""
+    """Return a frozenset of the names of the elements that are instances of the class."""
     return frozenset({
         name
         for name, element in elements.items()


### PR DESCRIPTION
This method is not OrientDB specific and I plan to use reuse it for the SQLAlchemy SchemaGraph generation. 