### PR TITLE
Add support for edge_counts_between_vertex_pairs

### DIFF
--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -111,7 +111,7 @@ def _probe_statistics_for_edge_count_between_vertex_pair(
         query_metadata, child_location, parent_location
     )
     probe_result = statistics.get_edge_count_between_vertex_pair(
-        outbound_vertex_name, inbound_vertex_name, edge_name
+        outbound_vertex_name, edge_name, inbound_vertex_name
     )
     return probe_result
 
@@ -188,7 +188,7 @@ def _estimate_children_per_parent(
         statistics, query_metadata, child_location, parent_location
     )
 
-    if not edge_counts:
+    if edge_counts is None:
         edge_counts = _estimate_edge_count_between_vertex_pair_using_class_count(
             schema_graph, statistics, query_metadata, child_location, parent_location
         )

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -119,7 +119,7 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
     edges using class counts. If A and B are subclasses of C and D respectively, we only have
     access to CD edges, so in general, we assume that the number of CD edges with A as an endpoint 
     are proportional to the fraction of A vertices over C vertices, and likewise for B and D. 
-	Using this assumption, in general we estimate the (# of AB edges) as
+	Using this assumption, in general we estimate the statistic as
     (# of AB edges) = (# of CD edges) * (# of A vertices) / (# of C vertices) * 
     								    (# of B vertices) / (# of D vertices).
 

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -87,7 +87,7 @@ def _get_parent_and_child_base_classnames_from_edge(schema_graph, child_location
 
 def _get_outbound_and_inbound_names_from_locations(query_metadata, child_location, parent_location):
     """Get the out and in classnames of a location and its parent from the last edge information."""
-    edge_direction, _ = _get_last_edge_direction_and_name_to_location(child_location)
+    edge_direction, edge_name = _get_last_edge_direction_and_name_to_location(child_location)
     parent_name_from_location = query_metadata.get_location_info(parent_location).type.name
     child_name_from_location = query_metadata.get_location_info(child_location).type.name
     if edge_direction == INBOUND_EDGE_DIRECTION:

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -124,9 +124,7 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
     Given a parent location of type A and a child location of type B, we estimate the number of AB
     edges using class counts. If A and B are subclasses of C and D respectively, we only have access
     to CD edges, so in general, we estimate using the assumption that CD edges are distributed
-    evenly among all C and D vertices. So to get the number of AB edges, we scale the number of CD
-    edges by the fraction of C vertices that are of type A and also independently by the fraction of
-    D vertices that are of type B.
+    among all C and D vertices independently of the vertex's subclass. 
     Using this assumption, in general we estimate the statistic as
     (# of AB edges) = (# of CD edges) * (# of A vertices) / (# of C vertices) *
                                         (# of B vertices) / (# of D vertices).

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -117,11 +117,11 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
 
     Given a parent location of type A and a child location of type B, we estimate the number of AB
     edges using class counts. If A and B are subclasses of C and D respectively, we only have
-    access to CD edges, so in general, we assume that the number of CD edges with A as an endpoint 
-    are proportional to the fraction of A vertices over C vertices, and likewise for B and D. 
-	Using this assumption, in general we estimate the statistic as
-    (# of AB edges) = (# of CD edges) * (# of A vertices) / (# of C vertices) * 
-    								    (# of B vertices) / (# of D vertices).
+    access to CD edges, so in general, we assume that the number of CD edges with A as an endpoint
+    are proportional to the fraction of A vertices over C vertices, and likewise for B and D.
+    Using this assumption, in general we estimate the statistic as
+    (# of AB edges) = (# of CD edges) * (# of A vertices) / (# of C vertices) *
+                                        (# of B vertices) / (# of D vertices).
 
     Args:
         schema_graph: SchemaGraph object
@@ -130,8 +130,8 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
         child_location: BaseLocation object
         parent_location: BaseLocation object
 
-	Returns:
-		float, estimate for (# of AB edges)
+    Returns:
+        float, estimate for (# of AB edges)
     """
     _, edge_name = _get_last_edge_direction_and_name_to_location(child_location)
     edge_counts = statistics.get_class_count(edge_name)

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -123,7 +123,7 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
 
     Given a parent location of class A and a child location of class B, this function estimates the
     number of AB edges using class counts. If A and B are subclasses of the edge's endpoint classes
-    which we'll name C and D respectively, we only have statistics for CD edges. So estimates for
+    (which we'll name C and D respectively), we only have statistics for CD edges. So estimates for
     the number of AB edges will be made using the assumption that CD edges are distributed
     independently of whether or not the vertex of class C is also of class A and likewise for D and
     B. In the general case, we estimate the statistic as

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -116,9 +116,12 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
     """Estimate the count of edges connecting two vertex classes via the class_count statistic.
 
     Given a parent location of type A and a child location of type B, we estimate the number of AB
-    edges using class counts. If A and B are subclasses of C and D respectively, we only have access
-    to CD edges, so in general, we'll use (# of CD edges) / (# of C vertices), but since we're only
-    interested in edges to Bs, we'll scale this result by the fraction of Bs over Ds.
+    edges using class counts. If A and B are subclasses of C and D respectively, we only have
+    access to CD edges, so in general, we assume that the number of CD edges with A as an endpoint 
+    are proportional to the fraction of A vertices over C vertices, and likewise for B and D. 
+	Using this assumption, in general we estimate the (# of AB edges) as
+    (# of AB edges) = (# of CD edges) * (# of A vertices) / (# of C vertices) * 
+    								    (# of B vertices) / (# of D vertices).
 
     Args:
         schema_graph: SchemaGraph object
@@ -126,6 +129,9 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
         query_metadata: QueryMetadataTable object
         child_location: BaseLocation object
         parent_location: BaseLocation object
+
+	Returns:
+		float, estimate for (# of AB edges)
     """
     _, edge_name = _get_last_edge_direction_and_name_to_location(child_location)
     edge_counts = statistics.get_class_count(edge_name)

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -81,7 +81,7 @@ def _get_parent_and_child_name_from_edge(schema_graph, child_location):
         child_name_from_edge = edge_element.base_out_connection
     else:
         raise AssertionError(u'Expected edge direction to be either inbound or outbound.'
-                             u'Found: {}'.format(edge_direction))
+                             u'Found: edge {} with direction {}'.format(edge_name, edge_direction))
     return parent_name_from_edge, child_name_from_edge
 
 
@@ -98,7 +98,7 @@ def _get_outbound_and_inbound_names_from_locations(query_metadata, child_locatio
         inbound_vertex_name = child_name_from_location
     else:
         raise AssertionError(u'Expected edge direction to be either inbound or outbound.'
-                             u'Found: {}'.format(edge_direction))
+                             u'Found: edge {} with direction {}'.format(edge_name, edge_direction))
     return outbound_vertex_name, inbound_vertex_name
 
 

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -79,6 +79,9 @@ def _get_parent_and_child_name_from_edge(schema_graph, child_location):
     elif edge_direction == OUTBOUND_EDGE_DIRECTION:
         parent_name_from_edge = edge_element.base_in_connection
         child_name_from_edge = edge_element.base_out_connection
+    else:
+        raise AssertionError(u'Expected edge direction to be either inbound or outbound.'
+                             u'Found: {}'.format(edge_direction))
     return parent_name_from_edge, child_name_from_edge
 
 
@@ -93,6 +96,9 @@ def _get_outbound_and_inbound_names_from_locations(query_metadata, child_locatio
     elif edge_direction == OUTBOUND_EDGE_DIRECTION:
         outbound_vertex_name = parent_name_from_location
         inbound_vertex_name = child_name_from_location
+    else:
+        raise AssertionError(u'Expected edge direction to be either inbound or outbound.'
+                             u'Found: {}'.format(edge_direction))
     return outbound_vertex_name, inbound_vertex_name
 
 

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -123,10 +123,10 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
 
     Given a parent location of class A and a child location of class B, this function estimates the
     number of AB edges using class counts. If A and B are subclasses of the edge's endpoint classes
-    which we'll name C and D respectively, we only have statistics for CD edges, so in general, we
-    estimate using the assumption that CD edges are distributed among all C and D vertices
-    independently of the vertex's class.  Using this assumption, in general we estimate the
-    statistic as
+    which we'll name C and D respectively, we only have statistics for CD edges. So estimates for
+    the number of AB edges will be made using the assumption that CD edges are distributed
+    independently of whether or not the vertex of class C is also of class A and likewise for D and
+    B. In the general case, we estimate the statistic as
     (# of AB edges) = (# of CD edges) * (# of A vertices) / (# of C vertices) *
                                         (# of B vertices) / (# of D vertices).
 

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -121,11 +121,12 @@ def _estimate_edge_count_between_vertex_pair_using_class_count(
 ):
     """Estimate the count of edges connecting two vertex classes via the class_count statistic.
 
-    Given a parent location of type A and a child location of type B, we estimate the number of AB
-    edges using class counts. If A and B are subclasses of C and D respectively, we only have access
-    to CD edges, so in general, we estimate using the assumption that CD edges are distributed
-    among all C and D vertices independently of the vertex's subclass. 
-    Using this assumption, in general we estimate the statistic as
+    Given a parent location of class A and a child location of class B, this function estimates the
+    number of AB edges using class counts. If A and B are subclasses of the edge's endpoint classes
+    which we'll name C and D respectively, we only have statistics for CD edges, so in general, we
+    estimate using the assumption that CD edges are distributed among all C and D vertices
+    independently of the vertex's class.  Using this assumption, in general we estimate the
+    statistic as
     (# of AB edges) = (# of CD edges) * (# of A vertices) / (# of C vertices) *
                                         (# of B vertices) / (# of D vertices).
 

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -40,7 +40,7 @@ class Statistics(object):
 
     @abstractmethod
     def get_edge_count_between_vertex_pair(
-        self, vertex_out_class_name, vertex_in_class_name, edge_class_name
+        self, vertex_source_class_name, edge_class_name, vertex_target_class_name
     ):
         """Return the count of edges connecting two vertices.
 
@@ -50,9 +50,9 @@ class Statistics(object):
         several orders of magnitude. In such cases, this statistic should be provided.
 
         Args:
-            vertex_out_class_name: str, vertex class name.
-            vertex_in_class_name: str, vertex class name.
+            vertex_source_class_name: str, vertex class name.
             edge_class_name: str, edge class name.
+            vertex_target_class_name: str, vertex class name.
 
         Returns:
             - int, the count of edges if the statistic exists
@@ -148,7 +148,7 @@ class LocalStatistics(Statistics):
         return self._class_counts[class_name]
 
     def get_edge_count_between_vertex_pair(
-        self, vertex_out_class_name, vertex_in_class_name, edge_class_name
+        self, vertex_source_class_name, edge_class_name, vertex_target_class_name
     ):
         """Return the count of edges connecting two vertices.
 
@@ -158,15 +158,15 @@ class LocalStatistics(Statistics):
         several orders of magnitude. In such cases, this statistic should be provided.
 
         Args:
-            vertex_out_class_name: str, vertex class name.
-            vertex_in_class_name: str, vertex class name.
+            vertex_source_class_name: str, vertex class name.
             edge_class_name: str, edge class name.
+            vertex_target_class_name: str, vertex class name.
 
         Returns:
             - int, the count of edges if the statistic exists
             - None otherwise
         """
-        statistic_key = (vertex_out_class_name, vertex_in_class_name, edge_class_name)
+        statistic_key = (vertex_source_class_name, edge_class_name, vertex_target_class_name)
         return self._edge_count_between_vertex_pairs.get(statistic_key)
 
     def get_distinct_field_values_count(self, vertex_name, field_name):

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -101,22 +101,29 @@ class Statistics(object):
 class LocalStatistics(Statistics):
     """Provides statistics using ones given at initialization."""
     def __init__(
-        self, class_counts, edge_count_between_vertex_pairs, count_of_distinct_field_values,
-        histograms
+        self, class_counts, edge_count_between_vertex_pairs=None,
+        count_of_distinct_field_values=None, histograms=None
     ):
         """Initializes statistics with the given data.
 
         Args:
             class_counts: dict, str -> int, mapping vertex/edge class name to class count.
-            edge_count_between_vertex_pairs: dict, (str, str, str) -> int,
+            edge_count_between_vertex_pairs: optional dict, (str, str, str) -> int,
                 mapping tuple of (vertex out class name, vertex in class name, edge class name) to
                 count of edge instances of given class connecting instances of two vertex classes.
-            count_of_distinct_values: dict, (str, str) -> int, mapping vertex class name and field
-                name on that vertex class to the count of distinct values of the field for that
-                vertex class.
-            histograms: dict, (str, str) -> list[tuple(float, float, int)], mapping vertex class
-                name and field name on that vertex class to histogram.
+            count_of_distinct_values: optional dict, (str, str) -> int, mapping vertex class name
+                and field name on that vertex class to the count of distinct values of the field for
+                that vertex class.
+            histograms:optional dict, (str, str) -> list[tuple(float, float, int)], mapping vertex
+                class name and field name on that vertex class to histogram.
         """
+        if edge_count_between_vertex_pairs is None:
+            edge_count_between_vertex_pairs = dict()
+        if count_of_distinct_field_values is None:
+            count_of_distinct_field_values = dict()
+        if histograms is None:
+            histograms = dict()
+
         self._class_counts = class_counts
         self._edge_count_between_vertex_pairs = edge_count_between_vertex_pairs
         self._count_of_distinct_field_values = count_of_distinct_field_values
@@ -159,7 +166,7 @@ class LocalStatistics(Statistics):
             - int, the count of edges if the statistic exists
             - None otherwise
         """
-        statistic_key = (vertex_in_class_name, vertex_out_class_name, edge_class_name)
+        statistic_key = (vertex_out_class_name, vertex_in_class_name, edge_class_name)
         return self._edge_count_between_vertex_pairs.get(statistic_key)
 
     def get_distinct_field_values_count(self, vertex_name, field_name):

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -32,12 +32,7 @@ class CostEstimationTests(unittest.TestCase):
         count_data = {
             'Animal': 3,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, test_data.graphql_input, dict()
@@ -56,12 +51,7 @@ class CostEstimationTests(unittest.TestCase):
             'Animal': 3,
             'Animal_ParentOf': 5,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, test_data.graphql_input, dict()
@@ -84,12 +74,7 @@ class CostEstimationTests(unittest.TestCase):
             'Food': 11,
             'FoodOrSpecies': 14,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, test_data.graphql_input, dict()
@@ -131,12 +116,7 @@ class CostEstimationTests(unittest.TestCase):
             'Animal_BornAt': 13,
             'BirthEvent': 17
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -171,12 +151,7 @@ class CostEstimationTests(unittest.TestCase):
             'Animal_BornAt': 7,
             'Animal_FedAt': 3,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -216,12 +191,7 @@ class CostEstimationTests(unittest.TestCase):
             'Species_Eats': 5,
             'Species': 97,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -241,12 +211,7 @@ class CostEstimationTests(unittest.TestCase):
             'Entity': 11,
             'Species_Eats': 17,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -276,13 +241,9 @@ class CostEstimationTests(unittest.TestCase):
             'Animal': 5,
             'Animal_BornAt': 7,
             'Animal_FedAt': 3,
+            'FeedingEvent': 11
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -321,12 +282,7 @@ class CostEstimationTests(unittest.TestCase):
             'Entity': 11,
             'Species_Eats': 5,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -346,12 +302,7 @@ class CostEstimationTests(unittest.TestCase):
             'Entity': 11,
             'Species_Eats': 17,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -378,12 +329,7 @@ class CostEstimationTests(unittest.TestCase):
             'Animal': 7,
             'Animal_ParentOf': 11,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -415,12 +361,7 @@ class CostEstimationTests(unittest.TestCase):
             'Animal_ParentOf': 11,
             'Animal_BornAt': 13,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, dict()
@@ -451,12 +392,7 @@ class CostEstimationTests(unittest.TestCase):
         count_data = {
             'Animal': 3,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -492,13 +428,9 @@ class CostEstimationTests(unittest.TestCase):
             'Event_RelatedEvent': 7,
             'Event': 17,
             'FeedingEvent': 11,
+            'BirthEvent': 13
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -528,12 +460,7 @@ class CostEstimationTests(unittest.TestCase):
         count_data = {
             'Animal': 3,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -570,13 +497,9 @@ class CostEstimationTests(unittest.TestCase):
             'Event_RelatedEvent': 11,
             'Event': 7,
             'FeedingEvent': 6,
+            'BirthEvent': 13
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -617,13 +540,9 @@ class CostEstimationTests(unittest.TestCase):
             'Event_RelatedEvent': 23,
             'Event': 7,
             'FeedingEvent': 6,
+            'BirthEvent': 13
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -663,13 +582,9 @@ class CostEstimationTests(unittest.TestCase):
             'Event_RelatedEvent': 11,
             'Event': 7,
             'FeedingEvent': 6,
+            'BirthEvent': 13
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -710,13 +625,9 @@ class CostEstimationTests(unittest.TestCase):
             'Event_RelatedEvent': 23,
             'Event': 7,
             'FeedingEvent': 6,
+            'BirthEvent': 11
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -753,12 +664,7 @@ class CostEstimationTests(unittest.TestCase):
             'Animal_ParentOf': 11,
             'Animal_BornAt': 13,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -793,12 +699,7 @@ class CostEstimationTests(unittest.TestCase):
             'Animal_ParentOf': 11,
             'Animal_BornAt': 13,
         }
-        statistics = LocalStatistics(
-            class_counts=count_data,
-            edge_count_between_vertex_pairs=dict(),
-            count_of_distinct_field_values=dict(),
-            histograms=dict()
-        )
+        statistics = LocalStatistics(count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -866,10 +767,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         classname = 'Animal'
 
-        empty_statistics = LocalStatistics(class_counts=dict(),
-                                           edge_count_between_vertex_pairs=dict(),
-                                           count_of_distinct_field_values=dict(),
-                                           histograms=dict())
+        empty_statistics = LocalStatistics(dict())
         params = dict()
 
         # If we '='-filter on a property that isn't an index return a fractional selectivity of 1.
@@ -903,10 +801,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
     def test_get_in_collection_filter_selectivity(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         classname = 'Animal'
-        empty_statistics = LocalStatistics(class_counts=dict(),
-                                           edge_count_between_vertex_pairs=dict(),
-                                           count_of_distinct_field_values=dict(),
-                                           histograms=dict())
+        empty_statistics = LocalStatistics(dict())
 
         nonunique_filter = FilterInfo(fields=('birthday',), op_name='in_collection',
                                       args=('$birthday_collection',))

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -153,7 +153,7 @@ class CostEstimationTests(unittest.TestCase):
             'Entity_Related': 11
         }
         edge_count_data = {
-            ('Animal', 'Event', 'Entity_Related'): 2
+            ('Animal', 'Entity_Related', 'Event'): 2
         }
         statistics = LocalStatistics(
             count_data, edge_count_between_vertex_pairs=edge_count_data)
@@ -189,7 +189,7 @@ class CostEstimationTests(unittest.TestCase):
             'Entity_Related': 11
         }
         edge_count_data = {
-            ('Animal', 'Event', 'Entity_Related'): 2
+            ('Animal', 'Entity_Related', 'Event'): 2
         }
         statistics = LocalStatistics(
             count_data, edge_count_between_vertex_pairs=edge_count_data)
@@ -231,7 +231,7 @@ class CostEstimationTests(unittest.TestCase):
             'Location': 13
         }
         edge_count_data = {
-            ('Animal', 'Event', 'Entity_Related'): 2
+            ('Animal', 'Entity_Related', 'Event'): 2
         }
         statistics = LocalStatistics(
             count_data, edge_count_between_vertex_pairs=edge_count_data)
@@ -548,7 +548,7 @@ class CostEstimationTests(unittest.TestCase):
             'BirthEvent': 13
         }
         edge_count_data = {
-            ('Animal', 'BirthEvent', 'Animal_BornAt'): 2
+            ('Animal', 'Animal_BornAt', 'BirthEvent'): 2
         }
         statistics = LocalStatistics(count_data, edge_count_between_vertex_pairs=edge_count_data)
 


### PR DESCRIPTION
Okay, I lied. I did quite a few changes:

- add tests for new statistic. Check if it overrides estimates using get_class_count.
- The cardinality estimator now tries to use the statistic in the title if possible, which helps out when using really general edges like Entity->Entity, when we really want to traverse between two rare vertices.
- As a design decision, when traversing from vertex type A to vertex type B, the estimator first finds out the number of edges from A to B in a separate function, then divides by the number of vertices of type A. To make this work, class_count needs to multiply by the count of A vertices, which we'll later cancel out. This means we need to add `BirthEvent` class_counts to tests that didn't previously have them, even though it doesn't impact the result.
- I made all statistics besides get_class_count optional by assigning them default values of `None`, and reflected that in the test set.