### PR TITLE
Refactor graph_client to snapshot_graph_client for code clarity

### DIFF
--- a/graphql_compiler/tests/conftest.py
+++ b/graphql_compiler/tests/conftest.py
@@ -51,7 +51,7 @@ def _init_graph_client(load_schema_func, generate_data_func):
 
 
 @pytest.fixture(scope='class')
-def graph_client(request, init_snapshot_graph_client):
+def snapshot_graph_client(request, init_snapshot_graph_client):
     """Get a client for an initialized db, with all test data imported."""
     request.cls.graph_client = init_snapshot_graph_client
 

--- a/graphql_compiler/tests/snapshot_tests/test_orientdb_match_query.py
+++ b/graphql_compiler/tests/snapshot_tests/test_orientdb_match_query.py
@@ -63,7 +63,7 @@ def execute_graphql(schema, test_data, client, sample_parameters):
     return row_counters_frozenset
 
 
-# The following TestCase class uses the 'graph_client' fixture
+# The following TestCase class uses the 'snapshot_graph_client' fixture
 # which pylint does not recognize as a class member.
 # pylint: disable=no-member
 
@@ -75,7 +75,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
         self.maxDiff = None
         self.schema = get_schema()
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_immediate_output(self):
         test_data = test_input_data.immediate_output()
         sample_parameters = {}
@@ -84,7 +84,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_immediate_output_custom_scalars(self):
         test_data = test_input_data.immediate_output_custom_scalars()
         sample_parameters = {}
@@ -93,7 +93,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_traverse_and_output(self):
         test_data = test_input_data.traverse_and_output()
         sample_parameters = {}
@@ -102,7 +102,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_optional_traverse_after_mandatory_traverse(self):
         test_data = test_input_data.optional_traverse_after_mandatory_traverse()
         sample_parameters = {}
@@ -111,7 +111,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_filter_on_optional_variable_equality(self):
         test_data = test_input_data.filter_on_optional_variable_equality()
         sample_parameters = {}
@@ -120,7 +120,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_filter_on_optional_variable_name_or_alias(self):
         test_data = test_input_data.filter_on_optional_variable_name_or_alias()
         sample_parameters = {}
@@ -129,7 +129,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_complex_optional_variables(self):
         test_data = test_input_data.complex_optional_variables()
         sample_parameters = {}
@@ -138,7 +138,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_simple_fragment(self):
         test_data = test_input_data.simple_fragment()
         sample_parameters = {}
@@ -147,7 +147,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_simple_union(self):
         test_data = test_input_data.simple_union()
         sample_parameters = {}
@@ -156,7 +156,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_optional_on_union(self):
         test_data = test_input_data.optional_on_union()
         sample_parameters = {}
@@ -165,7 +165,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_typename_output(self):
         test_data = test_input_data.typename_output()
         sample_parameters = {}
@@ -174,7 +174,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_simple_recurse(self):
         test_data = test_input_data.simple_recurse()
         sample_parameters = {}
@@ -183,7 +183,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_recurse_within_fragment(self):
         test_data = test_input_data.recurse_within_fragment()
         sample_parameters = {}
@@ -192,7 +192,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_recurse_with_immediate_type_coercion(self):
         test_data = test_input_data.recurse_with_immediate_type_coercion()
         sample_parameters = {}
@@ -201,7 +201,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_in_collection_op_filter_with_tag(self):
         test_data = test_input_data.in_collection_op_filter_with_tag()
         sample_parameters = {}
@@ -210,7 +210,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_in_collection_op_filter_with_optional_tag(self):
         test_data = test_input_data.in_collection_op_filter_with_optional_tag()
         sample_parameters = {}
@@ -219,7 +219,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_intersects_op_filter_with_tag(self):
         test_data = test_input_data.intersects_op_filter_with_tag()
         sample_parameters = {}
@@ -228,7 +228,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_intersects_op_filter_with_optional_tag(self):
         test_data = test_input_data.intersects_op_filter_with_optional_tag()
         sample_parameters = {}
@@ -237,7 +237,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_contains_op_filter_with_tag(self):
         test_data = test_input_data.contains_op_filter_with_tag()
         sample_parameters = {}
@@ -246,7 +246,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_contains_op_filter_with_optional_tag(self):
         test_data = test_input_data.contains_op_filter_with_optional_tag()
         sample_parameters = {}
@@ -255,7 +255,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_has_substring_op_filter_with_optional_tag(self):
         test_data = test_input_data.has_substring_op_filter_with_optional_tag()
         sample_parameters = {}
@@ -264,7 +264,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_fold_on_output_variable(self):
         test_data = test_input_data.fold_on_output_variable()
         sample_parameters = {}
@@ -273,7 +273,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_fold_after_traverse(self):
         test_data = test_input_data.fold_after_traverse()
         sample_parameters = {}
