### PR TITLE
Cypher support compiler changes

### DIFF
--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -6,6 +6,7 @@ from .compiler import (  # noqa
     compile_graphql_to_gremlin,
     compile_graphql_to_match,
     compile_graphql_to_sql,
+    compile_graphql_to_cypher,
 )
 from .query_formatting import insert_arguments_into_query  # noqa
 from .query_formatting.graphql_formatting import pretty_print_graphql  # noqa
@@ -198,3 +199,40 @@ def get_graphql_schema_from_orientdb_schema_data(schema_data, class_to_field_typ
     schema_graph = get_orientdb_schema_graph(schema_data, [])
     return get_graphql_schema_from_schema_graph(schema_graph, class_to_field_type_overrides,
                                                 hidden_classes)
+
+
+def graphql_to_cypher(schema, graphql_query, parameters, type_equivalence_hints=None):
+    """Compile the GraphQL input using the schema into a Cypher query and associated metadata.
+
+    Args:
+        schema: GraphQL schema object describing the schema of the graph to be queried
+        graphql_query: the GraphQL query to compile to Cypher, as a string
+        parameters: dict, mapping argument name to its value, for every parameter the query expects.
+        type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
+                                *****
+                                Be very careful with this option, as bad input here will
+                                lead to incorrect output queries being generated.
+                                *****
+
+    Returns:
+        a CompilationResult object, containing:
+            - query: string, the resulting compiled and parameterized query string
+            - language: string, specifying the language to which the query was compiled
+            - output_metadata: dict, output name -> OutputMetadata namedtuple object
+            - input_metadata: dict, name of input variables -> inferred GraphQL type, based on use
+    """
+    compilation_result = compile_graphql_to_cypher(
+        schema, graphql_query, type_equivalence_hints=type_equivalence_hints)
+    return compilation_result._replace(
+        query=insert_arguments_into_query(compilation_result, parameters))
+

--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -235,4 +235,3 @@ def graphql_to_cypher(schema, graphql_query, parameters, type_equivalence_hints=
         schema, graphql_query, type_equivalence_hints=type_equivalence_hints)
     return compilation_result._replace(
         query=insert_arguments_into_query(compilation_result, parameters))
-

--- a/graphql_compiler/compiler/emit_cypher.py
+++ b/graphql_compiler/compiler/emit_cypher.py
@@ -109,7 +109,7 @@ def _emit_with_clause_components(cypher_steps):
 
 def emit_code_from_ir(cypher_query, compiler_metadata):
     """Return a Cypher query string from a CypherQuery object."""
-    query_data = [u'CYPHER 9\n']
+    query_data = [u'CYPHER\n']
 
     for cypher_step in cypher_query.steps:
         query_data.append(_emit_code_from_cypher_step(cypher_step))

--- a/graphql_compiler/compiler/emit_cypher.py
+++ b/graphql_compiler/compiler/emit_cypher.py
@@ -109,7 +109,7 @@ def _emit_with_clause_components(cypher_steps):
 
 def emit_code_from_ir(cypher_query, compiler_metadata):
     """Return a Cypher query string from a CypherQuery object."""
-    query_data = [u'CYPHER\n']
+    query_data = [u'CYPHER 9\n']
 
     for cypher_step in cypher_query.steps:
         query_data.append(_emit_code_from_cypher_step(cypher_step))

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -7,14 +7,14 @@ import arrow
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 import six
 
-from ..compiler import GREMLIN_LANGUAGE, MATCH_LANGUAGE, SQL_LANGUAGE, CYPHER_LANGUAGE
+from ..compiler import CYPHER_LANGUAGE, GREMLIN_LANGUAGE, MATCH_LANGUAGE, SQL_LANGUAGE
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
+from .cypher_formatting import insert_arguments_into_cypher_query
 from .gremlin_formatting import insert_arguments_into_gremlin_query
 from .match_formatting import insert_arguments_into_match_query
 from .sql_formatting import insert_arguments_into_sql_query
-from .cypher_formatting import insert_arguments_into_cypher_query
 
 
 ######

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -7,13 +7,14 @@ import arrow
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 import six
 
-from ..compiler import GREMLIN_LANGUAGE, MATCH_LANGUAGE, SQL_LANGUAGE
+from ..compiler import GREMLIN_LANGUAGE, MATCH_LANGUAGE, SQL_LANGUAGE, CYPHER_LANGUAGE
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .gremlin_formatting import insert_arguments_into_gremlin_query
 from .match_formatting import insert_arguments_into_match_query
 from .sql_formatting import insert_arguments_into_sql_query
+from .cypher_formatting import insert_arguments_into_cypher_query
 
 
 ######
@@ -132,6 +133,8 @@ def insert_arguments_into_query(compilation_result, arguments):
         return insert_arguments_into_gremlin_query(compilation_result, arguments)
     elif compilation_result.language == SQL_LANGUAGE:
         return insert_arguments_into_sql_query(compilation_result, arguments)
+    elif compilation_result.language == CYPHER_LANGUAGE:
+        return insert_arguments_into_cypher_query(compilation_result, arguments)
     else:
         raise AssertionError(u'Unrecognized language in compilation result: '
                              u'{}'.format(compilation_result))

--- a/graphql_compiler/query_formatting/cypher_formatting.py
+++ b/graphql_compiler/query_formatting/cypher_formatting.py
@@ -20,8 +20,9 @@ def _safe_cypher_string(argument_value):
         if isinstance(argument_value, bytes):  # should only happen in py3
             argument_value = argument_value.decode('utf-8')
         else:
-            raise GraphQLInvalidArgumentError(u'Attempting to convert a non-string into a string: '
-                                              u'{}'.format(argument_value))
+            raise GraphQLInvalidArgumentError(
+                u'Attempting to convert a non-string into a string: ' u'{}'.format(argument_value)
+            )
 
     # Using JSON encoding means that all unicode literals and special chars
     # (e.g. newlines and backslashes) are replaced by appropriate escape sequences.
@@ -45,9 +46,11 @@ def _safe_cypher_date_and_datetime(graphql_type, expected_python_types, value):
     # Rather than using isinstance, we will therefore check for exact type equality.
     value_type = type(value)
     if not any(value_type == x for x in expected_python_types):
-        raise GraphQLInvalidArgumentError(u'Expected value to be exactly one of '
-                                          u'python types {}, but was {}: '
-                                          u'{}'.format(expected_python_types, value_type, value))
+        raise GraphQLInvalidArgumentError(
+            u'Expected value to be exactly one of '
+            u'python types {}, but was {}: '
+            u'{}'.format(expected_python_types, value_type, value)
+        )
 
     # The serialize() method of GraphQLDate and GraphQLDateTime produces the correct
     # ISO-8601 format that MATCH expects. We then simply represent it as a regular string.
@@ -63,18 +66,18 @@ def _safe_cypher_list(inner_type, argument_value):
     """Represent the list of "inner_type" objects in Cypher form."""
     stripped_type = strip_non_null_from_type(inner_type)
     if isinstance(stripped_type, GraphQLList):
-        raise GraphQLInvalidArgumentError(u'Cypher does not currently support nested lists, '
-                                          u'but inner type was {}: '
-                                          u'{}'.format(inner_type, argument_value))
+        raise GraphQLInvalidArgumentError(
+            u'Cypher does not currently support nested lists, '
+            u'but inner type was {}: '
+            u'{}'.format(inner_type, argument_value)
+        )
 
     if not isinstance(argument_value, list):
-        raise GraphQLInvalidArgumentError(u'Attempting to represent a non-list as a list: '
-                                          u'{}'.format(argument_value))
+        raise GraphQLInvalidArgumentError(
+            u'Attempting to represent a non-list as a list: ' u'{}'.format(argument_value)
+        )
 
-    components = (
-        _safe_cypher_argument(stripped_type, x)
-        for x in argument_value
-    )
+    components = (_safe_cypher_argument(stripped_type, x) for x in argument_value)
     return u'[' + u','.join(components) + u']'
 
 
@@ -97,8 +100,9 @@ def _safe_cypher_argument(expected_type, argument_value):
         # Special case: in Python, isinstance(True, int) returns True.
         # Safeguard against this with an explicit check against bool type.
         if isinstance(argument_value, bool):
-            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-int as an int: '
-                                              u'{}'.format(argument_value))
+            raise GraphQLInvalidArgumentError(
+                u'Attempting to represent a non-int as an int: ' u'{}'.format(argument_value)
+            )
         return type_check_and_str(int, argument_value)
     elif GraphQLBoolean.is_same_type(expected_type):
         return type_check_and_str(bool, argument_value)
