### PR TITLE
Broaden query formatting APIs, and ensure they handle non-null types

### DIFF
--- a/graphql_compiler/query_formatting/__init__.py
+++ b/graphql_compiler/query_formatting/__init__.py
@@ -1,3 +1,3 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Safely insert runtime arguments into compiled GraphQL queries."""
-from .common import insert_arguments_into_query  # noqa
+from .common import insert_arguments_into_query, validate_argument_type  # noqa

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -1,18 +1,106 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Safely insert runtime arguments into compiled GraphQL queries."""
+import datetime
+import decimal
+
+import arrow
+from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 import six
 
 from ..compiler import GREMLIN_LANGUAGE, MATCH_LANGUAGE, SQL_LANGUAGE
+from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
+from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .gremlin_formatting import insert_arguments_into_gremlin_query
 from .match_formatting import insert_arguments_into_match_query
 from .sql_formatting import insert_arguments_into_sql_query
 
 
-def _ensure_arguments_are_provided(expected_types, arguments):
+######
+# Public API
+######
+
+
+def validate_argument_type(expected_type, value):
+    """Ensure the value has the expected type and is usable in any of our backends, or raise errors.
+
+    Backends are the database languages we have the ability to compile to, like OrientDB MATCH,
+    Gremlin, or SQLAlchemy. This function should be stricter than the validation done by any
+    specific backend. That way code that passes validation can be compiled to any backend.
+
+    Args:
+        expected_type: GraphQLType we expect. All GraphQLNonNull type wrappers are stripped.
+        value: object that can be interpreted as being of that type
+    """
+    stripped_type = strip_non_null_from_type(expected_type)
+    if GraphQLString.is_same_type(stripped_type):
+        if not isinstance(value, six.string_types):
+            raise GraphQLInvalidArgumentError(u'Attempting to convert a non-string into a string: '
+                                              u'{}'.format(value))
+    elif GraphQLID.is_same_type(stripped_type):
+        # IDs can be strings or numbers, but the GraphQL library coerces them to strings.
+        # We will follow suit and treat them as strings.
+        if not isinstance(value, six.string_types):
+            raise GraphQLInvalidArgumentError(u'Attempting to convert a non-string into a string: '
+                                              u'{}'.format(value))
+    elif GraphQLFloat.is_same_type(stripped_type):
+        if not isinstance(value, float):
+            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-float as a float: '
+                                              u'{} {}'.format(type(value), value))
+    elif GraphQLInt.is_same_type(stripped_type):
+        # Special case: in Python, isinstance(True, int) returns True.
+        # Safeguard against this with an explicit check against bool type.
+        if isinstance(value, bool) or not isinstance(value, six.integer_types):
+            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-int as an int: '
+                                              u'{} {}'.format(type(value), value))
+    elif GraphQLBoolean.is_same_type(stripped_type):
+        if not isinstance(value, bool):
+            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-bool as a bool: '
+                                              u'{} {}'.format(type(value), value))
+    elif GraphQLDecimal.is_same_type(stripped_type):
+        # Types we support are int, float, and Decimal, but not bool.
+        # isinstance(True, int) returns True, so we explicitly forbid bool.
+        if isinstance(value, bool):
+            raise GraphQLInvalidArgumentError(
+                u'Attempting to represent a non-decimal as a decimal: {} {}'
+                .format(type(value), value))
+        if not isinstance(value, decimal.Decimal):
+            try:
+                decimal.Decimal(value)
+            except decimal.InvalidOperation as e:
+                raise GraphQLInvalidArgumentError(e)
+    elif GraphQLDate.is_same_type(stripped_type):
+        # Datetimes pass as instances of date. We want to explicitly only allow dates.
+        if isinstance(value, datetime.datetime) or not isinstance(value, datetime.date):
+            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-date as a date: '
+                                              u'{} {}'.format(type(value), value))
+        try:
+            stripped_type.serialize(value)
+        except ValueError as e:
+            raise GraphQLInvalidArgumentError(e)
+    elif GraphQLDateTime.is_same_type(stripped_type):
+        if not isinstance(value, (datetime.date, arrow.Arrow)):
+            raise GraphQLInvalidArgumentError(
+                u'Attempting to represent a non-datetime as a datetime: {} {}'
+                .format(type(value), value))
+        try:
+            stripped_type.serialize(value)
+        except ValueError as e:
+            raise GraphQLInvalidArgumentError(e)
+    elif isinstance(stripped_type, GraphQLList):
+        if not isinstance(value, list):
+            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-list as a list: '
+                                              u'{} {}'.format(type(value), value))
+        inner_type = strip_non_null_from_type(stripped_type.of_type)
+        for element in value:
+            validate_argument_type(inner_type, element)
+    else:
+        raise AssertionError(u'Could not safely represent the requested GraphQLType: '
+                             u'{} {}'.format(stripped_type, value))
+
+
+def ensure_arguments_are_provided(expected_types, arguments):
     """Ensure that all arguments expected by the query were actually provided."""
