### PR TITLE
Add AST and schema manipulation helpers, refactor code to use them.

### DIFF
--- a/graphql_compiler/ast_manipulation.py
+++ b/graphql_compiler/ast_manipulation.py
@@ -1,0 +1,97 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+from graphql.error import GraphQLSyntaxError
+from graphql.language.ast import Document, InlineFragment, OperationDefinition
+from graphql.language.parser import parse
+
+from .exceptions import GraphQLParsingError
+from .schema import TYPENAME_META_FIELD_NAME
+
+
+def get_ast_field_name(ast):
+    """Return the normalized field name for the given AST node."""
+    replacements = {
+        # We always rewrite the following field names into their proper underlying counterparts.
+        TYPENAME_META_FIELD_NAME: '@class'
+    }
+    base_field_name = ast.name.value
+    normalized_name = replacements.get(base_field_name, base_field_name)
+    return normalized_name
+
+
+def get_ast_field_name_or_none(ast):
+    """Return the field name for the AST node, or None if the AST is an InlineFragment."""
+    if isinstance(ast, InlineFragment):
+        return None
+    return get_ast_field_name(ast)
+
+
+def get_human_friendly_ast_field_name(ast):
+    """Return a human-friendly name for the AST node, suitable for error messages."""
+    if isinstance(ast, InlineFragment):
+        return 'type coercion to {}'.format(ast.type_condition)
+    elif isinstance(ast, OperationDefinition):
+        return '{} operation definition'.format(ast.operation)
+
+    return get_ast_field_name(ast)
+
+
+def _preprocess_graphql_string(graphql_string):
+    """Apply any necessary preprocessing to the input GraphQL string, returning the new version."""
+    # HACK(predrag): Workaround for graphql-core issue, to avoid needless errors:
+    #                https://github.com/graphql-python/graphql-core/issues/98
+    return graphql_string + '\n'
+
+
+def safe_parse_graphql(graphql_string):
+    """Return an AST representation of the given GraphQL input, avoiding known land mines."""
+    graphql_string = _preprocess_graphql_string(graphql_string)
+    try:
+        ast = parse(graphql_string)
+    except GraphQLSyntaxError as e:
+        raise GraphQLParsingError(e)
+
+    return ast
+
+
+def get_only_query_definition(document_ast, desired_error_type):
+    """Assert that the Document AST contains only a single definition for a query, and return it."""
+    if not isinstance(document_ast, Document) or not document_ast.definitions:
+        raise AssertionError(u'Received an unexpected value for "document_ast": {}'
+                             .format(document_ast))
+
+    if len(document_ast.definitions) != 1:
+        raise desired_error_type(
+            u'Encountered multiple definitions within GraphQL input. This is not supported.'
+            u'{}'.format(document_ast.definitions))
+
+    definition_ast = document_ast.definitions[0]
+    if definition_ast.operation != 'query':
+        raise desired_error_type(
+            u'Expected a GraphQL document with a single query definition, but instead found a '
+            u'but instead found a "{}" operation. This is not supported.'
+            .format(definition_ast.operation))
+
+    return definition_ast
+
+
+def get_only_selection_from_ast(ast, desired_error_type):
+    """Return the selected sub-ast, ensuring that there is precisely one."""
+    selections = [] if ast.selection_set is None else ast.selection_set.selections
+
+    if len(selections) != 1:
+        ast_name = get_human_friendly_ast_field_name(ast)
+        if selections:
+            selection_names = [
+                get_human_friendly_ast_field_name(selection_ast)
+                for selection_ast in selections
+            ]
+            raise desired_error_type(u'Expected an AST with exactly one selection, but found '
+                                     u'{} selections at AST node named {}: {}'
+                                     .format(len(selection_names), selection_names, ast_name))
+        else:
+            ast_name = get_human_friendly_ast_field_name(ast)
+            raise desired_error_type(u'Expected an AST with exactly one selection, but got '
+                                     u'one with no selections. Error near AST node named: {}'
+                                     .format(ast_name))
+
+    return selections[0]

--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -1018,7 +1018,7 @@ def validate_schema_and_ast(schema, ast):
 
 
 def ast_to_ir(schema, ast, type_equivalence_hints=None):