@@ -107,13 +111,16 @@ def _safe_cypher_argument(expected_type, argument_value):
     elif GraphQLDate.is_same_type(expected_type):
         return _safe_cypher_date_and_datetime(expected_type, (datetime.date,), argument_value)
     elif GraphQLDateTime.is_same_type(expected_type):
-        return _safe_cypher_date_and_datetime(expected_type,
-                                              (datetime.datetime, arrow.Arrow), argument_value)
+        return _safe_cypher_date_and_datetime(
+            expected_type, (datetime.datetime, arrow.Arrow), argument_value
+        )
     elif isinstance(expected_type, GraphQLList):
         return _safe_cypher_list(expected_type.of_type, argument_value)
     else:
-        raise AssertionError(u'Could not safely represent the requested GraphQL type: '
-                             u'{} {}'.format(expected_type, argument_value))
+        raise AssertionError(
+            u'Could not safely represent the requested GraphQL type: '
+            u'{} {}'.format(expected_type, argument_value)
+        )
 
 
 ######
@@ -126,7 +133,8 @@ def insert_arguments_into_cypher_query(compilation_result, arguments):
 
     Args:
         compilation_result: a CompilationResult object derived from the GraphQL compiler
-        arguments: dict, str -> any, mapping argument name to its value, for every parameter the query expects.
+        arguments: dict, str -> any, mapping argument name to its value, for every parameter the
+                    query expects.
 
     Returns:
         string, a Cypher query with inserted argument data.
