### PR TITLE
Rename graph_client to orientdb_client

### DIFF
--- a/graphql_compiler/tests/conftest.py
+++ b/graphql_compiler/tests/conftest.py
@@ -9,7 +9,7 @@ from .test_data_tools.data_tool import (
     generate_orient_integration_data, generate_orient_snapshot_data, generate_sql_integration_data,
     init_sql_integration_test_backends, tear_down_integration_test_backends
 )
-from .test_data_tools.graph import get_test_graph
+from .test_data_tools.orientdb_graph import get_test_orientdb_graph
 from .test_data_tools.schema import load_schema
 
 
@@ -19,25 +19,26 @@ from .test_data_tools.schema import load_schema
 
 
 @pytest.fixture(scope='session')
-def init_snapshot_graph_client():
+def init_snapshot_orientdb_client():
     """Return a client for an initialized db, with all test data imported."""
-    return _init_graph_client(load_schema, generate_orient_snapshot_data)
+    return _init_orientdb_client(load_schema, generate_orient_snapshot_data)
 
 
 @pytest.fixture(scope='session')
-def init_integration_graph_client():
+def init_integration_orientdb_client():
     """Return a client for an initialized db, with all test data imported."""
-    return _init_graph_client(load_schema, generate_orient_integration_data)
+    return _init_orientdb_client(load_schema, generate_orient_integration_data)
 
 
-def _init_graph_client(load_schema_func, generate_data_func):
+def _init_orientdb_client(load_schema_func, generate_data_func):
     graph_name = 'animals'
 
     # Try to set up the database for the test up to 20 times before giving up.
     set_up_successfully = False
     for _ in range(20):
         try:
-            graph_client = get_test_graph(graph_name, load_schema_func, generate_data_func)
+            orientdb_client = get_test_orientdb_graph(graph_name, load_schema_func,
+                                                      generate_data_func)
             set_up_successfully = True
             break
         except Exception as e:  # pylint: disable=broad-except
@@ -47,19 +48,19 @@ def _init_graph_client(load_schema_func, generate_data_func):
     if not set_up_successfully:
         raise AssertionError(u'Failed to set up database without raising an exception!')
 
-    return graph_client
+    return orientdb_client
 
 
 @pytest.fixture(scope='class')
-def snapshot_graph_client(request, init_snapshot_graph_client):
+def snapshot_orientdb_client(request, init_snapshot_orientdb_client):
     """Get a client for an initialized db, with all test data imported."""
-    request.cls.graph_client = init_snapshot_graph_client
+    request.cls.orientdb_client = init_snapshot_orientdb_client
 
 
 @pytest.fixture(scope='class')
-def integration_graph_client(request, init_integration_graph_client):
+def integration_orientdb_client(request, init_integration_orientdb_client):
     """Get a client for an initialized db, with all test data imported."""
-    request.cls.graph_client = init_integration_graph_client
+    request.cls.orientdb_client = init_integration_orientdb_client
 
 
 @pytest.fixture(scope='class')

--- a/graphql_compiler/tests/integration_tests/integration_test_helpers.py
+++ b/graphql_compiler/tests/integration_tests/integration_test_helpers.py
@@ -36,7 +36,7 @@ def try_convert_decimal_to_string(value):
     return value
 
 