-    # This function only checks that the arguments were specified,
-    # and does not check types. Type checking is done as part of the actual formatting step.
     expected_arg_names = set(six.iterkeys(expected_types))
     provided_arg_names = set(six.iterkeys(arguments))
 
@@ -22,11 +110,9 @@ def _ensure_arguments_are_provided(expected_types, arguments):
         raise GraphQLInvalidArgumentError(u'Missing or unexpected arguments found: '
                                           u'missing {}, unexpected '
                                           u'{}'.format(missing_args, unexpected_args))
+    for name in expected_arg_names:
+        validate_argument_type(expected_types[name], arguments[name])
 
-
-######
-# Public API
-######
 
 def insert_arguments_into_query(compilation_result, arguments):
     """Insert the arguments into the compiled GraphQL query to form a complete query.
@@ -38,7 +124,7 @@ def insert_arguments_into_query(compilation_result, arguments):
     Returns:
         string, a query in the appropriate output language, with inserted argument data
     """
-    _ensure_arguments_are_provided(compilation_result.input_metadata, arguments)
+    ensure_arguments_are_provided(compilation_result.input_metadata, arguments)
 
     if compilation_result.language == MATCH_LANGUAGE:
         return insert_arguments_into_match_query(compilation_result, arguments)

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -215,4 +215,3 @@ class QueryFormattingTests(unittest.TestCase):
 
         for graphql_type, value in type_and_value:
             validate_argument_type(graphql_type, value)
-

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -1,13 +1,19 @@
 # Copyright 2017-present Kensho Technologies, LLC.
+import datetime
 from decimal import Decimal
 import unittest
 
-from graphql import GraphQLList, GraphQLNonNull, GraphQLString
+from graphql import (
+    GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString
+)
+import pytz
 
 from .. import graphql_to_gremlin, graphql_to_match
 from ..compiler import compile_graphql_to_gremlin, compile_graphql_to_match
 from ..exceptions import GraphQLInvalidArgumentError
-from ..query_formatting import insert_arguments_into_query, validate_argument_type
+from ..query_formatting import insert_arguments_into_query
+from ..query_formatting.common import validate_argument_type
+from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .test_helpers import compare_gremlin, compare_match, get_schema
 
 
@@ -156,6 +162,46 @@ class QueryFormattingTests(unittest.TestCase):
             with self.assertRaises(GraphQLInvalidArgumentError):
                 graphql_to_gremlin(schema, EXAMPLE_GRAPHQL_QUERY, {})
 
+    def test_argument_types(self):
+        test_cases = (
+            (GraphQLString, ('asdf',), (4, 5.4, True)),
+            (GraphQLID, ('13d72846-1777-6c3a-5743-5d9ced3032ed', 'asf'), (4, 4.4, True)),
+            (GraphQLFloat, (4.1, 4.0), ('4.3', 5)),
+            (GraphQLInt, (3, 4), (4.0, 4.1, True, False, '4')),
+            (GraphQLBoolean, (True, False,), ('True', 0, 1, 0.4)),
+            (GraphQLDecimal, (Decimal(4), 0.4, 4), (True, 'sdfsdf')),
+            (
+                GraphQLDate, (
+                    datetime.date(2007, 12, 6),
+                    datetime.date(2008, 12, 6),
+                    datetime.date(2009, 12, 6),
+                ), (
+                    '2007-12-06',
+                    datetime.datetime(2007, 12, 6, 16, 29, 43, 79043),
+                )
+            ),
+            (
+                GraphQLDateTime, (
+                    datetime.datetime(2007, 12, 6, 16, 29, 43, 79043),
+                    datetime.datetime(2008, 12, 6, 16, 29, 43, 79043, tzinfo=pytz.utc),
+                    datetime.datetime(2009, 12, 6, 16, 29, 43, 79043,
+                                      tzinfo=pytz.timezone('US/Eastern')),
+                    datetime.datetime(2007, 12, 6),
+                ), (
+                    '2007-12-06 16:29:43',
+                    datetime.date(2007, 12, 6),
+                )
+            ),
+            (GraphQLList(GraphQLInt), ([], [1], [3, 5]), (4, ['a'], [1, 'a'], [True])),
+            (GraphQLList(GraphQLString), ([], ['a']), (1, 'a', ['a', 4])),
+        )
+        for graphql_type, valid_values, invalid_values in test_cases:
+            for valid_value in valid_values:
+                validate_argument_type(graphql_type, valid_value)
+            for invalid_value in invalid_values:
+                with self.assertRaises(GraphQLInvalidArgumentError):
+                    validate_argument_type(graphql_type, invalid_value)
+
     def test_non_null_types_pass_validation(self):
         type_and_value = [
             (GraphQLString, 'abc'),  # sanity check
@@ -169,3 +215,4 @@ class QueryFormattingTests(unittest.TestCase):
 
         for graphql_type, value in type_and_value:
             validate_argument_type(graphql_type, value)
+


### PR DESCRIPTION
PR 2/n for merging the `macro_system` branch into `master`. See #356 for the full context of where we're going, and how we're getting there.

Relative to #356, I added handling for non-null types and a test case to make sure that code is correct.