@@ -144,5 +152,6 @@ def insert_arguments_into_cypher_query(compilation_result, arguments):
     }
 
     return Template(base_query).substitute(sanitized_arguments)
+
 
 ######

--- a/graphql_compiler/query_formatting/cypher_formatting.py
+++ b/graphql_compiler/query_formatting/cypher_formatting.py
@@ -111,8 +111,8 @@ def insert_arguments_into_cypher_query(compilation_result, arguments):
     """Insert the arguments into the compiled Cypher query to form a complete query.
 
     Args:
-        compilation_result: CompilationResult, compilation result from the GraphQL compiler.
-        arguments: Dict[str, Any], parameter name -> value, for every parameter the query expects.
+        compilation_result: a CompilationResult object derived from the GraphQL compiler
+        arguments: dict, str -> any, mapping argument name to its value, for every parameter the query expects.
 
     Returns:
         string, a Cypher query with inserted argument data.

--- a/graphql_compiler/query_formatting/cypher_formatting.py
+++ b/graphql_compiler/query_formatting/cypher_formatting.py
@@ -4,7 +4,6 @@ import json
 from string import Template
 
 import arrow
-
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 import six
 
@@ -12,7 +11,7 @@ from ..compiler import CYPHER_LANGUAGE
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
-from .representations import represent_float_as_str, type_check_and_str, coerce_to_decimal
+from .representations import coerce_to_decimal, represent_float_as_str, type_check_and_str
 
 
 def _safe_cypher_string(argument_value):
@@ -95,7 +94,7 @@ def _safe_cypher_argument(expected_type, argument_value):
         return _safe_cypher_date_and_datetime(expected_type, (datetime.date,), argument_value)
     elif GraphQLDateTime.is_same_type(expected_type):
         return _safe_cypher_date_and_datetime(expected_type,
-                                             (datetime.datetime, arrow.Arrow), argument_value)
+                                              (datetime.datetime, arrow.Arrow), argument_value)
     elif isinstance(expected_type, GraphQLList):
         return _safe_cypher_list(expected_type.of_type, argument_value)
     else:
@@ -116,7 +115,7 @@ def insert_arguments_into_cypher_query(compilation_result, arguments):
         arguments: Dict[str, Any], parameter name -> value, for every parameter the query expects.
 
     Returns:
-        string, a Cypher query with  with inserted argument data.
+        string, a Cypher query with inserted argument data.
     """
     if compilation_result.language != CYPHER_LANGUAGE:
         raise AssertionError(u'Unexpected query output language: {}'.format(compilation_result))