-def compile_and_run_match_query(schema, graphql_query, parameters, graph_client):
+def compile_and_run_match_query(schema, graphql_query, parameters, orientdb_client):
     """Compiles and runs a MATCH query against the supplied graph client."""
     # MATCH code emitted by the compiler expects Decimals to be passed in as strings
     converted_parameters = {
@@ -46,7 +46,7 @@ def compile_and_run_match_query(schema, graphql_query, parameters, graph_client)
     compilation_result = graphql_to_match(schema, graphql_query, converted_parameters)
 
     query = compilation_result.query
-    results = [row.oRecordData for row in graph_client.command(query)]
+    results = [row.oRecordData for row in orientdb_client.command(query)]
     return results
 
 

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -31,7 +31,7 @@ all_backends = parameterized.expand([
 # Store the typical fixtures required for an integration tests.
 # Individual tests can supply the full @pytest.mark.usefixtures to override if necessary.
 integration_fixtures = pytest.mark.usefixtures(
-    'integration_graph_client',
+    'integration_orientdb_client',
     'sql_integration_data',
 )
 
@@ -79,7 +79,7 @@ class IntegrationTests(TestCase):
                 cls.schema, graphql_query, parameters, engine, cls.sql_metadata)
         elif backend_name in MATCH_BACKENDS:
             results = compile_and_run_match_query(
-                cls.schema, graphql_query, parameters, cls.graph_client)
+                cls.schema, graphql_query, parameters, cls.orientdb_client)
         else:
             raise AssertionError(u'Unknown test backend {}.'.format(backend_name))
         return results
@@ -194,7 +194,7 @@ class IntegrationTests(TestCase):
         class_to_field_type_overrides = {
             'UniquelyIdentifiable': {'uuid': GraphQLID}
         }
-        schema, _ = generate_schema(self.graph_client,
+        schema, _ = generate_schema(self.orientdb_client,
                                     class_to_field_type_overrides=class_to_field_type_overrides,
                                     hidden_classes={ORIENTDB_BASE_VERTEX_CLASS_NAME})
         compare_ignoring_whitespace(self, SCHEMA_TEXT, print_schema(schema), None)
@@ -204,7 +204,7 @@ class IntegrationTests(TestCase):
         class_to_field_type_overrides = {
             'UniquelyIdentifiable': {'uuid': GraphQLID}
         }
-        schema, _ = generate_schema(self.graph_client,
+        schema, _ = generate_schema(self.orientdb_client,
                                     class_to_field_type_overrides=class_to_field_type_overrides)
         # Since Animal implements the UniquelyIdentifiable interface and since we we overrode
         # UniquelyIdentifiable's uuid field to be of type GraphQLID when we generated the schema,
@@ -213,18 +213,18 @@ class IntegrationTests(TestCase):
 
     @integration_fixtures
     def test_include_admissible_non_graph_class(self):
-        schema, _ = generate_schema(self.graph_client)
+        schema, _ = generate_schema(self.orientdb_client)
         # Included abstract non-vertex classes whose non-abstract subclasses are all vertexes.
         self.assertIsNotNone(schema.get_type('UniquelyIdentifiable'))
 
     @integration_fixtures
     def test_selectively_hide_classes(self):
-        schema, _ = generate_schema(self.graph_client, hidden_classes={'Animal'})
+        schema, _ = generate_schema(self.orientdb_client, hidden_classes={'Animal'})
         self.assertNotIn('Animal', schema.get_type_map())
 
     @integration_fixtures
     def test_parsed_schema_element_custom_fields(self):
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         parent_of_edge = schema_graph.get_element_by_class_name('Animal_ParentOf')
         expected_custom_class_fields = {
             'human_name_in': 'Parent',

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -22,7 +22,7 @@ def create_lookup_counts(count_data):
     return lookup_counts
 
 
-# The following TestCase class uses the 'snapshot_graph_client' fixture
+# The following TestCase class uses the 'snapshot_orientdb_client' fixture
 # which pylint does not recognize as a class member.
 # pylint: disable=no-member
 @pytest.mark.slow
@@ -30,10 +30,10 @@ class CostEstimationTests(unittest.TestCase):
     """Test the cost estimation module using standard input data when possible."""
 
     # TODO: These tests can be sped up by having an existing test SchemaGraph object.
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_root_count(self):
         """"Ensure we correctly estimate the cardinality of the query root."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         test_data = test_input_data.immediate_output()
 
         count_data = {
@@ -48,10 +48,10 @@ class CostEstimationTests(unittest.TestCase):
 
         self.assertEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_traverse(self):
         """Ensure we correctly estimate cardinality over edges."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         test_data = test_input_data.traverse_and_output()
 
         count_data = {
@@ -69,10 +69,10 @@ class CostEstimationTests(unittest.TestCase):
 
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fragment(self):
         """Ensure we correctly adjust for fragments."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         test_data = test_input_data.simple_union()
 
         count_data = {
@@ -92,10 +92,10 @@ class CostEstimationTests(unittest.TestCase):
 
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_complex_traverse(self):
         """Ensure we correctly handle more complicated arrangements of traversals."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 in_Entity_Related {
@@ -138,10 +138,10 @@ class CostEstimationTests(unittest.TestCase):
         )
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional(self):
         """Ensure we handle an optional edge correctly."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_BornAt @optional {
@@ -173,10 +173,10 @@ class CostEstimationTests(unittest.TestCase):
 
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_and_traverse(self):
         """Ensure traversals inside optionals are handled correctly."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 in_Entity_Related @optional {
@@ -229,10 +229,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 3.0 * (23.0 / 11.0) * (7.0 / 11.0) * (17.0 / 13.0)
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold(self):
         """Ensure we handle an folded edge correctly."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_BornAt @fold {
@@ -264,10 +264,10 @@ class CostEstimationTests(unittest.TestCase):
 
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_and_traverse(self):
         """Ensure traversals inside folds are handled correctly."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 in_Entity_Related @fold {
@@ -319,10 +319,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 3.0 * (23.0 / 11.0) * (7.0 / 11.0) * (17.0 / 13.0)
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_recurse(self):
         """Ensure we handle recursion correctly."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_ParentOf @recurse(depth: 2){
@@ -347,10 +347,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 7.0 * (11.0 / 7.0 + 1)
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_recurse_and_traverse(self):
         """Ensure we handle traversals inside recurses correctly."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_ParentOf @recurse(depth: 2){
@@ -380,11 +380,11 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 7.0 * (11.0 / 7.0 + 1) * (13.0 / 7.0)
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_single_filter(self):
         """Ensure we handle filters correctly."""
         # TODO: eventually, we should ensure other fractional/absolute selectivies work.
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 uuid @filter(op_name: "=", value:["$uuid"])
@@ -408,10 +408,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 1.0
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_traverse_and_filter(self):
         """Ensure we filters work correctly below the root location."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_BornAt {
@@ -446,10 +446,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 3.0 * 1.0 * (7.0 / 17.0) * (11.0 / 17.0)
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_multiple_filters(self):
         """Ensure we handle multiple filters correctly."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal @filter(op_name: "name_or_alias", value: ["$name"]) {
                 uuid @filter(op_name: "=", value:["$uuid"])
@@ -476,10 +476,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 1.0
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_and_filter(self):
         """Test an optional and filter on the same Location."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_BornAt @optional {
@@ -517,10 +517,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 5.0 * 1.0 * (11.0 / 7.0) * (6.0 / 7.0)
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_then_filter(self):
         """Test a filter within an optional scope."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_BornAt @optional {
@@ -559,10 +559,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 5.0 * 1.0
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_and_filter(self):
         """Test an fold and filter on the same Location."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_BornAt @fold {
@@ -600,10 +600,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 5.0 * 1.0 * (11.0 / 7.0) * (6.0 / 7.0)
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_then_filter(self):
         """Test a filter within an fold scope."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_BornAt @fold {
@@ -642,10 +642,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 5.0 * 1.0
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_recurse_and_filter(self):
         """Test a filter that immediately follows a recursed edge."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_ParentOf @recurse(depth: 2){
@@ -677,10 +677,10 @@ class CostEstimationTests(unittest.TestCase):
         expected_cardinality_estimate = 7.0 * 1.0 * (13.0 / 7.0)
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_recurse_then_filter(self):
         """Test a filter that immediately follows a recursed edge."""
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
                 out_Animal_ParentOf @recurse(depth: 2){
@@ -763,9 +763,9 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=2.0)
         self.assertEqual(expected_selectivity, _combine_filter_selectivities(selectivities))
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_get_equals_filter_selectivity(self):
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         classname = 'Animal'
 
         def empty_lookup_counts(classname):
@@ -801,9 +801,9 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=1.0)
         self.assertEqual(expected_selectivity, selectivity)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_get_in_collection_filter_selectivity(self):
-        schema_graph = generate_schema_graph(self.graph_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)
         classname = 'Animal'
 
         def empty_lookup_counts(classname):

--- a/graphql_compiler/tests/snapshot_tests/test_orientdb_match_query.py
+++ b/graphql_compiler/tests/snapshot_tests/test_orientdb_match_query.py
@@ -63,7 +63,7 @@ def execute_graphql(schema, test_data, client, sample_parameters):
     return row_counters_frozenset
 
 
-# The following TestCase class uses the 'snapshot_graph_client' fixture
+# The following TestCase class uses the 'snapshot_orientdb_client' fixture
 # which pylint does not recognize as a class member.
 # pylint: disable=no-member
 
@@ -75,480 +75,480 @@ class OrientDBUnparameterizedMatchQueryTests(TestCase):
         self.maxDiff = None
         self.schema = get_schema()
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_immediate_output(self):
         test_data = test_input_data.immediate_output()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_immediate_output_custom_scalars(self):
         test_data = test_input_data.immediate_output_custom_scalars()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_traverse_and_output(self):
         test_data = test_input_data.traverse_and_output()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_traverse_after_mandatory_traverse(self):
         test_data = test_input_data.optional_traverse_after_mandatory_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_filter_on_optional_variable_equality(self):
         test_data = test_input_data.filter_on_optional_variable_equality()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_filter_on_optional_variable_name_or_alias(self):
         test_data = test_input_data.filter_on_optional_variable_name_or_alias()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_complex_optional_variables(self):
         test_data = test_input_data.complex_optional_variables()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_simple_fragment(self):
         test_data = test_input_data.simple_fragment()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_simple_union(self):
         test_data = test_input_data.simple_union()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_on_union(self):
         test_data = test_input_data.optional_on_union()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_typename_output(self):
         test_data = test_input_data.typename_output()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_simple_recurse(self):
         test_data = test_input_data.simple_recurse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_recurse_within_fragment(self):
         test_data = test_input_data.recurse_within_fragment()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_recurse_with_immediate_type_coercion(self):
         test_data = test_input_data.recurse_with_immediate_type_coercion()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_in_collection_op_filter_with_tag(self):
         test_data = test_input_data.in_collection_op_filter_with_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_in_collection_op_filter_with_optional_tag(self):
         test_data = test_input_data.in_collection_op_filter_with_optional_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_not_in_collection_op_filter_with_tag(self):
         test_data = test_input_data.not_in_collection_op_filter_with_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_not_in_collection_op_filter_with_optional_tag(self):
         test_data = test_input_data.not_in_collection_op_filter_with_optional_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_intersects_op_filter_with_tag(self):
         test_data = test_input_data.intersects_op_filter_with_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_intersects_op_filter_with_optional_tag(self):
         test_data = test_input_data.intersects_op_filter_with_optional_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_contains_op_filter_with_tag(self):
         test_data = test_input_data.contains_op_filter_with_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_contains_op_filter_with_optional_tag(self):
         test_data = test_input_data.contains_op_filter_with_optional_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_not_contains_op_filter_with_tag(self):
         test_data = test_input_data.not_contains_op_filter_with_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_not_contains_op_filter_with_optional_tag(self):
         test_data = test_input_data.not_contains_op_filter_with_optional_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_has_substring_op_filter_with_optional_tag(self):
         test_data = test_input_data.has_substring_op_filter_with_optional_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_on_output_variable(self):
         test_data = test_input_data.fold_on_output_variable()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_after_traverse(self):
         test_data = test_input_data.fold_after_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_and_traverse(self):
         test_data = test_input_data.fold_and_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_and_deep_traverse(self):
         test_data = test_input_data.fold_and_deep_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_traverse_and_fold_and_traverse(self):
         test_data = test_input_data.traverse_and_fold_and_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_multiple_outputs_in_same_fold(self):
         test_data = test_input_data.multiple_outputs_in_same_fold()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_multiple_outputs_in_same_fold_and_traverse(self):
         test_data = test_input_data.multiple_outputs_in_same_fold_and_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_multiple_folds(self):
         test_data = test_input_data.multiple_folds()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_multiple_folds_and_traverse(self):
         test_data = test_input_data.multiple_folds_and_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_date_and_datetime_fields(self):
         test_data = test_input_data.fold_date_and_datetime_fields()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_coercion_to_union_base_type_inside_fold(self):
         test_data = test_input_data.coercion_to_union_base_type_inside_fold()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_no_op_coercion_inside_fold(self):
         test_data = test_input_data.no_op_coercion_inside_fold()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_coercion_on_interface_within_fold_scope(self):
         test_data = test_input_data.coercion_on_interface_within_fold_scope()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_coercion_on_interface_within_fold_traversal(self):
         test_data = test_input_data.coercion_on_interface_within_fold_traversal()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_coercion_on_union_within_fold_scope(self):
         test_data = test_input_data.coercion_on_union_within_fold_scope()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_and_traverse(self):
         test_data = test_input_data.optional_and_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_and_deep_traverse(self):
         test_data = test_input_data.optional_and_deep_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_traverse_and_optional_and_traverse(self):
         test_data = test_input_data.traverse_and_optional_and_traverse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_coercion_on_interface_within_optional_traversal(self):
         test_data = test_input_data.coercion_on_interface_within_optional_traversal()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_filter_on_optional_traversal_equality(self):
         test_data = test_input_data.filter_on_optional_traversal_equality()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_filter_on_optional_traversal_name_or_alias(self):
         test_data = test_input_data.filter_on_optional_traversal_name_or_alias()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_simple_optional_recurse(self):
         test_data = test_input_data.simple_optional_recurse()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_multiple_traverse_within_optional(self):
         test_data = test_input_data.multiple_traverse_within_optional()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_and_fold(self):
         test_data = test_input_data.optional_and_fold()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_and_optional(self):
         test_data = test_input_data.fold_and_optional()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_optional_traversal_and_fold_traversal(self):
         test_data = test_input_data.optional_traversal_and_fold_traversal()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_fold_traversal_and_optional_traversal(self):
         test_data = test_input_data.fold_traversal_and_optional_traversal()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_coercion_and_filter_with_tag(self):
         test_data = test_input_data.coercion_and_filter_with_tag()
         sample_parameters = {}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
@@ -561,43 +561,43 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
         self.maxDiff = None
         self.schema = get_schema()
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_immediate_output_with_custom_scalar_filter(self):
         test_data = test_input_data.immediate_output_with_custom_scalar_filter()
         sample_parameters = {'min_worth': 500}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_multiple_filters(self):
         test_data = test_input_data.multiple_filters()
         sample_parameters = {'lower_bound': 'Nazgul', 'upper_bound': 'Pteranodon'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_traverse_filter_and_output(self):
         test_data = test_input_data.traverse_filter_and_output()
         sample_parameters = {'wanted': 'Nazgul__2'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_name_or_alias_filter_on_interface_type(self):
         test_data = test_input_data.name_or_alias_filter_on_interface_type()
         sample_parameters = {'wanted': 'Nazgul_1'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_output_source_and_complex_output(self):
         test_data = test_input_data.output_source_and_complex_output()
         sample_name = 'Nazgul__((((18_19_2_6)_1_19_6)_15_16_2)_14_8_9)'
@@ -605,38 +605,38 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
             'wanted': sample_name
         }
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_filter_in_optional_block(self):
         test_data = test_input_data.filter_in_optional_block()
         sample_parameters = {'name': 'Nazgul__2'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_between_filter_on_simple_scalar(self):
         test_data = test_input_data.between_filter_on_simple_scalar()
         sample_parameters = {'lower': 'Nazgul', 'upper': 'Pteranodon'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_between_lowering_on_simple_scalar(self):
         test_data = test_input_data.between_lowering_on_simple_scalar()
         sample_parameters = {'lower': 'Nazgul', 'upper': 'Pteranodon'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_between_lowering_with_extra_filters(self):
         test_data = test_input_data.between_lowering_with_extra_filters()
         sample_fauna = [
@@ -676,65 +676,65 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
             'fauna': sample_fauna,
         }
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_no_between_lowering_on_simple_scalar(self):
         test_data = test_input_data.no_between_lowering_on_simple_scalar()
         sample_parameters = {'lower0': 'Nazgul', 'lower1': 'Nazgul_3', 'upper': 'Pteranodon'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_complex_optional_variables_with_starting_filter(self):
         test_data = test_input_data.complex_optional_variables_with_starting_filter()
         sample_parameters = {'animal_name': 'Nazgul__((((18_19_2_6)_1_19_6)_15_16_2)_11_14_6)'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_filter_on_fragment_in_union(self):
         test_data = test_input_data.filter_on_fragment_in_union()
         sample_parameters = {'wanted': 'Bacon'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_typename_filter(self):
         test_data = test_input_data.typename_filter()
         sample_parameters = {'base_cls': 'Food'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_filter_within_recurse(self):
         test_data = test_input_data.filter_within_recurse()
         sample_parameters = {'wanted': 'red'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_recurse_with_immediate_type_coercion_and_filter(self):
         test_data = test_input_data.recurse_with_immediate_type_coercion_and_filter()
         sample_parameters = {'color': 'red'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_in_collection_op_filter_with_variable(self):
         test_data = test_input_data.in_collection_op_filter_with_variable()
         sample_names = [
@@ -759,11 +759,11 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
         ]
         sample_parameters = {'wanted': sample_names}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_not_in_collection_op_filter_with_variable(self):
         test_data = test_input_data.not_in_collection_op_filter_with_variable()
         sample_names = [
@@ -788,11 +788,11 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
         ]
         sample_parameters = {'wanted': sample_names}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_intersects_op_filter_with_variable(self):
         test_data = test_input_data.intersects_op_filter_with_variable()
         sample_names = [
@@ -802,71 +802,71 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
         ]
         sample_parameters = {'wanted': sample_names}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_contains_op_filter_with_variable(self):
         test_data = test_input_data.contains_op_filter_with_variable()
         sample_parameters = {'wanted': 'Nazgul_1'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_not_contains_op_filter_with_variable(self):
         test_data = test_input_data.not_contains_op_filter_with_variable()
         sample_parameters = {'wanted': 'Nazgul_1'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_has_substring_op_filter(self):
         test_data = test_input_data.has_substring_op_filter()
         sample_parameters = {'wanted': '6)_((1_12'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_has_edge_degree_op_filter(self):
         test_data = test_input_data.has_edge_degree_op_filter()
         sample_parameters = {'child_count': 9}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_has_edge_degree_op_filter_with_optional(self):
         test_data = test_input_data.has_edge_degree_op_filter_with_optional()
 
         sample_parameters = {'child_count': 1}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_has_edge_degree_op_filter_with_fold(self):
         test_data = test_input_data.has_edge_degree_op_filter_with_fold()
         sample_parameters = {'child_count': 9}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 
-    @pytest.mark.usefixtures('snapshot_graph_client')
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_filter_within_fold_scope(self):
         test_data = test_input_data.filter_within_fold_scope()
         sample_parameters = {'desired': 'Nazgul__2'}
 
-        rows = execute_graphql(self.schema, test_data, self.graph_client, sample_parameters)
+        rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)
 
         self.assertMatchSnapshot(rows)
 

--- a/graphql_compiler/tests/test_data_tools/orientdb_graph.py
+++ b/graphql_compiler/tests/test_data_tools/orientdb_graph.py
@@ -16,7 +16,7 @@ def get_orientdb_url(database_name):
     return template.format(ORIENTDB_SERVER, database_name)
 
 
-def get_test_graph(graph_name, load_schema_func, generate_data_func):
+def get_test_orientdb_graph(graph_name, load_schema_func, generate_data_func):
     """Generate the test database and return the pyorient client."""
     url = get_orientdb_url(graph_name)
     config = Config.from_url(url, ORIENTDB_USER, ORIENTDB_PASSWORD, initial_drop=True)

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -272,18 +272,18 @@ def get_schema():
     return schema
 
 
-def generate_schema_graph(graph_client):
+def generate_schema_graph(orientdb_client):
     """Generate SchemaGraph from a pyorient client"""
-    schema_records = graph_client.command(ORIENTDB_SCHEMA_RECORDS_QUERY)
+    schema_records = orientdb_client.command(ORIENTDB_SCHEMA_RECORDS_QUERY)
     schema_data = [x.oRecordData for x in schema_records]
-    index_records = graph_client.command(ORIENTDB_INDEX_RECORDS_QUERY)
+    index_records = orientdb_client.command(ORIENTDB_INDEX_RECORDS_QUERY)
     index_query_data = [x.oRecordData for x in index_records]
     return get_orientdb_schema_graph(schema_data, index_query_data)
 
 
-def generate_schema(graph_client, class_to_field_type_overrides=None, hidden_classes=None):
+def generate_schema(orientdb_client, class_to_field_type_overrides=None, hidden_classes=None):
     """Generate schema and type equivalence dict from a pyorient client"""
-    schema_records = graph_client.command(ORIENTDB_SCHEMA_RECORDS_QUERY)
+    schema_records = orientdb_client.command(ORIENTDB_SCHEMA_RECORDS_QUERY)
     schema_data = [x.oRecordData for x in schema_records]
     return get_graphql_schema_from_orientdb_schema_data(schema_data, class_to_field_type_overrides,
                                                         hidden_classes)


### PR DESCRIPTION
Since we're adding Neo4j support, which is also a graph database, this
disambiguates what database the client is for.