### PR TITLE
Cardinality estimation: Add in_collection support

### DIFF
--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -228,8 +228,7 @@ def estimate_query_result_cardinality(
         lookup_class_counts: function, string -> int, that accepts a class name and returns the
                              total number of instances plus subclass instances
         graphql_query: string, a valid GraphQL query
-        parameters: dict, parameters with which query will be executed. Must be valid for the
-                    given graphql_query.
+        parameters: dict, parameters with which query will be executed.
         class_to_field_type_overrides: optional dict, class name -> {field name -> field type},
                                        (string -> {string -> GraphQLType}). Used to override the
                                        type of a field in the class where it's first defined and all

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -1,3 +1,4 @@
+# Copyright 2019-present Kensho Technologies, LLC.
 from itertools import chain
 
 from ..compiler.compiler_frontend import graphql_to_ir

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -227,7 +227,8 @@ def estimate_query_result_cardinality(
         lookup_class_counts: function, string -> int, that accepts a class name and returns the
                              total number of instances plus subclass instances
         graphql_query: string, a valid GraphQL query
-        parameters: dict, parameters with which query will be executed
+        parameters: dict, parameters with which query will be executed. Must be valid for the
+                    given graphql_query.
         class_to_field_type_overrides: optional dict, class name -> {field name -> field type},
                                        (string -> {string -> GraphQLType}). Used to override the
                                        type of a field in the class where it's first defined and all

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -70,6 +70,7 @@ def _get_filter_selectivity(
         if _are_filter_fields_uniquely_indexed(filter_info.fields, unique_indexes):
             collection_name = get_parameter_name(filter_info.args[0])
             collection_size = len(parameters[collection_name])
+            # Assumption: each entry in the collection adds a row to the result
             return Selectivity(kind=ABSOLUTE_SELECTIVITY, value=float(collection_size))
 
     return Selectivity(kind=FRACTIONAL_SELECTIVITY, value=1.0)

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 import sys
 

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
 import sys
 
+from ..compiler.helpers import get_parameter_name
+
 
 # The Selectivity represents the selectivity of a filter or a set of filters
 Selectivity = namedtuple('Selectivity', (
@@ -57,13 +59,18 @@ def _get_filter_selectivity(
     Returns:
         Selectivity object, the selectivity of a specific filter at a given location.
     """
-    # TODO(evan): implement logic for various filter types
     unique_indexes = schema_graph.get_unique_indexes_for_class(location_name)
 
+    # TODO(vlad): support selectivity for non-uniquely indexed fields
     if filter_info.op_name == '=':
         if _are_filter_fields_uniquely_indexed(filter_info.fields, unique_indexes):
             # TODO(evan): don't return a higher absolute selectivity than class counts.
             return Selectivity(kind=ABSOLUTE_SELECTIVITY, value=1.0)
+    elif filter_info.op_name == 'in_collection':
+        if _are_filter_fields_uniquely_indexed(filter_info.fields, unique_indexes):
+            collection_name = get_parameter_name(filter_info.args[0])
+            collection_size = len(parameters[collection_name])
+            return Selectivity(kind=ABSOLUTE_SELECTIVITY, value=float(collection_size))
 
     return Selectivity(kind=FRACTIONAL_SELECTIVITY, value=1.0)
 

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -763,7 +763,6 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=2.0)
         self.assertEqual(expected_selectivity, _combine_filter_selectivities(selectivities))
 
-
     @pytest.mark.usefixtures('graph_client')
     def test_get_equals_filter_selectivity(self):
         schema_graph = generate_schema_graph(self.graph_client)
@@ -801,7 +800,6 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         )
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=1.0)
         self.assertEqual(expected_selectivity, selectivity)
-
 
     @pytest.mark.usefixtures('graph_client')
     def test_get_in_collection_filter_selectivity(self):

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -4,14 +4,14 @@ import unittest
 
 import pytest
 
-from . import test_input_data
-from ..compiler.metadata import FilterInfo
-from ..cost_estimation.cardinality_estimator import estimate_query_result_cardinality
-from ..cost_estimation.filter_selectivity_utils import (
+from .. import test_input_data
+from ...compiler.metadata import FilterInfo
+from ...cost_estimation.cardinality_estimator import estimate_query_result_cardinality
+from ...cost_estimation.filter_selectivity_utils import (
     ABSOLUTE_SELECTIVITY, FRACTIONAL_SELECTIVITY, Selectivity, _combine_filter_selectivities,
     _get_filter_selectivity
 )
-from .test_helpers import generate_schema_graph
+from ..test_helpers import generate_schema_graph
 
 
 def create_lookup_counts(count_data):
@@ -763,6 +763,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=2.0)
         self.assertEqual(expected_selectivity, _combine_filter_selectivities(selectivities))
 
+
     @pytest.mark.usefixtures('graph_client')
     def test_get_equals_filter_selectivity(self):
         schema_graph = generate_schema_graph(self.graph_client)
@@ -800,6 +801,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         )
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=1.0)
         self.assertEqual(expected_selectivity, selectivity)
+
 
     @pytest.mark.usefixtures('graph_client')
     def test_get_in_collection_filter_selectivity(self):
@@ -842,3 +844,6 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         )
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=3.0)
         self.assertEqual(expected_selectivity, selectivity)
+
+
+# pylint: enable=no-member

--- a/graphql_compiler/tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/test_cost_estimation.py
@@ -784,7 +784,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         expected_selectivity = Selectivity(kind=FRACTIONAL_SELECTIVITY, value=1.0)
         self.assertEqual(expected_selectivity, selectivity)
 
-        # If we '='-filter on a property that's non-uniquely 
+        # If we '='-filter on a property that's non-uniquely
         # indexed return a fractional selectivity of 1.
         nonunique_filter = FilterInfo(fields=('birthday',), op_name='=', args=('$birthday',))
         selectivity = _get_filter_selectivity(
@@ -818,7 +818,8 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
                 date(1999, 12, 31),
             ]
         }
-        # If we use an in_collection-filter on a property that is not uniquely indexed return a fractional selectivity of 1.
+        # If we use an in_collection-filter on a property that is not uniquely indexed
+        # return a fractional selectivity of 1.
         selectivity = _get_filter_selectivity(
             schema_graph, empty_lookup_counts, nonunique_filter, nonunique_params, classname
         )


### PR DESCRIPTION
I've added support for @filters that use the in_collection operator on uniquely-indexed fields. 
For estimating in_collection, I assume that for a collection with K elements, an in_collection filter on a unique field will create approximately K rows in the result.