### PR TITLE
Schema for macro definitions

### DIFF
--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -175,6 +175,7 @@ def get_schema_for_macro_definition(schema):
     macro editors, enabling them to autocomplete on the @macro_edge_definition and
     @macro_edge_target directives. Some directives that are disallowed in macro edge definitions,
     like @output and @output_source, will be removed from the directives list.
+    Raises an error if any non-default directives are present in the given schema.
 
     Args:
         schema: GraphQLSchema over which we want to write macros

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -10,7 +10,6 @@ from graphql import parse
 from graphql.language.printer import print_ast
 from graphql.utils.build_ast_schema import build_ast_schema
 from graphql.utils.schema_printer import print_schema
-from graphql_compiler.schema import DIRECTIVES
 
 from ..compiler.compiler_frontend import validate_schema_and_ast
 from ..ast_manipulation import safe_parse_graphql
@@ -20,7 +19,7 @@ from .macro_edge.directives import (MacroEdgeDirective,
                                     DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION,
                                     DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
 from .macro_expansion import expand_macros_in_query_ast
-from ..exceptions import GraphQLInvalidMacroError, GraphQLValidationError, GraphQLCompilationError
+from ..exceptions import GraphQLInvalidMacroError, GraphQLValidationError
 
 
 MacroRegistry = namedtuple(
@@ -170,9 +169,8 @@ def get_schema_with_macros(macro_registry):
 def get_schema_for_macro_definition(schema):
     """Returns a schema with macro directives.
 
-    Precondition:
+    Preconditions:
     1. No user-created directives are in schema.
-
     This returned schema can be used to validate macro definitions, and support GraphQL
     macro editors, enabling them to autocomplete on the @macro_edge_definition and
     @macro_edge_target directives. Some directives that are disallowed in macro edge definitions,
@@ -187,12 +185,11 @@ def get_schema_for_macro_definition(schema):
 
     macro_definition_schema = copy(schema)
     macro_definition_schema_directives_set = set(macro_definition_schema.get_directives())
+
     # Include required directives
-    macro_definition_schema_directives_set += DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
+    macro_definition_schema_directives_set |= set(DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
     # Exclude disallowed directives
-    for directive in macro_definition_schema_directives_set:
-        if directive.name not in DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION:
-            macro_definition_schema_directives_set.remove(directive)
+    macro_definition_schema_directives_set &= set(DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION)
 
     # pylint: disable=protected-access
     macro_definition_schema._directives = list(macro_definition_schema_directives_set)

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -17,7 +17,7 @@ from .macro_edge import make_macro_edge_descriptor
 from .macro_edge.helpers import get_type_at_macro_edge_target
 from .macro_edge.directives import (MacroEdgeDirective, DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION,
                                     DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
-from ..schema import _check_for_nondefault_directives
+from ..schema import _check_for_nondefault_directive_names
 from .macro_expansion import expand_macros_in_query_ast
 from ..exceptions import GraphQLInvalidMacroError, GraphQLValidationError
 
@@ -169,6 +169,9 @@ def get_schema_with_macros(macro_registry):
 def get_schema_for_macro_definition(schema):
     """Returns a schema with macro directives.
 
+    Preconditions:
+    1. All compiler-supported and graphql-default directives have their default behavior.
+
     This returned schema can be used to validate macro definitions, and support GraphQL
     macro editors, enabling them to autocomplete on the @macro_edge_definition and
     @macro_edge_target directives. Some directives that are disallowed in macro edge definitions,
@@ -181,11 +184,11 @@ def get_schema_for_macro_definition(schema):
         GraphQLSchema usable for writing macros. Modifying this schema is undefined behavior.
 
     Raises:
-        AssertionError, if the schema contains directives that are non-default.
+        AssertionError, if the schema contains directive names that are non-default.
     """
     macro_definition_schema = copy(schema)
     macro_definition_schema_directives = schema.get_directives()
-    _check_for_nondefault_directives(macro_definition_schema_directives)
+    _check_for_nondefault_directive_names(macro_definition_schema_directives)
     macro_definition_schema_directives += DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
     # Remove disallowed directives from directives list
     macro_definition_schema_directives = list(set(macro_definition_schema_directives) &

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -16,6 +16,7 @@ from ..ast_manipulation import safe_parse_graphql
 from .macro_edge import make_macro_edge_descriptor
 from .macro_edge.helpers import get_type_at_macro_edge_target
 from .macro_edge.directives import (MacroEdgeDirective,
+                                    DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION,
                                     DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
 from .macro_expansion import expand_macros_in_query_ast
 from ..exceptions import GraphQLInvalidMacroError, GraphQLValidationError
@@ -168,9 +169,6 @@ def get_schema_with_macros(macro_registry):
 def get_schema_for_macro_definition(schema):
     """Returns a schema with macro directives.
 
-    Preconditions:
-    1. Only default directives are present in the given schema.
-
     This returned schema can be used to validate macro definitions, and support GraphQL
     macro editors, enabling them to autocomplete on the @macro_edge_definition and
     @macro_edge_target directives. Some directives that are disallowed in macro edge definitions,
@@ -183,8 +181,10 @@ def get_schema_for_macro_definition(schema):
         GraphQLSchema usable for writing macros
     """
     macro_definition_schema = copy(schema)
-    macro_definition_schema_directives_set = macro_definition_schema.get_directives() + \
-        DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
+    macro_definition_schema_directives_set = set(macro_definition_schema.get_directives()).union(
+        DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
+    # Exclude disallowed directives
+    macro_definition_schema_directives_set &= DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION
 
     # pylint: disable=protected-access
     macro_definition_schema._directives = list(macro_definition_schema_directives_set)

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -173,7 +173,6 @@ def get_schema_for_macro_definition(schema):
     macro editors, enabling them to autocomplete on the @macro_edge_definition and
     @macro_edge_target directives. Some directives that are disallowed in macro edge definitions,
     like @output and @output_source, will be removed from the directives list.
-    Raises an error if any non-default directives are present in the given schema.
 
     Args:
         schema: GraphQLSchema over which we want to write macros
@@ -196,7 +195,7 @@ def get_schema_for_macro_definition(schema):
     macro_definition_schema._directives = macro_definition_schema_directives
     # pylint: enable=protected-access
     return macro_definition_schema
-`
+
 
 def perform_macro_expansion(macro_registry, graphql_with_macro, graphql_args):
     """Return a new GraphQL query string and args, after expanding any encountered macros.

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
+from copy import copy
 import six
 
 from graphql.language.ast import (FieldDefinition, Name, NamedType,
@@ -14,7 +15,8 @@ from ..compiler.compiler_frontend import validate_schema_and_ast
 from ..ast_manipulation import safe_parse_graphql
 from .macro_edge import make_macro_edge_descriptor
 from .macro_edge.helpers import get_type_at_macro_edge_target
-from .macro_edge.directives import MacroEdgeDirective
+from .macro_edge.directives import (MacroEdgeDirective,
+                                    DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
 from .macro_expansion import expand_macros_in_query_ast
 from ..exceptions import GraphQLInvalidMacroError, GraphQLValidationError
 
@@ -166,9 +168,13 @@ def get_schema_with_macros(macro_registry):
 def get_schema_for_macro_definition(schema):
     """Returns a schema with macro directives.
 
+    Preconditions:
+    1. Only default directives are present in the given schema.
+
     This returned schema can be used to validate macro definitions, and support GraphQL
-    macro editors, enabling them to autocomplete one the @macro_edge_definition and
-    @macro_edge_target directives.
+    macro editors, enabling them to autocomplete on the @macro_edge_definition and
+    @macro_edge_target directives. Some directives that are disallowed in macro edge definitions,
+    like @output and @output_source, will be removed from the directives list.
 
     Args:
         schema: GraphQLSchema over which we want to write macros
@@ -176,7 +182,15 @@ def get_schema_for_macro_definition(schema):
     Returns:
         GraphQLSchema usable for writing macros
     """
-    raise NotImplementedError()  # TODO(bojanserafimov): Implement
+    macro_definition_schema = copy(schema)
+    macro_definition_schema_directives_set = macro_definition_schema.get_directives() + \
+    	DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
+        
+
+    # pylint: disable=protected-access
+    macro_definition_schema._directives = list(macro_definition_schema_directives_set)
+    # pylint: enable=protected-access
+    return macro_definition_schema
 
 
 def perform_macro_expansion(macro_registry, graphql_with_macro, graphql_args):

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -184,8 +184,7 @@ def get_schema_for_macro_definition(schema):
     """
     macro_definition_schema = copy(schema)
     macro_definition_schema_directives_set = macro_definition_schema.get_directives() + \
-    	DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
-        
+        DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
 
     # pylint: disable=protected-access
     macro_definition_schema._directives = list(macro_definition_schema_directives_set)

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -171,6 +171,7 @@ def get_schema_for_macro_definition(schema):
 
     Preconditions:
     1. No user-created directives are in schema.
+    
     This returned schema can be used to validate macro definitions, and support GraphQL
     macro editors, enabling them to autocomplete on the @macro_edge_definition and
     @macro_edge_target directives. Some directives that are disallowed in macro edge definitions,

--- a/graphql_compiler/macros/macro_edge/directives.py
+++ b/graphql_compiler/macros/macro_edge/directives.py
@@ -57,9 +57,7 @@ DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION = frozenset({
 DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION = frozenset({
     FoldDirective,
     FilterDirective,
-    MacroEdgeDefinitionDirective,
-    MacroEdgeTargetDirective,
     OptionalDirective,
     TagDirective,
     RecurseDirective,
-})
+}.union(DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION))

--- a/graphql_compiler/macros/macro_edge/helpers.py
+++ b/graphql_compiler/macros/macro_edge/helpers.py
@@ -12,7 +12,10 @@ from ...compiler.helpers import (
     is_tagged_parameter
 )
 from ...schema import FilterDirective, TagDirective
-from ..macro_edge.directives import MacroEdgeTargetDirective
+from ..macro_edge.directives import (
+    DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION, DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION,
+    MacroEdgeTargetDirective
+)
 
 
 def _yield_ast_nodes_with_directives(ast):
@@ -424,3 +427,13 @@ def omit_ast_from_ast_selections(ast, ast_to_omit):
         new_ast.selection_set = SelectionSet(selections_to_keep)
 
     return new_ast
+
+
+def include_required_macro_directives(directives):
+    """Return list with added macro-definition-specific directives to the given directives list"""
+    return list(set(directives) | DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
+
+
+def exclude_disallowed_directives_in_macros(directives):
+    """Return list with disallowed directives in macros removed from the given directives list"""
+    return list(set(directives) & set(DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION))

--- a/graphql_compiler/macros/macro_edge/helpers.py
+++ b/graphql_compiler/macros/macro_edge/helpers.py
@@ -12,10 +12,7 @@ from ...compiler.helpers import (
     is_tagged_parameter
 )
 from ...schema import FilterDirective, TagDirective
-from ..macro_edge.directives import (
-    DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION, DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION,
-    MacroEdgeTargetDirective
-)
+from ..macro_edge.directives import MacroEdgeTargetDirective
 
 
 def _yield_ast_nodes_with_directives(ast):
@@ -427,13 +424,3 @@ def omit_ast_from_ast_selections(ast, ast_to_omit):
         new_ast.selection_set = SelectionSet(selections_to_keep)
 
     return new_ast
-
-
-def include_required_macro_directives(directives):
-    """Return list with added macro-definition-specific directives to the given directives list"""
-    return list(set(directives) | DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
-
-
-def exclude_disallowed_directives_in_macros(directives):
-    """Return list with disallowed directives in macros removed from the given directives list"""
-    return list(set(directives) & set(DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION))

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -292,6 +292,7 @@ DIRECTIVES = (
     FoldDirective,
 )
 
+
 TYPENAME_META_FIELD_NAME = '__typename'  # This meta field is built-in.
 COUNT_META_FIELD_NAME = '_x_count'
 

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -354,10 +354,10 @@ def insert_meta_fields_into_existing_schema(graphql_schema):
 def _check_for_nondefault_macro_directives(directives):
     """Check if any user-created directives are present"""
     deprecated_directive_names = {'deprecated', 'skip', 'include'}
-    default_directive_names = {d.name for d in DIRECTIVES}
+    default_directive_names = {directive.name for directive in DIRECTIVES}
     expected_directive_names = deprecated_directive_names | default_directive_names
     nondefault_directive_names_found = {directive.name for directive in directives} - \
         expected_directive_names
     if nondefault_directive_names_found != set():
-        raise AssertionError(u'Unexpected non-default directive found: {}'.format(
-            [directive.name for directive in nondefault_directive_names_found]))
+        raise AssertionError(u'Unexpected non-default directives found: {}'.format(
+            nondefault_directive_names_found))

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -349,3 +349,15 @@ def insert_meta_fields_into_existing_schema(graphql_schema):
                                      .format(meta_field_name))
 
             type_obj.fields[meta_field_name] = meta_field
+
+
+def _check_for_nondefault_macro_directives(directives):
+    """Check if any user-created directives are present"""
+    deprecated_directive_names = {'deprecated', 'skip', 'include'}
+    default_directive_names = {d.name for d in DIRECTIVES}
+    expected_directive_names = deprecated_directive_names | default_directive_names
+    nondefault_directive_names_found = {directive.name for directive in directives} - \
+        expected_directive_names
+    if nondefault_directive_names_found != set():
+        raise AssertionError(u'Unexpected non-default directive found: {}'.format(
+            [directive.name for directive in nondefault_directive_names_found]))

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -351,13 +351,15 @@ def insert_meta_fields_into_existing_schema(graphql_schema):
             type_obj.fields[meta_field_name] = meta_field
 
 
-def _check_for_nondefault_macro_directives(directives):
+def _check_for_nondefault_directives(directives):
     """Check if any user-created directives are present"""
     deprecated_directive_names = {'deprecated', 'skip', 'include'}
     default_directive_names = {directive.name for directive in DIRECTIVES}
     expected_directive_names = deprecated_directive_names | default_directive_names
-    nondefault_directive_names_found = {directive.name for directive in directives} - \
-        expected_directive_names
+    nondefault_directive_names_found = {
+        directive.name
+        for directive in directives
+    } - expected_directive_names
     if nondefault_directive_names_found != set():
         raise AssertionError(u'Unexpected non-default directives found: {}'.format(
             nondefault_directive_names_found))

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -9,6 +9,7 @@ from graphql import (
     GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLScalarType,
     GraphQLString
 )
+from graphql.type.directives import specified_directives
 import six
 
 
@@ -291,7 +292,6 @@ DIRECTIVES = (
     FoldDirective,
 )
 
-
 TYPENAME_META_FIELD_NAME = '__typename'  # This meta field is built-in.
 COUNT_META_FIELD_NAME = '_x_count'
 
@@ -351,15 +351,17 @@ def insert_meta_fields_into_existing_schema(graphql_schema):
             type_obj.fields[meta_field_name] = meta_field
 
 
-def _check_for_nondefault_directives(directives):
+def _check_for_nondefault_directive_names(directives):
     """Check if any user-created directives are present"""
-    deprecated_directive_names = {'deprecated', 'skip', 'include'}
-    default_directive_names = {directive.name for directive in DIRECTIVES}
-    expected_directive_names = deprecated_directive_names | default_directive_names
-    nondefault_directive_names_found = {
+    # Include compiler-supported directives, and the default directives graphql defines.
+    expected_directive_names = {
         directive.name
-        for directive in directives
-    } - expected_directive_names
-    if nondefault_directive_names_found != set():
+        for directive in DIRECTIVES + tuple(specified_directives)
+    }
+
+    directive_names = {directive.name for directive in directives}
+
+    nondefault_directives_found = directive_names - expected_directive_names
+    if nondefault_directives_found != set():
         raise AssertionError(u'Unexpected non-default directives found: {}'.format(
-            nondefault_directive_names_found))
+            nondefault_directives_found))

--- a/graphql_compiler/tests/test_macro_schema.py
+++ b/graphql_compiler/tests/test_macro_schema.py
@@ -3,12 +3,13 @@ import unittest
 
 from graphql.type import GraphQLList
 from graphql.utils.schema_printer import print_schema
-import pytest
+from graphql.validation import validate
 
+from ..ast_manipulation import safe_parse_graphql
 from ..macros import get_schema_for_macro_definition, get_schema_with_macros
-from ..macros.macro_edge.directives import (DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION,
-                                            DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
-from ..macros.macro_edge.validation import get_and_validate_macro_edge_info
+from ..macros.macro_edge.directives import (
+    DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION, DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
+)
 from .test_helpers import get_empty_test_macro_registry, get_test_macro_registry
 
 
@@ -57,15 +58,94 @@ class MacroSchemaTests(unittest.TestCase):
             self.assertTrue(directive.name != '@output')
             self.assertTrue(directive.name != '@output_source')
 
-    @pytest.mark.skip('unimplemented test')
     def test_get_schema_for_macro_definition_validation(self):
-        return
-        # partial_schema_with_macros = self.macro_registry.schema_without_macros
-        # macro_definition_schema = get_schema_for_macro_definition(partial_schema_with_macros)
-        # args = {}
-        #
-        # # TODO: validate macro edges using the generated schema
-        #
-        # for macro, partner in self.macro_registry.macro_edges.items():
-        #     get_and_validate_macro_edge_info(macro_definition_schema, partner, macro[1],
-        #                                      self.macro_registry.type_equivalence_hints)
+        macro_definition_schema = get_schema_for_macro_definition(
+            self.macro_registry.schema_without_macros)
+        valid_macro_definitions = [
+            '''{
+                Entity @macro_edge_definition(name: "out_Entity_AlmostRelated") {
+                    out_Entity_Related {
+                        out_Entity_Related @macro_edge_target{
+                            uuid
+                        }
+                    }
+                }
+            }''',
+            '''{
+                Animal @macro_edge_definition(name: "out_Animal_GrandparentOf") {
+                    out_Animal_ParentOf {
+                        out_Animal_ParentOf @macro_edge_target {
+                            uuid
+                        }
+                    }
+                }
+            }''',
+            '''{
+                Animal @macro_edge_definition(name: "out_Animal_GrandchildrenCalledNate") {
+                    out_Animal_ParentOf {
+                        out_Animal_ParentOf @filter(op_name: "name_or_alias", value: ["$wanted"])
+                                            @macro_edge_target {
+                            uuid
+                        }
+                    }
+                }
+            }''',
+            '''{
+                Animal @macro_edge_definition(name: "out_Animal_RichSiblings") {
+                    in_Animal_ParentOf {
+                        net_worth @tag(tag_name: "parent_net_worth")
+                        out_Animal_ParentOf @macro_edge_target {
+                            net_worth @filter(op_name: ">", value: ["%parent_net_worth"])
+                        }
+                    }
+                }
+            }''',
+            '''{
+                Location @macro_edge_definition(name: "out_Location_Orphans") {
+                    in_Animal_LivesIn @macro_edge_target {
+                        in_Animal_ParentOf @filter(op_name: "has_edge_degree",
+                                                   value: ["$num_parents"])
+                                           @optional {
+                            uuid
+                        }
+                    }
+                }
+            }''',
+            '''{
+                Animal @macro_edge_definition(name: "out_Animal_RichYoungerSiblings") {
+                    net_worth @tag(tag_name: "net_worth")
+                    out_Animal_BornAt {
+                        event_date @tag(tag_name: "birthday")
+                    }
+                    in_Animal_ParentOf {
+                        out_Animal_ParentOf @macro_edge_target {
+                            net_worth @filter(op_name: ">", value: ["%net_worth"])
+                            out_Animal_BornAt {
+                                event_date @filter(op_name: "<", value: ["%birthday"])
+                            }
+                        }
+                    }
+                }
+            }''',
+            '''{
+                Animal @macro_edge_definition(name: "out_Animal_RelatedFood") {
+                    in_Entity_Related {
+                        ... on Food @macro_edge_target {
+                            uuid
+                        }
+                    }
+                }
+            }''',
+            '''{
+                Animal @macro_edge_definition(name: "out_Animal_RelatedEntity") {
+                    in_Entity_Related {
+                        ... on Entity @macro_edge_target {
+                            uuid
+                        }
+                    }
+                }
+            }''']
+
+        for macro in valid_macro_definitions:
+            macro_edge_definition_ast = safe_parse_graphql(macro)
+            validate(macro_definition_schema, macro_edge_definition_ast)

--- a/graphql_compiler/tests/test_macro_schema.py
+++ b/graphql_compiler/tests/test_macro_schema.py
@@ -10,6 +10,7 @@ from ..macros import get_schema_for_macro_definition, get_schema_with_macros
 from ..macros.macro_edge.directives import (
     DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION, DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
 )
+from ..schema import OutputDirective, OutputSourceDirective
 from .test_helpers import VALID_MACROS_TEXT, get_empty_test_macro_registry, get_test_macro_registry
 
 
@@ -55,8 +56,8 @@ class MacroSchemaTests(unittest.TestCase):
         schema_with_macros = get_schema_with_macros(self.macro_registry)
         macro_definition_schema = get_schema_for_macro_definition(schema_with_macros)
         for directive in macro_definition_schema.get_directives():
-            self.assertTrue(directive.name != 'output')
-            self.assertTrue(directive.name != 'output_source')
+            self.assertTrue(directive.name != OutputDirective.name)
+            self.assertTrue(directive.name != OutputSourceDirective.name)
 
     def test_get_schema_for_macro_definition_validation(self):
         macro_definition_schema = get_schema_for_macro_definition(

--- a/graphql_compiler/tests/test_macro_schema.py
+++ b/graphql_compiler/tests/test_macro_schema.py
@@ -10,7 +10,7 @@ from ..macros import get_schema_for_macro_definition, get_schema_with_macros
 from ..macros.macro_edge.directives import (
     DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION, DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
 )
-from .test_helpers import get_empty_test_macro_registry, get_test_macro_registry
+from .test_helpers import VALID_MACROS_TEXT, get_empty_test_macro_registry, get_test_macro_registry
 
 
 class MacroSchemaTests(unittest.TestCase):
@@ -55,97 +55,13 @@ class MacroSchemaTests(unittest.TestCase):
         schema_with_macros = get_schema_with_macros(self.macro_registry)
         macro_definition_schema = get_schema_for_macro_definition(schema_with_macros)
         for directive in macro_definition_schema.get_directives():
-            self.assertTrue(directive.name != '@output')
-            self.assertTrue(directive.name != '@output_source')
+            self.assertTrue(directive.name != 'output')
+            self.assertTrue(directive.name != 'output_source')
 
     def test_get_schema_for_macro_definition_validation(self):
         macro_definition_schema = get_schema_for_macro_definition(
             self.macro_registry.schema_without_macros)
-        valid_macro_definitions = [
-            '''{
-                Entity @macro_edge_definition(name: "out_Entity_AlmostRelated") {
-                    out_Entity_Related {
-                        out_Entity_Related @macro_edge_target{
-                            uuid
-                        }
-                    }
-                }
-            }''',
-            '''{
-                Animal @macro_edge_definition(name: "out_Animal_GrandparentOf") {
-                    out_Animal_ParentOf {
-                        out_Animal_ParentOf @macro_edge_target {
-                            uuid
-                        }
-                    }
-                }
-            }''',
-            '''{
-                Animal @macro_edge_definition(name: "out_Animal_GrandchildrenCalledNate") {
-                    out_Animal_ParentOf {
-                        out_Animal_ParentOf @filter(op_name: "name_or_alias", value: ["$wanted"])
-                                            @macro_edge_target {
-                            uuid
-                        }
-                    }
-                }
-            }''',
-            '''{
-                Animal @macro_edge_definition(name: "out_Animal_RichSiblings") {
-                    in_Animal_ParentOf {
-                        net_worth @tag(tag_name: "parent_net_worth")
-                        out_Animal_ParentOf @macro_edge_target {
-                            net_worth @filter(op_name: ">", value: ["%parent_net_worth"])
-                        }
-                    }
-                }
-            }''',
-            '''{
-                Location @macro_edge_definition(name: "out_Location_Orphans") {
-                    in_Animal_LivesIn @macro_edge_target {
-                        in_Animal_ParentOf @filter(op_name: "has_edge_degree",
-                                                   value: ["$num_parents"])
-                                           @optional {
-                            uuid
-                        }
-                    }
-                }
-            }''',
-            '''{
-                Animal @macro_edge_definition(name: "out_Animal_RichYoungerSiblings") {
-                    net_worth @tag(tag_name: "net_worth")
-                    out_Animal_BornAt {
-                        event_date @tag(tag_name: "birthday")
-                    }
-                    in_Animal_ParentOf {
-                        out_Animal_ParentOf @macro_edge_target {
-                            net_worth @filter(op_name: ">", value: ["%net_worth"])
-                            out_Animal_BornAt {
-                                event_date @filter(op_name: "<", value: ["%birthday"])
-                            }
-                        }
-                    }
-                }
-            }''',
-            '''{
-                Animal @macro_edge_definition(name: "out_Animal_RelatedFood") {
-                    in_Entity_Related {
-                        ... on Food @macro_edge_target {
-                            uuid
-                        }
-                    }
-                }
-            }''',
-            '''{
-                Animal @macro_edge_definition(name: "out_Animal_RelatedEntity") {
-                    in_Entity_Related {
-                        ... on Entity @macro_edge_target {
-                            uuid
-                        }
-                    }
-                }
-            }''']
 
-        for macro in valid_macro_definitions:
+        for macro, _ in VALID_MACROS_TEXT:
             macro_edge_definition_ast = safe_parse_graphql(macro)
             validate(macro_definition_schema, macro_edge_definition_ast)

--- a/graphql_compiler/tests/test_macro_schema.py
+++ b/graphql_compiler/tests/test_macro_schema.py
@@ -1,12 +1,13 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 import unittest
 
-from graphql import parse
 from graphql.type import GraphQLList
 from graphql.utils.schema_printer import print_schema
+import pytest
 
 from ..macros import get_schema_for_macro_definition, get_schema_with_macros
-from ..macros.macro_edge.directives import DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
+from ..macros.macro_edge.directives import (DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION,
+                                            DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION)
 from ..macros.macro_edge.validation import get_and_validate_macro_edge_info
 from .test_helpers import get_empty_test_macro_registry, get_test_macro_registry
 
@@ -42,6 +43,13 @@ class MacroSchemaTests(unittest.TestCase):
         for directive in DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION:
             self.assertTrue(directive in macro_definition_schema.get_directives())
 
+    def test_get_schema_for_macro_definition_retain(self):
+        original_schema = self.macro_registry.schema_without_macros
+        macro_definition_schema = get_schema_for_macro_definition(original_schema)
+        for directive in original_schema.get_directives():
+            if directive in DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION:
+                self.assertTrue(directive in macro_definition_schema.get_directives())
+
     def test_get_schema_for_macro_definition_removal(self):
         schema_with_macros = get_schema_with_macros(self.macro_registry)
         macro_definition_schema = get_schema_for_macro_definition(schema_with_macros)
@@ -49,14 +57,15 @@ class MacroSchemaTests(unittest.TestCase):
             self.assertTrue(directive.name != '@output')
             self.assertTrue(directive.name != '@output_source')
 
-	@pytest.mark.skip(reason="unimplemented test")
+    @pytest.mark.skip('unimplemented test')
     def test_get_schema_for_macro_definition_validation(self):
-        schema_with_macros = get_schema_with_macros(self.macro_registry)
-        macro_definition_schema = get_schema_for_macro_definition(schema_with_macros)
-        args = {}
-
-        # TODO: validate macro edges using the generated schema
-
-        # get_and_validate_macro_edge_info(macro_definition_schema, schema_ast, args,
-        #     self.macro_registry.type_equivalence_hints)
-
+        return
+        # partial_schema_with_macros = self.macro_registry.schema_without_macros
+        # macro_definition_schema = get_schema_for_macro_definition(partial_schema_with_macros)
+        # args = {}
+        #
+        # # TODO: validate macro edges using the generated schema
+        #
+        # for macro, partner in self.macro_registry.macro_edges.items():
+        #     get_and_validate_macro_edge_info(macro_definition_schema, partner, macro[1],
+        #                                      self.macro_registry.type_equivalence_hints)

--- a/graphql_compiler/tests/test_macro_schema.py
+++ b/graphql_compiler/tests/test_macro_schema.py
@@ -1,10 +1,13 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 import unittest
 
+from graphql import parse
 from graphql.type import GraphQLList
 from graphql.utils.schema_printer import print_schema
 
-from ..macros import get_schema_with_macros
+from ..macros import get_schema_for_macro_definition, get_schema_with_macros
+from ..macros.macro_edge.directives import DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
+from ..macros.macro_edge.validation import get_and_validate_macro_edge_info
 from .test_helpers import get_empty_test_macro_registry, get_test_macro_registry
 
 
@@ -32,3 +35,27 @@ class MacroSchemaTests(unittest.TestCase):
             'Animal').fields['out_Animal_RelatedFood'].type
         self.assertTrue(isinstance(related_food_target_type, GraphQLList))
         self.assertEqual('Food', related_food_target_type.of_type.name)
+
+    def test_get_schema_for_macro_definition_addition(self):
+        original_schema = self.macro_registry.schema_without_macros
+        macro_definition_schema = get_schema_for_macro_definition(original_schema)
+        for directive in DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION:
+            self.assertTrue(directive in macro_definition_schema.get_directives())
+
+    def test_get_schema_for_macro_definition_removal(self):
+        schema_with_macros = get_schema_with_macros(self.macro_registry)
+        macro_definition_schema = get_schema_for_macro_definition(schema_with_macros)
+        for directive in macro_definition_schema.get_directives():
+            self.assertTrue(directive.name != '@output')
+            self.assertTrue(directive.name != '@output_source')
+
+    def test_get_schema_for_macro_definition_validation(self):
+        schema_with_macros = get_schema_with_macros(self.macro_registry)
+        macro_definition_schema = get_schema_for_macro_definition(schema_with_macros)
+        args = {}
+
+        # TODO: validate macro edges using the generated schema
+
+        # get_and_validate_macro_edge_info(macro_definition_schema, schema_ast, args,
+        #     self.macro_registry.type_equivalence_hints)
+

--- a/graphql_compiler/tests/test_macro_schema.py
+++ b/graphql_compiler/tests/test_macro_schema.py
@@ -49,6 +49,7 @@ class MacroSchemaTests(unittest.TestCase):
             self.assertTrue(directive.name != '@output')
             self.assertTrue(directive.name != '@output_source')
 
+	@pytest.mark.skip(reason="unimplemented test")
     def test_get_schema_for_macro_definition_validation(self):
         schema_with_macros = get_schema_with_macros(self.macro_registry)
         macro_definition_schema = get_schema_for_macro_definition(schema_with_macros)


### PR DESCRIPTION
In this PR, get_schema_for_macro_definitions is implemented. 
Here's my methodology: 

- We check for non-default directives, and report an error.
- We add the directives required for a macro edge definition(@macro_edge_definition and @macro_edge-target). 
- Then any directives not in DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION are removed from the set.
- We create a shallow copy of the schema, where the directives list is replaced by a list containing the elements of the set. @reviewers: Could the shallow copy cause issues, if for example, the macro editor modifies the schema? Is this a vulnerability? EDIT: Updated the function docstring to reflect modifying the schema is **undefined behavior**