--- a/graphql_compiler/query_formatting/cypher_formatting.py
+++ b/graphql_compiler/query_formatting/cypher_formatting.py
@@ -17,7 +17,7 @@ from .representations import coerce_to_decimal, represent_float_as_str, type_che
 def _safe_cypher_string(argument_value):
     """Sanitize and represent a string argument in Cypher."""
     if not isinstance(argument_value, six.string_types):
-        if isinstance(argument_value, bytes):  # should only happen in py3
+        if isinstance(argument_value, bytes):  # likely to only happen in py2
             argument_value = argument_value.decode('utf-8')
         else:
             raise GraphQLInvalidArgumentError(
@@ -89,7 +89,7 @@ def _safe_cypher_argument(expected_type, argument_value):
         # IDs can be strings or numbers, but the GraphQL library coerces them to strings.
         # We will follow suit and treat them as strings.
         if not isinstance(argument_value, six.string_types):
-            if isinstance(argument_value, bytes):  # should only happen in py3
+            if isinstance(argument_value, bytes):  # likely to only happen in py2
                 argument_value = argument_value.decode('utf-8')
             else:
                 argument_value = six.text_type(argument_value)

--- a/graphql_compiler/query_formatting/cypher_formatting.py
+++ b/graphql_compiler/query_formatting/cypher_formatting.py
@@ -1,0 +1,135 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+import datetime
+import json
+from string import Template
+
+import arrow
+
+from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
+import six
+
+from ..compiler import CYPHER_LANGUAGE
+from ..compiler.helpers import strip_non_null_from_type
+from ..exceptions import GraphQLInvalidArgumentError
+from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
+from .representations import represent_float_as_str, type_check_and_str, coerce_to_decimal
+
+
+def _safe_cypher_string(argument_value):
+    """Sanitize and represent a string argument in Cypher."""
+    if not isinstance(argument_value, six.string_types):
+        if isinstance(argument_value, bytes):  # should only happen in py3
+            argument_value = argument_value.decode('utf-8')
+        else:
+            raise GraphQLInvalidArgumentError(u'Attempting to convert a non-string into a string: '
+                                              u'{}'.format(argument_value))
+
+    # Using JSON encoding means that all unicode literals and special chars
+    # (e.g. newlines and backslashes) are replaced by appropriate escape sequences.
+    # However, the quoted result is wrapped in double quotes, and $ signs are not escaped,
+    # so that would allow arbitrary code execution in Cypher.
+    # TODO: Leon
+    #  does the gremlin strategy work? alternatively, just wrap everything in backticks. But then
+    #  we need to escape backticks.
+    escaped_and_quoted = json.dumps(argument_value)
+    return escaped_and_quoted
+
+
+def _safe_cypher_decimal(argument_value):
+    """Represent decimal objects as Cypher strings."""
+    decimal_value = coerce_to_decimal(argument_value)
+    return 'toFloat(' + _safe_cypher_string(str(decimal_value)) + ')'
+
+
+def _safe_cypher_date_and_datetime(expected_type, param, argument_value):
+    # TODO: Leon
+    raise NotImplementedError
+
+
+def _safe_cypher_list(inner_type, argument_value):
+    """Represent the list of "inner_type" objects in Cypher form."""
+    stripped_type = strip_non_null_from_type(inner_type)
+    if isinstance(stripped_type, GraphQLList):
+        raise GraphQLInvalidArgumentError(u'Cypher does not currently support nested lists, '
+                                          u'but inner type was {}: '
+                                          u'{}'.format(inner_type, argument_value))
+
+    if not isinstance(argument_value, list):
+        raise GraphQLInvalidArgumentError(u'Attempting to represent a non-list as a list: '
+                                          u'{}'.format(argument_value))
+
+    components = (
+        _safe_cypher_argument(stripped_type, x)
+        for x in argument_value
+    )
+    return u'[' + u','.join(components) + u']'
+
+
+def _safe_cypher_argument(expected_type, argument_value):
+    """Return a Cypher string representing the given argument value."""
+    if GraphQLString.is_same_type(expected_type):
+        return _safe_cypher_string(argument_value)
+    elif GraphQLID.is_same_type(expected_type):
+        # IDs can be strings or numbers, but the GraphQL library coerces them to strings.
+        # We will follow suit and treat them as strings.
+        if not isinstance(argument_value, six.string_types):
+            if isinstance(argument_value, bytes):  # should only happen in py3
+                argument_value = argument_value.decode('utf-8')
+            else:
+                argument_value = six.text_type(argument_value)
+        return _safe_cypher_string(argument_value)
+    elif GraphQLFloat.is_same_type(expected_type):
+        return represent_float_as_str(argument_value)
+    elif GraphQLInt.is_same_type(expected_type):
+        # Special case: in Python, isinstance(True, int) returns True.
+        # Safeguard against this with an explicit check against bool type.
+        if isinstance(argument_value, bool):
+            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-int as an int: '
+                                              u'{}'.format(argument_value))
+        return type_check_and_str(int, argument_value)
+    elif GraphQLBoolean.is_same_type(expected_type):
+        return type_check_and_str(bool, argument_value)
+    elif GraphQLDecimal.is_same_type(expected_type):
+        return _safe_cypher_decimal(argument_value)
+    elif GraphQLDate.is_same_type(expected_type):
+        return _safe_cypher_date_and_datetime(expected_type, (datetime.date,), argument_value)
+    elif GraphQLDateTime.is_same_type(expected_type):
+        return _safe_cypher_date_and_datetime(expected_type,
+                                             (datetime.datetime, arrow.Arrow), argument_value)
+    elif isinstance(expected_type, GraphQLList):
+        return _safe_cypher_list(expected_type.of_type, argument_value)
+    else:
+        raise AssertionError(u'Could not safely represent the requested GraphQL type: '
+                             u'{} {}'.format(expected_type, argument_value))
+
+
+######
+# Public API
+######
+
+
+def insert_arguments_into_cypher_query(compilation_result, arguments):
+    """Insert the arguments into the compiled Cypher query to form a complete query.
+
+    Args:
+        compilation_result: CompilationResult, compilation result from the GraphQL compiler.
+        arguments: Dict[str, Any], parameter name -> value, for every parameter the query expects.
+
+    Returns:
+        string, a Cypher query with  with inserted argument data.
+    """
+    if compilation_result.language != CYPHER_LANGUAGE:
+        raise AssertionError(u'Unexpected query output language: {}'.format(compilation_result))
+
+    base_query = compilation_result.query
+    argument_types = compilation_result.input_metadata
+
+    # The arguments are assumed to have already been validated against the query.
+    sanitized_arguments = {
+        key: _safe_cypher_argument(argument_types[key], value)
+        for key, value in six.iteritems(arguments)
+    }
+
+    return Template(base_query).substitute(sanitized_arguments)
+
+######

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -21,8 +21,9 @@ def _safe_gremlin_string(value):
         if isinstance(value, bytes):  # should only happen in py3
             value = value.decode('utf-8')
         else:
-            raise GraphQLInvalidArgumentError(u'Attempting to convert a non-string into a string: '
-                                              u'{}'.format(value))
+            raise GraphQLInvalidArgumentError(
+                u'Attempting to convert a non-string into a string: ' u'{}'.format(value)
+            )
 
     # Using JSON encoding means that all unicode literals and special chars
     # (e.g. newlines and backslashes) are replaced by appropriate escape sequences.
@@ -64,9 +65,11 @@ def _safe_gremlin_date_and_datetime(graphql_type, expected_python_types, value):
     # Rather than using isinstance, we will therefore check for exact type equality.
     value_type = type(value)
     if not any(value_type == x for x in expected_python_types):
-        raise GraphQLInvalidArgumentError(u'Expected value to be exactly one of '
-                                          u'python types {}, but was {}: '
-                                          u'{}'.format(expected_python_types, value_type, value))
+        raise GraphQLInvalidArgumentError(
+            u'Expected value to be exactly one of '
+            u'python types {}, but was {}: '
+            u'{}'.format(expected_python_types, value_type, value)
+        )
 
     # The serialize() method of GraphQLDate and GraphQLDateTime produces the correct
     # ISO-8601 format that Gremlin expects. We then simply represent it as a regular string.
@@ -81,14 +84,12 @@ def _safe_gremlin_date_and_datetime(graphql_type, expected_python_types, value):
 def _safe_gremlin_list(inner_type, argument_value):
     """Represent the list of "inner_type" objects in Gremlin form."""
     if not isinstance(argument_value, list):
