### PR TITLE
Relax tag filter constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,8 @@ as `@filter` parameters, for several reasons:
   (denoting a runtime parameter) or `%` (denoting a tagged parameter),
   followed by exclusively upper or lower case letters (`A-Z`, `a-z`) or underscores (`_`).
 - The `@tag` directives corresponding to any tagged parameters in a given `@filter` query
-  must be applied to fields that appear strictly before the field with the `@filter` directive.
+  must be applied to fields that appear either at the same vertex as the one with the `@filter`,
+  or strictly before the field with the `@filter` directive.
 - "Can't compare apples and oranges" -- the GraphQL type of the parameters supplied to the `@filter`
   must match the GraphQL types the compiler infers based on the field the `@filter` is applied to.
 - If the `@tag` corresponding to a tagged parameter originates from within a vertex field

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -303,7 +303,7 @@ def _compile_property_ast(schema, current_schema_type, ast, location,
                                           u'in a fold. Location: {}'
                                           .format(COUNT_META_FIELD_NAME, location))
 
-    # step P-2: process property-only directives
+    # step P-2: Process @output directives.
     output_directive = unique_local_directives.get('output', None)
     if output_directive:
         # Schema validation has ensured that the fields below exist.

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -284,15 +284,14 @@ def _compile_property_ast(schema, current_schema_type, ast, location,
 
         # Schema validation has ensured that the fields below exist.
         tag_name = tag_directive.arguments[0].value.value
-        if tag_name in context['tags']:
+        if context['metadata'].get_tag_info(tag_name) is not None:
             raise GraphQLCompilationError(u'Cannot reuse tag name: {}'.format(tag_name))
         validate_safe_string(tag_name)
-        context['tags'][tag_name] = {
-            'location': location,
-            'optional': is_in_optional_scope(context),
-            'type': strip_non_null_from_type(current_schema_type),
-        }
-        context['metadata'].record_tag_info(tag_name, TagInfo(location=location))
+        context['metadata'].record_tag_info(tag_name, TagInfo(
+            location=location,
+            optional=is_in_optional_scope(context),
+            type=strip_non_null_from_type(current_schema_type),
+        ))
 
     output_directive = unique_local_directives.get('output', None)
     if output_directive:

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -245,7 +245,17 @@ def _process_output_source_directive(schema, current_schema_type, ast,
     else:
         return None
 
+
 def _process_tag_directive(context, current_schema_type, location, tag_directive):
+    """Process the tag directive, modifying the context as appropriate.
+
+    Args:
+        context: dict, various per-compilation data (e.g. declared tags, whether the current block
+                 is optional, etc.). May be mutated in-place in this function!
+        current_schema_type: GraphQLType, the schema type at the current location
+        location: Location object representing the current location in the query
+        tag_directive: GraphQL Directive that we want to process
+    """
     if is_in_fold_scope(context):
         raise GraphQLCompilationError(u'Tagging values within a @fold vertex field is '
                                       u'not allowed! Location: {}'.format(location))
@@ -266,6 +276,7 @@ def _process_tag_directive(context, current_schema_type, location, tag_directive
         optional=is_in_optional_scope(context),
         type=strip_non_null_from_type(current_schema_type),
     ))
+
 
 def _compile_property_ast(schema, current_schema_type, ast, location,
                           context, unique_local_directives):

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -824,11 +824,6 @@ def _compile_root_ast_to_ir(schema, ast, type_equivalence_hints=None):
         # 'metadata' is the QueryMetadataTable describing all the metadata collected during query
         # processing, including location metadata (e.g. which locations are folded or optional).
         'metadata': query_metadata_table,
-        # 'tags' is a dict containing
-        #  - location: Location where the tag was defined
-        #  - optional: boolean representing whether the tag was defined within an @optional scope
-        #  - type: GraphQLType of the tagged value
-        'tags': dict(),
         # 'global_filters' is a list that may contain Filter blocks that are generated during
         # query processing, but apply to the global query scope and should be appended to the
         # IR blocks only after the GlobalOperationsStart block has been emitted.

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -113,13 +113,13 @@ def _represent_argument(directive_location, context, argument, inferred_type):
 
         return (expressions.Variable(argument, inferred_type), None)
     elif is_tagged_parameter(argument):
-        argument_context = context['tags'].get(argument_name, None)
-        if argument_context is None:
+        tag_info = context['metadata'].get_tag_info(argument_name)
+        if tag_info is None:
             raise GraphQLCompilationError(u'Undeclared argument used: {}'.format(argument))
 
-        location = argument_context['location']
-        optional = argument_context['optional']
-        tag_inferred_type = argument_context['type']
+        location = tag_info.location
+        optional = tag_info.optional
+        tag_inferred_type = tag_info.type
 
         if location is None:
             raise AssertionError(u'Argument declared without location: {}'.format(argument_name))

--- a/graphql_compiler/compiler/metadata.py
+++ b/graphql_compiler/compiler/metadata.py
@@ -36,7 +36,9 @@ OutputInfo = namedtuple(
 TagInfo = namedtuple(
     'TagInfo',
     (
-        'location',
+        'location',     # Location/FoldScopeLocation, where to output from
+        'type',         # GraphQLType of the tag
+        'optional',     # boolean, whether the output was defined within an @optional scope
     )
 )
 

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -100,6 +100,28 @@ def colocated_filter_and_tag():
         type_equivalence_hints=None)
 
 
+def colocated_out_of_order_filter_and_tag():
+    graphql_input = '''{
+        Animal {
+            out_Entity_Related {
+                alias @filter(op_name: "contains", value: ["%name"])
+                name @output(out_name: "related_name")
+                     @tag(tag_name: "name")
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'related_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
 def multiple_filters():
     graphql_input = '''{
         Animal {

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -341,6 +341,38 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
+    def test_colocated_out_of_order_filter_and_tag(self):
+        test_data = test_input_data.colocated_out_of_order_filter_and_tag()
+
+        base_location = helpers.Location(('Animal',))
+        child_location = base_location.navigate_to_subpath('out_Entity_Related')
+
+        expected_blocks = [
+            blocks.QueryRoot({'Animal'}),
+            blocks.MarkLocation(base_location),
+            blocks.Traverse('out', 'Entity_Related'),
+            blocks.Filter(
+                expressions.BinaryComposition(
+                    u'contains',
+                    expressions.LocalField('alias', GraphQLList(GraphQLString)),
+                    expressions.LocalField('name', GraphQLString)
+                )
+            ),
+            blocks.MarkLocation(child_location),
+            blocks.Backtrack(base_location),
+            blocks.GlobalOperationsStart(),
+            blocks.ConstructResult({
+                'related_name': expressions.OutputContextField(
+                    child_location.navigate_to_field('name'), GraphQLString)
+            }),
+        ]
+        expected_location_types = {
+            base_location: 'Animal',
+            child_location: 'Entity',
+        }
+
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
+
     def test_multiple_filters(self):
         test_data = test_input_data.multiple_filters()
 


### PR DESCRIPTION
Tags are now allowed to appear after filters, if they are on a different property of the same vertex.

Changes made:
- Removed uses of undocumented `context['tags']` and replaced them with `TagInfo` from the metadata table.
- Changed the directive processing order, so that tags at all property fields on a vertex are processed before we compile any of those property fields.