### PR TITLE
Refactor and clean up IR lowering code. Add common IR lowering module.

### DIFF
--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -802,7 +802,8 @@ class BinaryComposition(Expression):
         intersects_operator_format = '(%(operator)s(%(left)s, %(right)s).asList().size() > 0)'
         # pylint: enable=unused-variable
 
-        # Null literals use 'is/is not' as (in)equality operators, while other values use '=/<>'.
+        # Null literals use the OrientDB 'IS/IS NOT' (in)equality operators,
+        # while other values use the OrientDB '=/<>' operators.
         if self.left == NullLiteral or self.right == NullLiteral:
             translation_table = {
                 u'=': (u'IS', regular_operator_format),

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -205,6 +205,8 @@ class Variable(Expression):
 
     def to_gremlin(self):
         """Return a unicode object with the Gremlin representation of this expression."""
+        self.validate()
+
         # We can't directly pass a Date or a DateTime object, so we have to pass it as a string
         # and then parse it inline. For date format parameter meanings, see:
         # http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
@@ -559,8 +561,9 @@ class FoldedContextField(Expression):
         return template % template_data
 
     def to_gremlin(self):
-        """Must never be called."""
-        raise NotImplementedError()
+        """Not implemented, should not be used."""
+        raise AssertionError(u'FoldedContextField are not used during the query emission process '
+                             u'in Gremlin, so this is a bug. This function should not be called.')
 
     def __eq__(self, other):
         """Return True if the given object is equal to this one, and False otherwise."""
@@ -618,7 +621,7 @@ class FoldCountContextField(Expression):
         return template % template_data
 
     def to_gremlin(self):
-        """Must never be called."""
+        """Not supported yet."""
         raise NotImplementedError()
 
 
@@ -800,8 +803,7 @@ class BinaryComposition(Expression):
         # pylint: enable=unused-variable
 
         # Null literals use 'is/is not' as (in)equality operators, while other values use '=/<>'.
-        if any((isinstance(self.left, Literal) and self.left.value is None,
-                isinstance(self.right, Literal) and self.right.value is None)):
+        if self.left == NullLiteral or self.right == NullLiteral:
             translation_table = {
                 u'=': (u'IS', regular_operator_format),
                 u'!=': (u'IS NOT', regular_operator_format),
@@ -947,6 +949,7 @@ class TernaryConditional(Expression):
     def to_gremlin(self):
         """Return a unicode object with the Gremlin representation of this expression."""
         self.validate()
+
         return u'({predicate} ? {if_true} : {if_false})'.format(
             predicate=self.predicate.to_gremlin(),
             if_true=self.if_true.to_gremlin(),

--- a/graphql_compiler/compiler/ir_lowering_common/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_common/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2019-present Kensho Technologies, LLC.

--- a/graphql_compiler/compiler/ir_lowering_common/common.py
+++ b/graphql_compiler/compiler/ir_lowering_common/common.py
@@ -2,13 +2,13 @@
 """Language-independent IR lowering and optimization functions."""
 import six
 
-from .blocks import (
+from ..blocks import (
     ConstructResult, EndOptional, Filter, Fold, MarkLocation, Recurse, Traverse, Unfold
 )
-from .expressions import (
+from ..expressions import (
     BinaryComposition, ContextField, ContextFieldExistence, FalseLiteral, NullLiteral, TrueLiteral
 )
-from .helpers import validate_safe_string
+from ..helpers import validate_safe_string
 
 
 def merge_consecutive_filter_clauses(ir_blocks):

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -50,6 +50,7 @@ def make_location_rewriter_visitor_fn(location_translations):
         # All CompilerEntity objects store their exact constructor input args/kwargs.
         # To minimize the chances that we forget to update a location somewhere in an expression,
         # we rewrite all locations that we find as arguments to expression constructors.
+        # pylint: disable=protected-access
         new_args = [
             translate_potential_location(location_translations, arg)
             for arg in expression._print_args
@@ -58,6 +59,7 @@ def make_location_rewriter_visitor_fn(location_translations):
             kwarg_name: translate_potential_location(location_translations, kwarg_value)
             for kwarg_name, kwarg_value in six.iteritems(expression._print_kwargs)
         }
+        # pylint: enable=protected-access
 
         expression_cls = type(expression)
         return expression_cls(*new_args, **new_kwargs)

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -1,0 +1,65 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+"""Utilities for rewriting IR to replace one set of locations with another."""
+import six
+
+from ..helpers import FoldScopeLocation, Location
+
+
+def make_revisit_location_translations(query_metadata_table):
+    """Return a dict mapping location revisits to the location being revisited, for rewriting."""
+    location_translations = dict()
+
+    for location, _ in query_metadata_table.registered_locations:
+        location_being_revisited = query_metadata_table.get_revisit_origin(location)
+        if location_being_revisited != location:
+            location_translations[location] = location_being_revisited
+
+    return location_translations
+
+
+def translate_potential_location(location_translations, potential_location):
+    """If the input is a BaseLocation object, translate it, otherwise return it as-is."""
+    if isinstance(potential_location, Location):
+        old_location_at_vertex = potential_location.at_vertex()
+        field = potential_location.field
+
+        new_location = location_translations.get(old_location_at_vertex, None)
+        if new_location is None:
+            # No translation needed.
+            return potential_location
+        else:
+            # If necessary, add the field component to the new location before returning it.
+            if field is None:
+                return new_location
+            else:
+                return new_location.navigate_to_field(field)
+    elif isinstance(potential_location, FoldScopeLocation):
+        old_base_location = potential_location.base_location
+        new_base_location = location_translations.get(old_base_location, old_base_location)
+        fold_path = potential_location.fold_path
+        fold_field = potential_location.field
+        return FoldScopeLocation(new_base_location, fold_path, field=fold_field)
+    else:
+        return potential_location
+
+
+def make_location_rewriter_visitor_fn(location_translations):
+    """Return a visitor function that is able to replace locations with equivalent locations."""
+    def visitor_fn(expression):
+        """Expression visitor function used to rewrite expressions with updated Location data."""
+        # All CompilerEntity objects store their exact constructor input args/kwargs.
+        # To minimize the chances that we forget to update a location somewhere in an expression,
+        # we rewrite all locations that we find as arguments to expression constructors.
+        new_args = [
+            translate_potential_location(location_translations, arg)
+            for arg in expression._print_args
+        ]
+        new_kwargs = {
+            kwarg_name: translate_potential_location(location_translations, kwarg_value)
+            for kwarg_name, kwarg_value in six.iteritems(expression._print_kwargs)
+        }
+
+        expression_cls = type(expression)
+        return expression_cls(*new_args, **new_kwargs)
+
+    return visitor_fn

--- a/graphql_compiler/compiler/ir_lowering_gremlin/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/__init__.py
@@ -1,9 +1,11 @@
 # Copyright 2018-present Kensho Technologies, LLC.
 from .ir_lowering import (lower_coerce_type_block_type_data, lower_coerce_type_blocks,
-                          lower_folded_outputs, rewrite_filters_in_optional_blocks)
+                          lower_folded_outputs_and_context_fields,
+                          rewrite_filters_in_optional_blocks)
 from ..ir_sanity_checks import sanity_check_ir_blocks_from_frontend
-from ..ir_lowering_common import (lower_context_field_existence, merge_consecutive_filter_clauses,
-                                  optimize_boolean_expression_comparisons)
+from ..ir_lowering_common.common import (lower_context_field_existence,
+                                         merge_consecutive_filter_clauses,
+                                         optimize_boolean_expression_comparisons)
 
 
 ##############
@@ -48,6 +50,6 @@ def lower_ir(ir_blocks, query_metadata_table, type_equivalence_hints=None):
     ir_blocks = lower_coerce_type_blocks(ir_blocks)
     ir_blocks = rewrite_filters_in_optional_blocks(ir_blocks)
     ir_blocks = merge_consecutive_filter_clauses(ir_blocks)
-    ir_blocks = lower_folded_outputs(ir_blocks)
+    ir_blocks = lower_folded_outputs_and_context_fields(ir_blocks)
 
     return ir_blocks

--- a/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
@@ -1,27 +1,32 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Perform optimizations and lowering of the IR that allows the compiler to emit Gremlin queries.
 
-The compiler IR allows blocks and expressions that cannot be directly compiled to Gremlin or MATCH.
-For example, ContextFieldExistence is an Expression that returns True iff its given vertex exists,
-but the produced Gremlin and MATCH outputs for this purpose are entirely different and not easy
-to generate directly from this Expression object. An output-language-aware IR lowering step allows
-us to convert this Expression into other Expressions, using data already present in the IR,
-to simplify the final code generation step.
+The compiler IR allows blocks and expressions that cannot be directly compiled to the underlying
+database query languages. For example, ContextFieldExistence is an Expression that returns
+True iff its given vertex exists, but the produced Gremlin and MATCH outputs for this purpose
+are entirely different and not easy to generate directly from this Expression object.
+An output-language-aware IR lowering step allows us to convert this Expression into
+other Expressions, using data already present in the IR, to simplify the final code generation step.
 """
-from graphql import GraphQLList
+from graphql import GraphQLInt, GraphQLList
 from graphql.type import GraphQLInterfaceType, GraphQLObjectType, GraphQLUnionType
 import six
 
 from ...exceptions import GraphQLCompilationError
 from ...schema import GraphQLDate, GraphQLDateTime
-from ..blocks import Backtrack, CoerceType, ConstructResult, Filter, MarkLocation, Traverse
+from ..blocks import (
+    Backtrack, CoerceType, ConstructResult, Filter, GlobalOperationsStart, MarkLocation, Traverse
+)
 from ..compiler_entities import Expression
-from ..expressions import BinaryComposition, FoldedContextField, Literal, LocalField, NullLiteral
+from ..expressions import (
+    BinaryComposition, FoldedContextField, Literal, LocalField, NullLiteral,
+    make_type_replacement_visitor
+)
 from ..helpers import (
     STANDARD_DATE_FORMAT, STANDARD_DATETIME_FORMAT, FoldScopeLocation,
     get_only_element_from_collection, strip_non_null_from_type, validate_safe_string
 )
-from ..ir_lowering_common import extract_folds_from_ir_blocks
+from ..ir_lowering_common.common import extract_folds_from_ir_blocks
 
 
 ##################################
@@ -148,15 +153,18 @@ class GremlinFoldedContextField(Expression):
                     u'Allowed types are {}.'
                     .format(type(block), self.folded_ir_blocks, allowed_block_types))
 
-        if not isinstance(self.field_type, GraphQLList):
-            raise ValueError(u'Invalid value of "field_type", expected a list type but got: '
+        if isinstance(self.field_type, GraphQLList):
+            inner_type = strip_non_null_from_type(self.field_type.of_type)
+            if isinstance(inner_type, GraphQLList):
+                raise GraphQLCompilationError(
+                    u'Outputting list-valued fields in a @fold context is currently not supported: '
+                    u'{} {}'.format(self.fold_scope_location, self.field_type.of_type))
+        elif GraphQLInt.is_same_type(self.field_type):
+            # This needs to be implemented for @fold _x_count support.
+            raise NotImplementedError()
+        else:
+            raise ValueError(u'Invalid value of "field_type", expected a list or int type but got: '
                              u'{}'.format(self.field_type))
-
-        inner_type = strip_non_null_from_type(self.field_type.of_type)
-        if isinstance(inner_type, GraphQLList):
-            raise GraphQLCompilationError(
-                u'Outputting list-valued fields in a @fold context is currently '
-                u'not supported: {} {}'.format(self.fold_scope_location, self.field_type.of_type))
 
     def to_match(self):
         """Must never be called."""
@@ -316,18 +324,13 @@ def _convert_folded_blocks(folded_ir_blocks):
     return new_folded_ir_blocks
 
 
-def lower_folded_outputs(ir_blocks):
-    """Lower standard folded output fields into GremlinFoldedContextField objects."""
+def lower_folded_outputs_and_context_fields(ir_blocks):
+    """Lower standard folded output / context fields into GremlinFoldedContextField objects."""
     folds, remaining_ir_blocks = extract_folds_from_ir_blocks(ir_blocks)
 
     if not remaining_ir_blocks:
         raise AssertionError(u'Expected at least one non-folded block to remain: {} {} '
                              u'{}'.format(folds, remaining_ir_blocks, ir_blocks))
-    output_block = remaining_ir_blocks[-1]
-    if not isinstance(output_block, ConstructResult):
-        raise AssertionError(u'Expected the last non-folded block to be ConstructResult, '
-                             u'but instead was: {} {} '
-                             u'{}'.format(type(output_block), output_block, ir_blocks))
 
     # Turn folded Filter blocks into GremlinFoldedFilter blocks.
     converted_folds = {
@@ -335,21 +338,28 @@ def lower_folded_outputs(ir_blocks):
         for base_fold_location, folded_ir_blocks in six.iteritems(folds)
     }
 
-    new_output_fields = dict()
-    for output_name, output_expression in six.iteritems(output_block.fields):
-        new_output_expression = output_expression
+    def rewriter_fn(folded_context_field):
+        """Rewrite FoldedContextField objects into GremlinFoldedContextField ones."""
+        # Get the matching folded IR blocks and put them in the new context field.
+        base_fold_location_name = folded_context_field.fold_scope_location.get_location_name()[0]
+        folded_ir_blocks = converted_folds[base_fold_location_name]
+        return GremlinFoldedContextField(
+            folded_context_field.fold_scope_location, folded_ir_blocks,
+            folded_context_field.field_type)
 
-        # Turn FoldedContextField expressions into GremlinFoldedContextField ones.
-        if isinstance(output_expression, FoldedContextField):
-            # Get the matching folded IR blocks and put them in the new context field.
-            base_fold_location_name = output_expression.fold_scope_location.get_location_name()[0]
-            folded_ir_blocks = converted_folds[base_fold_location_name]
-            new_output_expression = GremlinFoldedContextField(
-                output_expression.fold_scope_location, folded_ir_blocks,
-                output_expression.field_type)
+    visitor_fn = make_type_replacement_visitor(FoldedContextField, rewriter_fn)
 
-        new_output_fields[output_name] = new_output_expression
+    # Start by just appending blocks to the output list.
+    new_ir_blocks = []
+    block_collection = new_ir_blocks
+    for block in remaining_ir_blocks:
+        block_collection.append(block)
 
-    new_ir_blocks = remaining_ir_blocks[:-1]
-    new_ir_blocks.append(ConstructResult(new_output_fields))
+        if isinstance(block, GlobalOperationsStart):
+            # Once we see the GlobalOperationsStart, start accumulating the blocks for rewriting.
+            block_collection = []
+
+    for block in block_collection:
+        new_ir_blocks.append(block.visit_and_update_expressions(visitor_fn))
+
     return new_ir_blocks

--- a/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
@@ -14,9 +14,7 @@ import six
 
 from ...exceptions import GraphQLCompilationError
 from ...schema import GraphQLDate, GraphQLDateTime
-from ..blocks import (
-    Backtrack, CoerceType, ConstructResult, Filter, GlobalOperationsStart, MarkLocation, Traverse
-)
+from ..blocks import Backtrack, CoerceType, Filter, GlobalOperationsStart, MarkLocation, Traverse
 from ..compiler_entities import Expression
 from ..expressions import (
     BinaryComposition, FoldedContextField, Literal, LocalField, NullLiteral,

--- a/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_gremlin/ir_lowering.py
@@ -151,18 +151,19 @@ class GremlinFoldedContextField(Expression):
                     u'Allowed types are {}.'
                     .format(type(block), self.folded_ir_blocks, allowed_block_types))
 
-        if isinstance(self.field_type, GraphQLList):
-            inner_type = strip_non_null_from_type(self.field_type.of_type)
+        bare_field_type = strip_non_null_from_type(self.field_type)
+        if isinstance(bare_field_type, GraphQLList):
+            inner_type = strip_non_null_from_type(bare_field_type.of_type)
             if isinstance(inner_type, GraphQLList):
                 raise GraphQLCompilationError(
                     u'Outputting list-valued fields in a @fold context is currently not supported: '
-                    u'{} {}'.format(self.fold_scope_location, self.field_type.of_type))
-        elif GraphQLInt.is_same_type(self.field_type):
+                    u'{} {}'.format(self.fold_scope_location, bare_field_type.of_type))
+        elif GraphQLInt.is_same_type(bare_field_type):
             # This needs to be implemented for @fold _x_count support.
             raise NotImplementedError()
         else:
-            raise ValueError(u'Invalid value of "field_type", expected a list or int type but got: '
-                             u'{}'.format(self.field_type))
+            raise ValueError(u'Invalid value of "field_type", expected a (possibly non-null) '
+                             u'list or int type but got: {}'.format(self.field_type))
 
     def to_match(self):
         """Must never be called."""

--- a/graphql_compiler/compiler/ir_lowering_match/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_match/__init__.py
@@ -2,10 +2,12 @@
 import six
 
 from ..blocks import Filter
-from ..ir_lowering_common import (extract_optional_location_root_info,
-                                  extract_simple_optional_location_info,
-                                  lower_context_field_existence, merge_consecutive_filter_clauses,
-                                  optimize_boolean_expression_comparisons, remove_end_optionals)
+from ..ir_lowering_common.common import (extract_optional_location_root_info,
+                                         extract_simple_optional_location_info,
+                                         lower_context_field_existence,
+                                         merge_consecutive_filter_clauses,
+                                         optimize_boolean_expression_comparisons,
+                                         remove_end_optionals)
 from .ir_lowering import (lower_backtrack_blocks,
                           lower_folded_coerce_types_into_filter_blocks,
                           lower_has_substring_binary_compositions,
@@ -100,7 +102,7 @@ def lower_ir(ir_blocks, query_metadata_table, type_equivalence_hints=None):
 
     match_query = lower_comparisons_to_between(match_query)
 
-    match_query = lower_backtrack_blocks(match_query, location_types)
+    match_query = lower_backtrack_blocks(match_query, query_metadata_table)
     match_query = truncate_repeated_single_step_traversals(match_query)
     match_query = orientdb_class_with_while.workaround_type_coercions_in_recursions(match_query)
 

--- a/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
@@ -13,7 +13,7 @@ import six
 from ..blocks import Backtrack, CoerceType, MarkLocation, QueryRoot
 from ..expressions import BinaryComposition, FalseLiteral, Literal, TernaryConditional, TrueLiteral
 from ..ir_lowering_common.location_renaming import (
-    make_revisit_location_translations, make_location_rewriter_visitor_fn,
+    make_location_rewriter_visitor_fn, make_revisit_location_translations,
     translate_potential_location
 )
 from .utils import convert_coerce_type_to_instanceof_filter

--- a/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
+++ b/graphql_compiler/compiler/ir_lowering_match/ir_lowering.py
@@ -11,11 +11,11 @@ to simplify the final code generation step.
 import six
 
 from ..blocks import Backtrack, CoerceType, MarkLocation, QueryRoot
-from ..expressions import (
-    BinaryComposition, ContextField, ContextFieldExistence, FalseLiteral, FoldedContextField,
-    GlobalContextField, Literal, TernaryConditional, TrueLiteral
+from ..expressions import BinaryComposition, FalseLiteral, Literal, TernaryConditional, TrueLiteral
+from ..ir_lowering_common.location_renaming import (
+    make_revisit_location_translations, make_location_rewriter_visitor_fn,
+    translate_potential_location
 )
-from ..helpers import FoldScopeLocation
 from .utils import convert_coerce_type_to_instanceof_filter
 
 
@@ -171,16 +171,18 @@ def truncate_repeated_single_step_traversals(match_query):
     return match_query._replace(match_traversals=new_match_traversals)
 
 
-def lower_backtrack_blocks(match_query, location_types):
+def lower_backtrack_blocks(match_query, query_metadata_table):
     """Lower Backtrack blocks into (QueryRoot, MarkLocation) pairs of blocks."""
     # The lowering works as follows:
     #   1. Upon seeing a Backtrack block, end the current traversal (if non-empty).
     #   2. Start new traversal from the type and location to which the Backtrack pointed.
-    #   3. If the Backtrack block had an associated MarkLocation, mark that location
+    #   3. If the Backtrack block had an associated MarkLocation, ensure that location is marked
     #      as equivalent to the location where the Backtrack pointed.
+    #   4. Rewrite all expressions that reference such revisit locations, making them refer to
+    #      the revisit origin location instead.
     new_match_traversals = []
 
-    location_translations = dict()
+    locations_needing_translation = set()
 
     for current_match_traversal in match_query.match_traversals:
         new_traversal = []
@@ -194,16 +196,16 @@ def lower_backtrack_blocks(match_query, location_types):
                     new_traversal = []
 
                 backtrack_location = step.root_block.location
-                backtrack_location_type = location_types[backtrack_location]
+                backtrack_location_info = query_metadata_table.get_location_info(backtrack_location)
 
                 # 2. Start new traversal from the type and location to which the Backtrack pointed.
-                new_root_block = QueryRoot({backtrack_location_type.name})
+                new_root_block = QueryRoot({backtrack_location_info.type.name})
                 new_as_block = MarkLocation(backtrack_location)
 
                 # 3. If the Backtrack block had an associated MarkLocation, mark that location
                 #    as equivalent to the location where the Backtrack pointed.
                 if step.as_block is not None:
-                    location_translations[step.as_block.location] = backtrack_location
+                    locations_needing_translation.add(step.as_block.location)
 
                 if step.coerce_type_block is not None:
                     raise AssertionError(u'Encountered type coercion in a MatchStep with '
@@ -215,76 +217,24 @@ def lower_backtrack_blocks(match_query, location_types):
 
         new_match_traversals.append(new_traversal)
 
-    _flatten_location_translations(location_translations)
     new_match_query = match_query._replace(match_traversals=new_match_traversals)
 
+    location_translations = make_revisit_location_translations(query_metadata_table)
+
+    if locations_needing_translation != set(six.iterkeys(location_translations)):
+        raise AssertionError(u'Unexpectedly, the revisit location translations table computed from '
+                             u'the query metadata table did not match the locations needing '
+                             u'translation. This is a bug. {} {}'
+                             .format(location_translations, locations_needing_translation))
+
     return _translate_equivalent_locations(new_match_query, location_translations)
-
-
-def _flatten_location_translations(location_translations):
-    """If location A translates to B, and B to C, then make A translate directly to C.
-
-    Args:
-        location_translations: dict of Location -> Location, where the key translates to the value.
-                               Mutated in place for efficiency and simplicity of implementation.
-    """
-    sources_to_process = set(six.iterkeys(location_translations))
-
-    def _update_translation(source):
-        """Return the proper (fully-flattened) translation for the given location."""
-        destination = location_translations[source]
-        if destination not in location_translations:
-            # "destination" cannot be translated, no further flattening required.
-            return destination
-        else:
-            # "destination" can itself be translated -- do so,
-            # and then flatten "source" to the final translation as well.
-            sources_to_process.discard(destination)
-            final_destination = _update_translation(destination)
-            location_translations[source] = final_destination
-            return final_destination
-
-    while sources_to_process:
-        _update_translation(sources_to_process.pop())
 
 
 def _translate_equivalent_locations(match_query, location_translations):
     """Translate Location objects into their equivalent locations, based on the given dict."""
     new_match_traversals = []
 
-    def visitor_fn(expression):
-        """Expression visitor function used to rewrite expressions with updated Location data."""
-        if isinstance(expression, (ContextField, GlobalContextField)):
-            old_location = expression.location.at_vertex()
-            new_location = location_translations.get(old_location, old_location)
-            if expression.location.field is not None:
-                new_location = new_location.navigate_to_field(expression.location.field)
-
-            # The Expression could be one of many types, including:
-            #   - ContextField
-            #   - GlobalContextField
-            # We determine its exact class to make sure we return an object of the same class
-            # as the expression being replaced.
-            expression_cls = type(expression)
-            return expression_cls(new_location, expression.field_type)
-        elif isinstance(expression, ContextFieldExistence):
-            old_location = expression.location
-            new_location = location_translations.get(old_location, old_location)
-
-            return ContextFieldExistence(new_location)
-        elif isinstance(expression, FoldedContextField):
-            # Update the Location within FoldedContextField
-            old_location = expression.fold_scope_location.base_location
-            new_location = location_translations.get(old_location, old_location)
-
-            fold_path = expression.fold_scope_location.fold_path
-            fold_field = expression.fold_scope_location.field
-            new_fold_scope_location = FoldScopeLocation(new_location, fold_path, field=fold_field)
-            field_type = expression.field_type
-
-            return FoldedContextField(new_fold_scope_location, field_type)
-        else:
-            return expression
+    visitor_fn = make_location_rewriter_visitor_fn(location_translations)
 
     # Rewrite the Locations in the steps of each MATCH traversal.
     for current_match_traversal in match_query.match_traversals:
@@ -315,16 +265,11 @@ def _translate_equivalent_locations(match_query, location_translations):
 
         new_match_traversals.append(new_traversal)
 
-    new_folds = {}
     # Update the Location within each FoldScopeLocation
-    for fold_scope_location, fold_ir_blocks in six.iteritems(match_query.folds):
-        fold_path = fold_scope_location.fold_path
-        fold_field = fold_scope_location.field
-        old_location = fold_scope_location.base_location
-        new_location = location_translations.get(old_location, old_location)
-        new_fold_scope_location = FoldScopeLocation(new_location, fold_path, field=fold_field)
-
-        new_folds[new_fold_scope_location] = fold_ir_blocks
+    new_folds = {
+        translate_potential_location(location_translations, fold_scope_location): fold_ir_blocks
+        for fold_scope_location, fold_ir_blocks in six.iteritems(match_query.folds)
+    }
 
     # Rewrite the Locations in the ConstructResult output block.
     new_output_block = match_query.output_block.visit_and_update_expressions(visitor_fn)

--- a/graphql_compiler/compiler/ir_sanity_checks.py
+++ b/graphql_compiler/compiler/ir_sanity_checks.py
@@ -7,7 +7,7 @@ from .blocks import (
     Backtrack, CoerceType, ConstructResult, Filter, Fold, MarkLocation, OutputSource, QueryRoot,
     Recurse, Traverse, Unfold
 )
-from .ir_lowering_common import extract_folds_from_ir_blocks
+from .ir_lowering_common.common import extract_folds_from_ir_blocks
 
 
 def sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table):

--- a/graphql_compiler/compiler/match_query.py
+++ b/graphql_compiler/compiler/match_query.py
@@ -7,7 +7,7 @@ from .blocks import (
     Backtrack, CoerceType, ConstructResult, Filter, Fold, GlobalOperationsStart, MarkLocation,
     OutputSource, QueryRoot, Recurse, Traverse, Unfold
 )
-from .ir_lowering_common import extract_folds_from_ir_blocks
+from .ir_lowering_common.common import extract_folds_from_ir_blocks
 
 
 ###

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -241,7 +241,7 @@ class QueryMetadataTable(object):
             yield revisit_location
 
     def get_revisit_origin(self, location):
-        """Return the original location that this location revisits, or None if it isn't a revisit.
+        """Return the location that this location revisits, or the input if it isn't a revisit.
 
         Args:
             location: Location/FoldScopeLocation object whose revisit origin to get

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -10,7 +10,7 @@ from ..compiler.expressions import (
     TernaryConditional, Variable
 )
 from ..compiler.helpers import Location
-from ..compiler.ir_lowering_common import OutputContextVertex
+from ..compiler.ir_lowering_common.common import OutputContextVertex
 from ..compiler.ir_lowering_match.utils import CompoundMatchQuery
 from ..compiler.match_query import convert_to_match_query
 from ..schema import GraphQLDateTime

--- a/graphql_compiler/tests/test_ir_lowering.py
+++ b/graphql_compiler/tests/test_ir_lowering.py
@@ -4,7 +4,7 @@ import unittest
 
 from graphql import GraphQLID, GraphQLString
 
-from ..compiler import ir_lowering_common, ir_lowering_gremlin, ir_lowering_match, ir_sanity_checks
+from ..compiler import ir_lowering_gremlin, ir_lowering_match, ir_sanity_checks
 from ..compiler.blocks import (
     Backtrack, CoerceType, ConstructResult, EndOptional, Filter, MarkLocation, QueryRoot, Traverse
 )
@@ -14,12 +14,14 @@ from ..compiler.expressions import (
     ZeroLiteral
 )
 from ..compiler.helpers import Location
-from ..compiler.ir_lowering_common import OutputContextVertex
+from ..compiler.ir_lowering_common.common import (
+    OutputContextVertex, merge_consecutive_filter_clauses, optimize_boolean_expression_comparisons
+)
 from ..compiler.ir_lowering_match.utils import BetweenClause, CompoundMatchQuery
 from ..compiler.match_query import MatchQuery, convert_to_match_query
 from ..compiler.metadata import LocationInfo, QueryMetadataTable
 from ..schema import GraphQLDate, GraphQLDateTime
-from .test_helpers import compare_ir_blocks, construct_location_types, get_schema
+from .test_helpers import compare_ir_blocks, get_schema
 
 
 def check_test_data(test_case, expected_object, received_object):
@@ -77,7 +79,7 @@ class CommonIrLoweringTests(unittest.TestCase):
             expected_ir_blocks = [
                 Filter(expected_output),
             ]
-            actual_ir_blocks = ir_lowering_common.optimize_boolean_expression_comparisons(ir_blocks)
+            actual_ir_blocks = optimize_boolean_expression_comparisons(ir_blocks)
             check_test_data(self, expected_ir_blocks, actual_ir_blocks)
 
 
@@ -90,7 +92,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         schema = get_schema()
 
         base_location = Location(('Animal',))
-        revisited_base_location = base_location.revisit()
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         child_name_location = child_location.navigate_to_field('name')
 
@@ -101,9 +102,7 @@ class MatchIrLoweringTests(unittest.TestCase):
         query_metadata_table.register_location(
             child_location,
             LocationInfo(base_location, animal_graphql_type, None, 1, 0, False))
-        query_metadata_table.register_location(
-            revisited_base_location,
-            LocationInfo(None, animal_graphql_type, None, 0, 0, False))
+        revisited_base_location = query_metadata_table.revisit_location(base_location)
 
         ir_blocks = [
             QueryRoot({'Animal'}),
@@ -143,10 +142,8 @@ class MatchIrLoweringTests(unittest.TestCase):
 
         base_location = Location(('Animal',))
         base_name_location = base_location.navigate_to_field('name')
-        revisited_base_location = base_location.revisit()
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         child_name_location = child_location.navigate_to_field('name')
-        second_child_location = revisited_base_location.navigate_to_subpath('in_Animal_ParentOf')
 
         animal_graphql_type = schema.get_type('Animal')
         base_location_info = LocationInfo(None, animal_graphql_type, None, 0, 0, False)
@@ -155,9 +152,9 @@ class MatchIrLoweringTests(unittest.TestCase):
         query_metadata_table.register_location(
             child_location,
             LocationInfo(base_location, animal_graphql_type, None, 1, 0, False))
-        query_metadata_table.register_location(
-            revisited_base_location,
-            LocationInfo(None, animal_graphql_type, None, 0, 0, False))
+        revisited_base_location = query_metadata_table.revisit_location(base_location)
+
+        second_child_location = revisited_base_location.navigate_to_subpath('in_Animal_ParentOf')
         query_metadata_table.register_location(
             second_child_location,
             LocationInfo(base_location, animal_graphql_type, None, 0, 0, False))
@@ -250,10 +247,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         ir_sanity_checks.sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table)
 
-        location_types = construct_location_types({
-            base_location: 'Animal',
-            child_location: 'Animal',
-        })
         match_query = convert_to_match_query(ir_blocks)
 
         # The expected final query consists of two traversals:
@@ -273,7 +266,7 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         expected_final_query = convert_to_match_query(expected_final_blocks)
 
-        final_query = ir_lowering_match.lower_backtrack_blocks(match_query, location_types)
+        final_query = ir_lowering_match.lower_backtrack_blocks(match_query, query_metadata_table)
         check_test_data(self, expected_final_query, final_query)
 
     def test_backtrack_block_lowering_revisiting_root(self):
@@ -310,11 +303,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         ir_sanity_checks.sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table)
 
-        location_types = construct_location_types({
-            base_location: 'Animal',
-            child_location_1: 'Animal',
-            child_location_2: 'Animal',
-        })
         match_query = convert_to_match_query(ir_blocks)
 
         # The expected final query consists of three traversals:
@@ -339,14 +327,13 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         expected_final_query = convert_to_match_query(expected_final_blocks)
 
-        final_query = ir_lowering_match.lower_backtrack_blocks(match_query, location_types)
+        final_query = ir_lowering_match.lower_backtrack_blocks(match_query, query_metadata_table)
         check_test_data(self, expected_final_query, final_query)
 
     def test_optional_backtrack_block_lowering(self):
         schema = get_schema()
 
         base_location = Location(('Animal',))
-        base_location_revisited = base_location.revisit()
         base_name_location = base_location.navigate_to_field('name')
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
 
@@ -357,8 +344,7 @@ class MatchIrLoweringTests(unittest.TestCase):
         query_metadata_table.register_location(
             child_location,
             LocationInfo(base_location, animal_graphql_type, None, 1, 0, False))
-        query_metadata_table.register_location(
-            base_location_revisited, base_location_info)
+        base_location_revisited = query_metadata_table.revisit_location(base_location)
 
         ir_blocks = [
             QueryRoot({'Animal'}),
@@ -373,11 +359,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         ir_sanity_checks.sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table)
 
-        location_types = construct_location_types({
-            base_location: 'Animal',
-            child_location: 'Animal',
-            base_location_revisited: 'Animal',
-        })
         match_query = convert_to_match_query(ir_blocks)
 
         # The expected final query consists of two traversals:
@@ -398,7 +379,7 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         expected_final_query = convert_to_match_query(expected_final_blocks)
 
-        final_query = ir_lowering_match.lower_backtrack_blocks(match_query, location_types)
+        final_query = ir_lowering_match.lower_backtrack_blocks(match_query, query_metadata_table)
         check_test_data(self, expected_final_query, final_query)
 
     def test_backtrack_lowering_with_optional_traverse_after_mandatory_traverse(self):
@@ -408,8 +389,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         schema = get_schema()
 
         base_location = Location(('Animal',))
-        revisited_base_location = base_location.revisit()
-        twice_revisited_base_location = revisited_base_location.revisit()
         species_location = base_location.navigate_to_subpath('out_Animal_OfSpecies')
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
 
@@ -418,10 +397,9 @@ class MatchIrLoweringTests(unittest.TestCase):
         base_location_info = LocationInfo(None, animal_graphql_type, None, 0, 0, False)
         query_metadata_table = QueryMetadataTable(base_location, base_location_info)
 
-        query_metadata_table.register_location(
-            revisited_base_location, base_location_info)
-        query_metadata_table.register_location(
-            twice_revisited_base_location, base_location_info)
+        revisited_base_location = query_metadata_table.revisit_location(base_location)
+        twice_revisited_base_location = query_metadata_table.revisit_location(
+            revisited_base_location)
         query_metadata_table.register_location(
             species_location,
             LocationInfo(base_location, species_graphql_type, None, 0, 0, False))
@@ -447,13 +425,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         ir_sanity_checks.sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table)
 
-        location_types = construct_location_types({
-            base_location: 'Animal',
-            child_location: 'Animal',
-            revisited_base_location: 'Animal',
-            twice_revisited_base_location: 'Animal',
-            species_location: 'Species',
-        })
         match_query = convert_to_match_query(ir_blocks)
 
         # The expected final query consists of three traversals:
@@ -481,7 +452,7 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         expected_final_query = convert_to_match_query(expected_final_blocks)
 
-        final_query = ir_lowering_match.lower_backtrack_blocks(match_query, location_types)
+        final_query = ir_lowering_match.lower_backtrack_blocks(match_query, query_metadata_table)
         check_test_data(self, expected_final_query, final_query)
 
     def test_unnecessary_traversal_elimination(self):
@@ -501,9 +472,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         schema = get_schema()
 
         base_location = Location(('Animal',))
-        revisited_base_location = base_location.revisit()
-        twice_revisited_base_location = revisited_base_location.revisit()
-        thrice_revisited_base_location = twice_revisited_base_location.revisit()
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         species_location = base_location.navigate_to_subpath('out_Animal_OfSpecies')
         event_location = base_location.navigate_to_subpath('out_Animal_FedAt')
@@ -514,12 +482,11 @@ class MatchIrLoweringTests(unittest.TestCase):
         base_location_info = LocationInfo(None, animal_graphql_type, None, 0, 0, False)
         query_metadata_table = QueryMetadataTable(base_location, base_location_info)
 
-        query_metadata_table.register_location(
-            revisited_base_location, base_location_info)
-        query_metadata_table.register_location(
-            twice_revisited_base_location, base_location_info)
-        query_metadata_table.register_location(
-            thrice_revisited_base_location, base_location_info)
+        revisited_base_location = query_metadata_table.revisit_location(base_location)
+        twice_revisited_base_location = query_metadata_table.revisit_location(
+            revisited_base_location)
+        thrice_revisited_base_location = query_metadata_table.revisit_location(
+            twice_revisited_base_location)
         query_metadata_table.register_location(
             child_location,
             LocationInfo(base_location, animal_graphql_type, None, 1, 0, False))
@@ -556,15 +523,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         ir_sanity_checks.sanity_check_ir_blocks_from_frontend(ir_blocks, query_metadata_table)
 
-        location_types = construct_location_types({
-            base_location: 'Animal',
-            child_location: 'Animal',
-            revisited_base_location: 'Animal',
-            twice_revisited_base_location: 'Animal',
-            thrice_revisited_base_location: 'Animal',
-            species_location: 'Species',
-            event_location: 'Event',
-        })
         match_query = convert_to_match_query(ir_blocks)
 
         # The expected final query consists of the three optional traversals.
@@ -596,7 +554,7 @@ class MatchIrLoweringTests(unittest.TestCase):
         ]
         expected_final_query = convert_to_match_query(expected_final_blocks)
 
-        temp_query = ir_lowering_match.lower_backtrack_blocks(match_query, location_types)
+        temp_query = ir_lowering_match.lower_backtrack_blocks(match_query, query_metadata_table)
         final_query = ir_lowering_match.truncate_repeated_single_step_traversals(temp_query)
 
         check_test_data(self, expected_final_query, final_query)
@@ -673,7 +631,7 @@ class MatchIrLoweringTests(unittest.TestCase):
             })
         ]
 
-        final_blocks = ir_lowering_common.merge_consecutive_filter_clauses(ir_blocks)
+        final_blocks = merge_consecutive_filter_clauses(ir_blocks)
         check_test_data(self, expected_final_blocks, final_blocks)
 
     def test_binary_composition_inside_ternary_conditional(self):
@@ -864,7 +822,6 @@ class MatchIrLoweringTests(unittest.TestCase):
         base_location = Location(('Animal',))
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         child_fed_at_location = child_location.navigate_to_subpath('out_Animal_FedAt')
-        revisited_base_location = base_location.revisit()
 
         animal_graphql_type = schema.get_type('Animal')
         event_graphql_type = schema.get_type('Event')
@@ -877,8 +834,7 @@ class MatchIrLoweringTests(unittest.TestCase):
         query_metadata_table.register_location(
             child_fed_at_location,
             LocationInfo(child_location, event_graphql_type, None, 1, 0, False))
-        query_metadata_table.register_location(
-            revisited_base_location, base_location_info)
+        revisited_base_location = query_metadata_table.revisit_location(base_location)
 
         ir_blocks = [
             QueryRoot({'Animal'}),
@@ -974,7 +930,6 @@ class GremlinIrLoweringTests(unittest.TestCase):
         schema = get_schema()
 
         base_location = Location(('Animal',))
-        revisited_base_location = base_location.revisit()
         child_location = base_location.navigate_to_subpath('out_Animal_ParentOf')
         child_name_location = child_location.navigate_to_field('name')
 
@@ -985,8 +940,7 @@ class GremlinIrLoweringTests(unittest.TestCase):
         query_metadata_table.register_location(
             child_location,
             LocationInfo(base_location, animal_graphql_type, None, 1, 0, False))
-        query_metadata_table.register_location(
-            revisited_base_location, base_location_info)
+        revisited_base_location = query_metadata_table.revisit_location(base_location)
 
         ir_blocks = [
             QueryRoot({'Animal'}),


### PR DESCRIPTION
This PR refactors the IR lowering code and extracts backend-agnostic lowering code into its own module, fixing multiple small issues along the way:
- Refactor location rewriting logic so that it is backend agnostic, and move it to this new module.
- Remove the last vestiges of the pre-`QueryMetadataTable` location type passing code in the MATCH backend.
- Ensure Gremlin correctly rewrites location objects, no matter what kind of Expression they are part of.
- Fix some trivial bugs and documentation mismatches related to IR Expression objects.

This the set of issues I came across while prototyping Cypher support, and I extracted these from that branch so that these could be merged earlier.