-        raise GraphQLInvalidArgumentError(u'Attempting to represent a non-list as a list: '
-                                          u'{}'.format(argument_value))
+        raise GraphQLInvalidArgumentError(
+            u'Attempting to represent a non-list as a list: ' u'{}'.format(argument_value)
+        )
 
     stripped_type = strip_non_null_from_type(inner_type)
-    components = (
-        _safe_gremlin_argument(stripped_type, x)
-        for x in argument_value
-    )
+    components = (_safe_gremlin_argument(stripped_type, x) for x in argument_value)
     return u'[' + u','.join(components) + u']'
 
 
@@ -111,8 +112,9 @@ def _safe_gremlin_argument(expected_type, argument_value):
         # Special case: in Python, isinstance(True, int) returns True.
         # Safeguard against this with an explicit check against bool type.
         if isinstance(argument_value, bool):
-            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-int as an int: '
-                                              u'{}'.format(argument_value))
+            raise GraphQLInvalidArgumentError(
+                u'Attempting to represent a non-int as an int: ' u'{}'.format(argument_value)
+            )
 
         return type_check_and_str(int, argument_value)
     elif GraphQLBoolean.is_same_type(expected_type):
@@ -122,18 +124,22 @@ def _safe_gremlin_argument(expected_type, argument_value):
     elif GraphQLDate.is_same_type(expected_type):
         return _safe_gremlin_date_and_datetime(expected_type, (datetime.date,), argument_value)
     elif GraphQLDateTime.is_same_type(expected_type):
-        return _safe_gremlin_date_and_datetime(expected_type,
-                                               (datetime.datetime, arrow.Arrow), argument_value)
+        return _safe_gremlin_date_and_datetime(
+            expected_type, (datetime.datetime, arrow.Arrow), argument_value
+        )
     elif isinstance(expected_type, GraphQLList):
         return _safe_gremlin_list(expected_type.of_type, argument_value)
     else:
-        raise AssertionError(u'Could not safely represent the requested GraphQL type: '
-                             u'{} {}'.format(expected_type, argument_value))
+        raise AssertionError(
+            u'Could not safely represent the requested GraphQL type: '
+            u'{} {}'.format(expected_type, argument_value)
+        )
 
 
 ######
 # Public API
 ######