@@ -282,7 +282,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_fold_and_traverse(self):
         test_data = test_input_data.fold_and_traverse()
         sample_parameters = {}
@@ -291,7 +291,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_fold_and_deep_traverse(self):
         test_data = test_input_data.fold_and_deep_traverse()
         sample_parameters = {}
@@ -300,7 +300,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_traverse_and_fold_and_traverse(self):
         test_data = test_input_data.traverse_and_fold_and_traverse()
         sample_parameters = {}
@@ -309,7 +309,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_multiple_outputs_in_same_fold(self):
         test_data = test_input_data.multiple_outputs_in_same_fold()
         sample_parameters = {}
@@ -318,7 +318,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_multiple_outputs_in_same_fold_and_traverse(self):
         test_data = test_input_data.multiple_outputs_in_same_fold_and_traverse()
         sample_parameters = {}
@@ -327,7 +327,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_multiple_folds(self):
         test_data = test_input_data.multiple_folds()
         sample_parameters = {}
@@ -336,7 +336,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_multiple_folds_and_traverse(self):
         test_data = test_input_data.multiple_folds_and_traverse()
         sample_parameters = {}
@@ -345,7 +345,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_fold_date_and_datetime_fields(self):
         test_data = test_input_data.fold_date_and_datetime_fields()
         sample_parameters = {}
@@ -354,7 +354,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_coercion_to_union_base_type_inside_fold(self):
         test_data = test_input_data.coercion_to_union_base_type_inside_fold()
         sample_parameters = {}
@@ -363,7 +363,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_no_op_coercion_inside_fold(self):
         test_data = test_input_data.no_op_coercion_inside_fold()
         sample_parameters = {}
@@ -372,7 +372,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_coercion_on_interface_within_fold_scope(self):
         test_data = test_input_data.coercion_on_interface_within_fold_scope()
         sample_parameters = {}
@@ -381,7 +381,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_coercion_on_interface_within_fold_traversal(self):
         test_data = test_input_data.coercion_on_interface_within_fold_traversal()
         sample_parameters = {}
@@ -390,7 +390,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_coercion_on_union_within_fold_scope(self):
         test_data = test_input_data.coercion_on_union_within_fold_scope()
         sample_parameters = {}
@@ -399,7 +399,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_optional_and_traverse(self):
         test_data = test_input_data.optional_and_traverse()
         sample_parameters = {}
@@ -408,7 +408,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_optional_and_deep_traverse(self):
         test_data = test_input_data.optional_and_deep_traverse()
         sample_parameters = {}
@@ -417,7 +417,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_traverse_and_optional_and_traverse(self):
         test_data = test_input_data.traverse_and_optional_and_traverse()
         sample_parameters = {}
@@ -426,7 +426,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_coercion_on_interface_within_optional_traversal(self):
         test_data = test_input_data.coercion_on_interface_within_optional_traversal()
         sample_parameters = {}
@@ -435,7 +435,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_filter_on_optional_traversal_equality(self):
         test_data = test_input_data.filter_on_optional_traversal_equality()
         sample_parameters = {}
@@ -444,7 +444,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_filter_on_optional_traversal_name_or_alias(self):
         test_data = test_input_data.filter_on_optional_traversal_name_or_alias()
         sample_parameters = {}
@@ -453,7 +453,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_simple_optional_recurse(self):
         test_data = test_input_data.simple_optional_recurse()
         sample_parameters = {}
@@ -462,7 +462,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_multiple_traverse_within_optional(self):
         test_data = test_input_data.multiple_traverse_within_optional()
         sample_parameters = {}
@@ -471,7 +471,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_optional_and_fold(self):
         test_data = test_input_data.optional_and_fold()
         sample_parameters = {}
@@ -480,7 +480,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_fold_and_optional(self):
         test_data = test_input_data.fold_and_optional()
         sample_parameters = {}
@@ -489,7 +489,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_optional_traversal_and_fold_traversal(self):
         test_data = test_input_data.optional_traversal_and_fold_traversal()
         sample_parameters = {}
@@ -498,7 +498,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_fold_traversal_and_optional_traversal(self):
         test_data = test_input_data.fold_traversal_and_optional_traversal()
         sample_parameters = {}
@@ -507,7 +507,7 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_coercion_and_filter_with_tag(self):
         test_data = test_input_data.coercion_and_filter_with_tag()
         sample_parameters = {}
@@ -525,7 +525,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
         self.maxDiff = None
         self.schema = get_schema()
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_immediate_output_with_custom_scalar_filter(self):
         test_data = test_input_data.immediate_output_with_custom_scalar_filter()
         sample_parameters = {'min_worth': 500}
@@ -534,7 +534,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_multiple_filters(self):
         test_data = test_input_data.multiple_filters()
         sample_parameters = {'lower_bound': 'Nazgul', 'upper_bound': 'Pteranodon'}
