### PR TITLE
Add to_cypher() methods to Expression objects.

### DIFF
--- a/graphql_compiler/compiler/compiler_entities.py
+++ b/graphql_compiler/compiler/compiler_entities.py
@@ -142,3 +142,10 @@ class MarkerBlock(BasicBlock):
         The effect of MarkerBlocks is applied during optimization and code generation steps.
         """
         return u''
+
+    def to_cypher(self):
+        """Return the Cypher representation of the block, which should almost always be empty.
+
+        The effect of MarkerBlocks is applied during optimization and code generation steps.
+        """
+        return u''

--- a/graphql_compiler/compiler/compiler_entities.py
+++ b/graphql_compiler/compiler/compiler_entities.py
@@ -72,6 +72,11 @@ class CompilerEntity(object):
         """Return the Gremlin unicode string representation of this object."""
         raise NotImplementedError()
 
+    @abstractmethod
+    def to_cypher(self):
+        """Return the Cypher unicode string representation of this object."""
+        raise NotImplementedError()
+
 
 @six.add_metaclass(ABCMeta)
 class Expression(CompilerEntity):

--- a/graphql_compiler/compiler/compiler_entities.py
+++ b/graphql_compiler/compiler/compiler_entities.py
@@ -72,11 +72,6 @@ class CompilerEntity(object):
         """Return the Gremlin unicode string representation of this object."""
         raise NotImplementedError()
 
-    @abstractmethod
-    def to_cypher(self):
-        """Return the Cypher unicode string representation of this object."""
-        raise NotImplementedError()
-
 
 @six.add_metaclass(ABCMeta)
 class Expression(CompilerEntity):
@@ -143,13 +138,6 @@ class MarkerBlock(BasicBlock):
 
     def to_gremlin(self):
         """Return the Gremlin representation of the block, which should almost always be empty.
-
-        The effect of MarkerBlocks is applied during optimization and code generation steps.
-        """
-        return u''
-
-    def to_cypher(self):
-        """Return the Cypher representation of the block, which should almost always be empty.
 
         The effect of MarkerBlocks is applied during optimization and code generation steps.
         """

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -968,7 +968,7 @@ class BinaryComposition(Expression):
         else:
             translation_table = {
                 u'=': (u'=', regular_operator_format),
-                u'!=': (u'!=', regular_operator_format),
+                u'!=': (u'<>', regular_operator_format),
                 u'>=': (u'>=', regular_operator_format),
                 u'<=': (u'<=', regular_operator_format),
                 u'>': (u'>', regular_operator_format),

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -95,8 +95,9 @@ class Literal(Expression):
         raise GraphQLCompilationError(u'Cannot represent literal: {}'.format(self.value))
 
     def _to_output_code(self):
-        """Return a unicode object with the Gremlin/MATCH representation of this Literal."""
-        # All supported Literal objects serialize to identical strings both in Gremlin and MATCH.
+        """Return a unicode object with the Gremlin/MATCH/Cypher representation of this Literal."""
+        # All supported Literal objects serialize to identical strings
+        # in all of Gremlin, Cypher, and MATCH.
         self.validate()
         if self.value is None:
             return u'null'
@@ -416,6 +417,7 @@ class ContextField(Expression):
         self.validate()
 
         mark_name, field_name = self.location.get_location_name()
+
         if field_name is not None:
             validate_safe_string(field_name)
             template = u'{mark_name}.{field_name}'
@@ -519,9 +521,8 @@ class OutputContextField(Expression):
         self.validate()
 
         mark_name, field_name = self.location.get_location_name()
-
-        validate_safe_string(field_name)
         validate_safe_string(mark_name)
+        validate_safe_string(field_name)
 
         template = u'{mark_name}.{field_name}'
 


### PR DESCRIPTION
Small, reviewable part of #325 that adds the `to_cypher()` method to the compiler primitives.

Whichever one of this PR and #350 merges first will cause the other to have to incorporate the necessary changes in `BinaryComposition.to_cypher()` to express the new operators correctly. It's not a difficult change, so I'm not worried about it.