+
 
 def insert_arguments_into_gremlin_query(compilation_result, arguments):
     """Insert the arguments into the compiled Gremlin query to form a complete query.
@@ -147,7 +153,8 @@ def insert_arguments_into_gremlin_query(compilation_result, arguments):
 
     Args:
         compilation_result: a CompilationResult object derived from the GraphQL compiler
-        arguments: dict, str -> any, mapping argument name to its value, for every parameter the query expects.
+        arguments: dict, str -> any, mapping argument name to its value, for every parameter the
+                    query expects.
 
     Returns:
         string, a Gremlin query with inserted argument data
@@ -165,5 +172,6 @@ def insert_arguments_into_gremlin_query(compilation_result, arguments):
     }
 
     return Template(base_query).substitute(sanitized_arguments)
+
 
 ######

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -147,7 +147,7 @@ def insert_arguments_into_gremlin_query(compilation_result, arguments):
 
     Args:
         compilation_result: a CompilationResult object derived from the GraphQL compiler
-        arguments: dict, mapping argument name to its value, for every parameter the query expects.
+        arguments: dict, str -> any, mapping argument name to its value, for every parameter the query expects.
 
     Returns:
         string, a Gremlin query with inserted argument data

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -18,7 +18,7 @@ from .representations import coerce_to_decimal, represent_float_as_str, type_che
 def _safe_gremlin_string(value):
     """Sanitize and represent a string argument in Gremlin."""
     if not isinstance(value, six.string_types):
-        if isinstance(value, bytes):  # should only happen in py3
+        if isinstance(value, bytes):  # likely to only happen in py2
             value = value.decode('utf-8')
         else:
             raise GraphQLInvalidArgumentError(
@@ -101,7 +101,7 @@ def _safe_gremlin_argument(expected_type, argument_value):
         # IDs can be strings or numbers, but the GraphQL library coerces them to strings.
         # We will follow suit and treat them as strings.
         if not isinstance(argument_value, six.string_types):
-            if isinstance(argument_value, bytes):  # should only happen in py3
+            if isinstance(argument_value, bytes):  # likely to only happen in py2
                 argument_value = argument_value.decode('utf-8')
             else:
                 argument_value = six.text_type(argument_value)

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -20,8 +20,9 @@ def _safe_match_string(value):
         if isinstance(value, bytes):  # should only happen in py3
             value = value.decode('utf-8')
         else:
-            raise GraphQLInvalidArgumentError(u'Attempting to convert a non-string into a string: '
-                                              u'{}'.format(value))
+            raise GraphQLInvalidArgumentError(
+                u'Attempting to convert a non-string into a string: ' u'{}'.format(value)
+            )
 
     # Using JSON encoding means that all unicode literals and special chars
     # (e.g. newlines and backslashes) are replaced by appropriate escape sequences.
@@ -36,9 +37,11 @@ def _safe_match_date_and_datetime(graphql_type, expected_python_types, value):
     # Rather than using isinstance, we will therefore check for exact type equality.
     value_type = type(value)
     if not any(value_type == x for x in expected_python_types):
-        raise GraphQLInvalidArgumentError(u'Expected value to be exactly one of '
-                                          u'python types {}, but was {}: '
-                                          u'{}'.format(expected_python_types, value_type, value))
+        raise GraphQLInvalidArgumentError(
+            u'Expected value to be exactly one of '
+            u'python types {}, but was {}: '
+            u'{}'.format(expected_python_types, value_type, value)
+        )
 
     # The serialize() method of GraphQLDate and GraphQLDateTime produces the correct
     # ISO-8601 format that MATCH expects. We then simply represent it as a regular string.
@@ -60,18 +63,18 @@ def _safe_match_list(inner_type, argument_value):
     """Represent the list of "inner_type" objects in MATCH form."""
     stripped_type = strip_non_null_from_type(inner_type)
     if isinstance(stripped_type, GraphQLList):
-        raise GraphQLInvalidArgumentError(u'MATCH does not currently support nested lists, '
-                                          u'but inner type was {}: '
-                                          u'{}'.format(inner_type, argument_value))
+        raise GraphQLInvalidArgumentError(
+            u'MATCH does not currently support nested lists, '
+            u'but inner type was {}: '
+            u'{}'.format(inner_type, argument_value)
+        )
 
     if not isinstance(argument_value, list):
-        raise GraphQLInvalidArgumentError(u'Attempting to represent a non-list as a list: '
-                                          u'{}'.format(argument_value))
+        raise GraphQLInvalidArgumentError(
+            u'Attempting to represent a non-list as a list: ' u'{}'.format(argument_value)
+        )
 
-    components = (
-        _safe_match_argument(stripped_type, x)
-        for x in argument_value
-    )
+    components = (_safe_match_argument(stripped_type, x) for x in argument_value)
     return u'[' + u','.join(components) + u']'
 
 
@@ -94,8 +97,9 @@ def _safe_match_argument(expected_type, argument_value):
         # Special case: in Python, isinstance(True, int) returns True.
         # Safeguard against this with an explicit check against bool type.
         if isinstance(argument_value, bool):
-            raise GraphQLInvalidArgumentError(u'Attempting to represent a non-int as an int: '
-                                              u'{}'.format(argument_value))
+            raise GraphQLInvalidArgumentError(
+                u'Attempting to represent a non-int as an int: ' u'{}'.format(argument_value)
+            )
         return type_check_and_str(int, argument_value)
     elif GraphQLBoolean.is_same_type(expected_type):
         return type_check_and_str(bool, argument_value)
@@ -104,25 +108,30 @@ def _safe_match_argument(expected_type, argument_value):
     elif GraphQLDate.is_same_type(expected_type):
         return _safe_match_date_and_datetime(expected_type, (datetime.date,), argument_value)
     elif GraphQLDateTime.is_same_type(expected_type):
-        return _safe_match_date_and_datetime(expected_type,
-                                             (datetime.datetime, arrow.Arrow), argument_value)
+        return _safe_match_date_and_datetime(
+            expected_type, (datetime.datetime, arrow.Arrow), argument_value
+        )
     elif isinstance(expected_type, GraphQLList):
         return _safe_match_list(expected_type.of_type, argument_value)
     else:
-        raise AssertionError(u'Could not safely represent the requested GraphQL type: '
-                             u'{} {}'.format(expected_type, argument_value))
+        raise AssertionError(
+            u'Could not safely represent the requested GraphQL type: '
+            u'{} {}'.format(expected_type, argument_value)
+        )
 
 
 ######
 # Public API
 ######
 
+
 def insert_arguments_into_match_query(compilation_result, arguments):
     """Insert the arguments into the compiled MATCH query to form a complete query.
 
     Args:
         compilation_result: a CompilationResult object derived from the GraphQL compiler