-    """Convert the given GraphQL string into compiler IR, using the given schema object.
+    """Convert the given GraphQL AST object into compiler IR, using the given schema object.
 
     Args:
         schema: GraphQL schema object, created using the GraphQL library

--- a/graphql_compiler/compiler/directive_helpers.py
+++ b/graphql_compiler/compiler/directive_helpers.py
@@ -4,12 +4,10 @@
 from graphql.language.ast import InlineFragment
 import six
 
+from ..ast_manipulation import get_ast_field_name, get_ast_field_name_or_none
 from ..exceptions import GraphQLCompilationError
 from .filters import is_filter_with_outer_scope_vertex_field_operator
-from .helpers import (
-    FilterOperationInfo, get_ast_field_name, get_ast_field_name_or_none, get_vertex_field_type,
-    is_vertex_field_type
-)
+from .helpers import FilterOperationInfo, get_vertex_field_type, is_vertex_field_type
 
 
 ALLOWED_DUPLICATED_DIRECTIVES = frozenset({'filter'})

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -7,9 +7,10 @@ from graphql.type.definition import is_leaf_type
 
 from . import blocks, expressions
 from ..exceptions import GraphQLCompilationError, GraphQLValidationError
+from ..schema import is_vertex_field_name
 from .helpers import (
     get_uniquely_named_objects_by_name, is_runtime_parameter, is_tagged_parameter,
-    is_vertex_field_name, is_vertex_field_type, strip_non_null_from_type, validate_safe_string
+    is_vertex_field_type, strip_non_null_from_type, validate_safe_string
 )
 from .metadata import FilterInfo
 

--- a/graphql_compiler/compiler/ir_lowering_match/utils.py
+++ b/graphql_compiler/compiler/ir_lowering_match/utils.py
@@ -4,12 +4,13 @@ import itertools
 
 import six
 
+from ...schema import is_vertex_field_name
 from ..blocks import Filter
 from ..expressions import (
     BinaryComposition, Expression, GlobalContextField, Literal, LocalField, NullLiteral,
     TrueLiteral, UnaryTransformation, ZeroLiteral
 )
-from ..helpers import get_only_element_from_collection, is_vertex_field_name
+from ..helpers import get_only_element_from_collection
 
 
 def convert_coerce_type_to_instanceof_filter(coerce_type_block):

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -9,7 +9,6 @@ from graphql import (
     GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLScalarType,
     GraphQLString
 )
-from graphql.type.directives import specified_directives
 import six
 
 

--- a/graphql_compiler/schema.py
+++ b/graphql_compiler/schema.py
@@ -9,6 +9,7 @@ from graphql import (
     GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLScalarType,
     GraphQLString
 )
+from graphql.type.directives import specified_directives
 import six
 
 
@@ -190,6 +191,20 @@ RecurseDirective = GraphQLDirective(
         DirectiveLocation.FIELD,
     ]
 )
+
+
+OUTBOUND_EDGE_FIELD_PREFIX = 'out_'
+INBOUND_EDGE_FIELD_PREFIX = 'in_'
+VERTEX_FIELD_PREFIXES = frozenset({OUTBOUND_EDGE_FIELD_PREFIX, INBOUND_EDGE_FIELD_PREFIX})
+
+
+def is_vertex_field_name(field_name):
+    """Return True if the field's name indicates it is a non-root vertex field."""
+    # N.B.: A vertex field is a field whose type is a vertex type. This is what edges are.
+    return (
+        field_name.startswith(OUTBOUND_EDGE_FIELD_PREFIX) or
+        field_name.startswith(INBOUND_EDGE_FIELD_PREFIX)
+    )
 
 
 def _unused_function(*args, **kwargs):


### PR DESCRIPTION
PR 1/n for merging the `macro_system` branch into `master`. See #356 for the full context of where we're going, and how we're getting there.

Relative to #356, I removed the directive validation code from `schema.py` and I'll add it back (possibly with minor changes) when we have a bit of a better idea of how we'll handle the schema-level directives for which edges are macro edges vs not. See the discussion with @MichaelaShtilmanMinkin on the documentation in #356 for reasons why we might need such additional directives that may cause changes in the validation logic.