@@ -543,7 +543,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_traverse_filter_and_output(self):
         test_data = test_input_data.traverse_filter_and_output()
         sample_parameters = {'wanted': 'Nazgul__2'}
@@ -552,7 +552,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_name_or_alias_filter_on_interface_type(self):
         test_data = test_input_data.name_or_alias_filter_on_interface_type()
         sample_parameters = {'wanted': 'Nazgul_1'}
@@ -561,7 +561,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_output_source_and_complex_output(self):
         test_data = test_input_data.output_source_and_complex_output()
         sample_name = 'Nazgul__((((18_19_2_6)_1_19_6)_15_16_2)_14_8_9)'
@@ -573,7 +573,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_filter_in_optional_block(self):
         test_data = test_input_data.filter_in_optional_block()
         sample_parameters = {'name': 'Nazgul__2'}
@@ -582,7 +582,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_between_filter_on_simple_scalar(self):
         test_data = test_input_data.between_filter_on_simple_scalar()
         sample_parameters = {'lower': 'Nazgul', 'upper': 'Pteranodon'}
@@ -591,7 +591,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_between_lowering_on_simple_scalar(self):
         test_data = test_input_data.between_lowering_on_simple_scalar()
         sample_parameters = {'lower': 'Nazgul', 'upper': 'Pteranodon'}
@@ -600,7 +600,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_between_lowering_with_extra_filters(self):
         test_data = test_input_data.between_lowering_with_extra_filters()
         sample_fauna = [
@@ -644,7 +644,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_no_between_lowering_on_simple_scalar(self):
         test_data = test_input_data.no_between_lowering_on_simple_scalar()
         sample_parameters = {'lower0': 'Nazgul', 'lower1': 'Nazgul_3', 'upper': 'Pteranodon'}
@@ -653,7 +653,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_complex_optional_variables_with_starting_filter(self):
         test_data = test_input_data.complex_optional_variables_with_starting_filter()
         sample_parameters = {'animal_name': 'Nazgul__((((18_19_2_6)_1_19_6)_15_16_2)_11_14_6)'}
@@ -662,7 +662,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_filter_on_fragment_in_union(self):
         test_data = test_input_data.filter_on_fragment_in_union()
         sample_parameters = {'wanted': 'Bacon'}
@@ -671,7 +671,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_typename_filter(self):
         test_data = test_input_data.typename_filter()
         sample_parameters = {'base_cls': 'Food'}
@@ -680,7 +680,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_filter_within_recurse(self):
         test_data = test_input_data.filter_within_recurse()
         sample_parameters = {'wanted': 'red'}
@@ -689,7 +689,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_recurse_with_immediate_type_coercion_and_filter(self):
         test_data = test_input_data.recurse_with_immediate_type_coercion_and_filter()
         sample_parameters = {'color': 'red'}
@@ -698,7 +698,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_in_collection_op_filter_with_variable(self):
         test_data = test_input_data.in_collection_op_filter_with_variable()
         sample_names = [
@@ -727,7 +727,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_intersects_op_filter_with_variable(self):
         test_data = test_input_data.intersects_op_filter_with_variable()
         sample_names = [
@@ -741,7 +741,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_contains_op_filter_with_variable(self):
         test_data = test_input_data.contains_op_filter_with_variable()
         sample_parameters = {'wanted': 'Nazgul_1'}
@@ -750,7 +750,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_has_substring_op_filter(self):
         test_data = test_input_data.has_substring_op_filter()
         sample_parameters = {'wanted': '6)_((1_12'}
@@ -759,7 +759,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_has_edge_degree_op_filter(self):
         test_data = test_input_data.has_edge_degree_op_filter()
         sample_parameters = {'child_count': 9}
@@ -768,7 +768,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_has_edge_degree_op_filter_with_optional(self):
         test_data = test_input_data.has_edge_degree_op_filter_with_optional()
 
@@ -778,7 +778,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_has_edge_degree_op_filter_with_fold(self):
         test_data = test_input_data.has_edge_degree_op_filter_with_fold()
         sample_parameters = {'child_count': 9}
@@ -787,7 +787,7 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('graph_client')
+    @pytest.mark.usefixtures('snapshot_graph_client')
     def test_filter_within_fold_scope(self):
         test_data = test_input_data.filter_within_fold_scope()
         sample_parameters = {'desired': 'Nazgul__2'}


### PR DESCRIPTION
We have a fixture called graph_client that initializes the database using snapshot_data. However, we also have another fixture called integration_graph_client that initializes the database using integration_data. It would be much more consistent to rename the graph_client fixture to snapshot_graph_client. Besides renaming the fixture, I've also changed all usage of fixture('graph_client') to fixture('snapshot_graph_client'). 