-        arguments: dict, str -> any, mapping argument name to its value, for every parameter the query expects.
+        arguments: dict, str -> any, mapping argument name to its value, for every parameter the
+                    query expects.
 
     Returns:
         string, a MATCH query with inserted argument data
@@ -140,5 +149,6 @@ def insert_arguments_into_match_query(compilation_result, arguments):
     }
 
     return base_query.format(**sanitized_arguments)
+
 
 ######

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -122,7 +122,7 @@ def insert_arguments_into_match_query(compilation_result, arguments):
 
     Args:
         compilation_result: a CompilationResult object derived from the GraphQL compiler
-        arguments: dict, mapping argument name to its value, for every parameter the query expects.
+        arguments: dict, str -> any, mapping argument name to its value, for every parameter the query expects.
 
     Returns:
         string, a MATCH query with inserted argument data

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -17,7 +17,7 @@ from .representations import coerce_to_decimal, represent_float_as_str, type_che
 def _safe_match_string(value):
     """Sanitize and represent a string argument in MATCH."""
     if not isinstance(value, six.string_types):
-        if isinstance(value, bytes):  # should only happen in py3
+        if isinstance(value, bytes):  # likely to only happen in py2
             value = value.decode('utf-8')
         else:
             raise GraphQLInvalidArgumentError(
@@ -86,7 +86,7 @@ def _safe_match_argument(expected_type, argument_value):
         # IDs can be strings or numbers, but the GraphQL library coerces them to strings.
         # We will follow suit and treat them as strings.
         if not isinstance(argument_value, six.string_types):
-            if isinstance(argument_value, bytes):  # should only happen in py3
+            if isinstance(argument_value, bytes):  # likely to only happen in py2
                 argument_value = argument_value.decode('utf-8')
             else:
                 argument_value = six.text_type(argument_value)


### PR DESCRIPTION
Part of PR #366. This PR is just for the compiler changes themselves.

Comments from the original PR:
- Two TODOs in cypher_formatting.py. I'll continue working on the one for dates, datetimes, etc. next-- in the meantime, feel free to read over the other TODO about the safe string insertion.

- Small issue: although the language spec says that we can specify the Cypher version in queries, when I tested this (both via the integration tests as well as manually in my browser, the queries failed).
```cypher
CYPHER 9
MATCH (n)
RETURN n
```
failed, but
```cypher
CYPHER
MATCH (n)
RETURN n
```
was fine. Changing this is simple (just find-and-replace for all instances of CYPHER 9), but let's confirm that this is a legitimate issue and not just some setup issue on my computer first.