### PR TITLE
Cost estimation nonunique field filters

### DIFF
--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -110,7 +110,7 @@ def _probe_statistics_for_edge_count_between_vertex_pair(
     outbound_vertex_name, inbound_vertex_name = _get_outbound_and_inbound_names_from_locations(
         query_metadata, child_location, parent_location
     )
-    probe_result = statistics.get_edge_count_between_vertex_pair(
+    probe_result = statistics.get_vertex_edge_vertex_count(
         outbound_vertex_name, edge_name, inbound_vertex_name
     )
     return probe_result

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -102,10 +102,10 @@ def _get_outbound_and_inbound_names_from_locations(query_metadata, child_locatio
     return outbound_vertex_name, inbound_vertex_name
 
 
-def _probe_statistics_for_edge_count_between_vertex_pair(
+def _probe_statistics_for_vertex_edge_vertex_count(
     statistics, query_metadata, child_location, parent_location
 ):
-    """Probe statistics for the count of edges connecting two vertex classes."""
+    """Probe statistics for vertex_edge_vertex count given parent and child locations."""
     _, edge_name = _get_last_edge_direction_and_name_to_location(child_location)
     outbound_vertex_name, inbound_vertex_name = _get_outbound_and_inbound_names_from_locations(
         query_metadata, child_location, parent_location
@@ -116,10 +116,10 @@ def _probe_statistics_for_edge_count_between_vertex_pair(
     return probe_result
 
 
-def _estimate_edge_count_between_vertex_pair_using_class_count(
+def _estimate_vertex_edge_vertex_count_using_class_count(
     schema_graph, statistics, query_metadata, child_location, parent_location
 ):
-    """Estimate the count of edges connecting two vertex classes via the class_count statistic.
+    """Estimate the count of edges that that connect the parent and child locations.
 
     Given a parent location of class A and a child location of class B, this function estimates the
     number of AB edges using class counts. If A and B are subclasses of the edge's endpoint classes

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -105,7 +105,7 @@ def _get_outbound_and_inbound_names_from_locations(query_metadata, child_locatio
 def _probe_statistics_for_vertex_edge_vertex_count(
     statistics, query_metadata, child_location, parent_location
 ):
-    """Probe statistics for vertex_edge_vertex count given parent and child locations."""
+    """Probe for the count of edges that connect parent_location and child_location vertices."""
     _, edge_name = _get_last_edge_direction_and_name_to_location(child_location)
     outbound_vertex_name, inbound_vertex_name = _get_outbound_and_inbound_names_from_locations(
         query_metadata, child_location, parent_location
@@ -119,7 +119,7 @@ def _probe_statistics_for_vertex_edge_vertex_count(
 def _estimate_vertex_edge_vertex_count_using_class_count(
     schema_graph, statistics, query_metadata, child_location, parent_location
 ):
-    """Estimate the count of edges that that connect the parent and child locations.
+    """Estimate the count of edges that connect parent_location and child_location vertices.
 
     Given a parent location of class A and a child location of class B, this function estimates the
     number of AB edges using class counts. If A and B are subclasses of the edge's endpoint classes

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -184,12 +184,12 @@ def _estimate_children_per_parent(
     Returns:
         float, expected number of child_location vertices connected to each parent_location vertex.
     """
-    edge_counts = _probe_statistics_for_edge_count_between_vertex_pair(
+    edge_counts = _probe_statistics_for_vertex_edge_vertex_count(
         statistics, query_metadata, child_location, parent_location
     )
 
     if edge_counts is None:
-        edge_counts = _estimate_edge_count_between_vertex_pair_using_class_count(
+        edge_counts = _estimate_vertex_edge_vertex_count_using_class_count(
             schema_graph, statistics, query_metadata, child_location, parent_location
         )
 

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -102,24 +102,24 @@ def _get_outbound_and_inbound_names_from_locations(query_metadata, child_locatio
     return outbound_vertex_name, inbound_vertex_name
 
 
-def _probe_statistics_for_vertex_edge_vertex_count(
+def _probe_statistics_for_edge_count_between_vertex_pair(
     statistics, query_metadata, child_location, parent_location
 ):
-    """Probe for the count of edges that connect parent_location and child_location vertices."""
+    """Probe statistics for the count of edges connecting two vertex classes."""
     _, edge_name = _get_last_edge_direction_and_name_to_location(child_location)
     outbound_vertex_name, inbound_vertex_name = _get_outbound_and_inbound_names_from_locations(
         query_metadata, child_location, parent_location
     )
-    probe_result = statistics.get_vertex_edge_vertex_count(
+    probe_result = statistics.get_edge_count_between_vertex_pair(
         outbound_vertex_name, edge_name, inbound_vertex_name
     )
     return probe_result
 
 
-def _estimate_vertex_edge_vertex_count_using_class_count(
+def _estimate_edge_count_between_vertex_pair_using_class_count(
     schema_graph, statistics, query_metadata, child_location, parent_location
 ):
-    """Estimate the count of edges that connect parent_location and child_location vertices.
+    """Estimate the count of edges connecting two vertex classes via the class_count statistic.
 
     Given a parent location of class A and a child location of class B, this function estimates the
     number of AB edges using class counts. If A and B are subclasses of the edge's endpoint classes
@@ -184,12 +184,12 @@ def _estimate_children_per_parent(
     Returns:
         float, expected number of child_location vertices connected to each parent_location vertex.
     """
-    edge_counts = _probe_statistics_for_vertex_edge_vertex_count(
+    edge_counts = _probe_statistics_for_edge_count_between_vertex_pair(
         statistics, query_metadata, child_location, parent_location
     )
 
     if edge_counts is None:
-        edge_counts = _estimate_vertex_edge_vertex_count_using_class_count(
+        edge_counts = _estimate_edge_count_between_vertex_pair_using_class_count(
             schema_graph, statistics, query_metadata, child_location, parent_location
         )
 

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -54,11 +54,16 @@ def _estimate_filter_selectivity_of_equality(
     if _are_filter_fields_uniquely_indexed(filter_fields, unique_indexes):
         # TODO(evan): don't return a higher absolute selectivity than class counts.
         result_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=1.0)
+    else:
+        # Assumption: each distinct field value is equally common
+        statistics_result = statistics.get_distinct_field_values_count(
+            location_name, filter_fields[0]
+        )
 
-    # Assumption: each distinct field value is equally common
-    statistics_result = statistics.get_distinct_field_values_count(location_name, filter_field_name)
-    if statistics_result is not None:
-    	result_selectivity = Selectivity(kind=FRACTIONAL_SELECTIVITY, value=1.0/statistics_result)
+        if statistics_result is not None:
+            result_selectivity = Selectivity(
+                kind=FRACTIONAL_SELECTIVITY, value=1.0 / statistics_result
+            )
 
     return result_selectivity
 
@@ -102,6 +107,7 @@ def _get_filter_selectivity(
                 value=float(collection_size) * selectivity_per_entry_in_collection.value
             )
         elif _is_fractional(selectivity_per_entry_in_collection):
+
             result_selectivity = Selectivity(
                 kind=FRACTIONAL_SELECTIVITY,
                 value=min(float(collection_size) * selectivity_per_entry_in_collection.value,

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -55,7 +55,7 @@ def _estimate_filter_selectivity_of_equality(
         # TODO(evan): don't return a higher absolute selectivity than class counts.
         result_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=1.0)
     else:
-        # Assumption: each distinct field value is equally common
+        # Assumption: each distinct field value is equally common.
         statistics_result = statistics.get_distinct_field_values_count(
             location_name, filter_fields[0]
         )
@@ -99,15 +99,13 @@ def _get_filter_selectivity(
             schema_graph, statistics, location_name, filter_info.fields
         )
 
-        # Assumption: The selectivity is proportional to the number of entries in the collection
-        # This will not hold in case of duplicates.
+        # Assumption: the selectivity is proportional to the number of entries in the collection.
         if _is_absolute(selectivity_per_entry_in_collection):
             result_selectivity = Selectivity(
                 kind=ABSOLUTE_SELECTIVITY,
                 value=float(collection_size) * selectivity_per_entry_in_collection.value
             )
         elif _is_fractional(selectivity_per_entry_in_collection):
-
             result_selectivity = Selectivity(
                 kind=FRACTIONAL_SELECTIVITY,
                 value=min(float(collection_size) * selectivity_per_entry_in_collection.value,

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -49,7 +49,18 @@ def _estimate_filter_selectivity_of_equality(
 ):
     """Calculate the selectivity of equality filter(s) at a given location.
 
-    Since there may be multiple equality filters at a given location, this function
+    Using the available unique indexes, and the distinct-field-values-count statistic, this function
+    extracts the current location's selectivites, and then combines them, returning one Selectivity
+    object.
+
+    Args:
+        schema_graph: SchemaGraph object
+        statistics: Statistics object
+        location_name: string, type of the location being filtered
+        filter_fields: tuple of str, listing all the fields being filtered over
+
+    Returns:
+        Selectivity object, the selectivity of an specific equality filter at a given location.
     """
     all_selectivities = []
 

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -100,6 +100,7 @@ def _get_filter_selectivity(
         )
 
         # Assumption: the selectivity is proportional to the number of entries in the collection.
+        # This will not hold in case of duplicates.
         if _is_absolute(selectivity_per_entry_in_collection):
             result_selectivity = Selectivity(
                 kind=ABSOLUTE_SELECTIVITY,
@@ -110,6 +111,9 @@ def _get_filter_selectivity(
                 kind=FRACTIONAL_SELECTIVITY,
                 value=min(float(collection_size) * selectivity_per_entry_in_collection.value,
                           1.0)
+                # The estimate may be above 1.0 in case of duplicates in the collection
+                # so we make sure the value is <= 1.0
+
             )
 
     return result_selectivity

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -20,7 +20,7 @@ class Statistics(object):
         raise NotImplementedError()
 
     def __repr__(self):
-        """Return a human-readable str representation of the Statistics object."""
+        """Return a human-readable str representation of the CompilerEntity object."""
         return self.__str__()
 
     @abstractmethod
@@ -32,23 +32,23 @@ class Statistics(object):
                         GraphQL schema.
 
         Returns:
-            - int, count of vertex or edge instances having, or inheriting, the given class name.
+            - int, the count of vertex or edge instances with, or inheriting the given class name
 
         Raises:
-            AssertionError, if the count statistic for the given vertex/edge class does not exist.
+            AssertionError, if statistic for the given vertex/edge class does not exist.
         """
         raise NotImplementedError()
 
     @abstractmethod
-    def get_vertex_edge_vertex_count(
+    def get_edge_count_between_vertex_pair(
         self, vertex_source_class_name, edge_class_name, vertex_target_class_name
     ):
-        """Return the count of edges of the given class connecting vertex_source to vertex_target.
+        """Return the count of edges connecting two vertices.
 
-        This statistic is optional, as the estimator can roughly predict this statistic using
+        This statistic is optional, as the estimator can roughly predict this cost using
         get_class_count(). In some cases of traversal between two vertices using an edge connecting
-        the vertices' superclasses, the predicitons made using get_class_count() may be off
-        by several orders of magnitude. In such cases, this statistic should be provided.
+        the vertices' superclasses, the estimates generated using get_class_count() may be off by
+        several orders of magnitude. In such cases, this statistic should be provided.
 
         Args:
             vertex_source_class_name: str, vertex class name.
@@ -56,9 +56,8 @@ class Statistics(object):
             vertex_target_class_name: str, vertex class name.
 
         Returns:
-            - int, count of edges of class edge_class with the two vertex classes as its endpoints
-                   if the statistic exists.
-            - None otherwise.
+            - int, the count of edges if the statistic exists
+            - None otherwise
         """
         return None
 
@@ -83,27 +82,27 @@ class Statistics(object):
 class LocalStatistics(Statistics):
     """Provides statistics using ones given at initialization."""
     def __init__(
-        self, class_counts, vertex_edge_vertex_counts=None,
+        self, class_counts, edge_count_between_vertex_pairs=None,
         distinct_field_values_counts=None
     ):
         """Initializes statistics with the given data.
 
         Args:
             class_counts: dict, str -> int, mapping vertex/edge class name to class count.
-            vertex_edge_vertex_counts: optional dict, (str, str, str) -> int, mapping
+            edge_count_between_vertex_pairs: optional dict, (str, str, str) -> int, mapping
                 tuple of (vertex source class name, edge class name, vertex target class name) to
                 count of edge instances of given class connecting instances of two vertex classes.
             distinct_field_values_counts: optional dict, (str, str) -> int, mapping vertex class
                 name and property field name to the count of distinct values of that vertex class's
                 property field.
         """
-        if vertex_edge_vertex_counts is None:
-            vertex_edge_vertex_counts = dict()
+        if edge_count_between_vertex_pairs is None:
+            edge_count_between_vertex_pairs = dict()
         if distinct_field_values_counts is None:
             distinct_field_values_counts = dict()
 
         self._class_counts = frozendict(class_counts)
-        self._vertex_edge_vertex_counts = frozendict(vertex_edge_vertex_counts)
+        self._edge_count_between_vertex_pairs = frozendict(edge_count_between_vertex_pairs)
         self._distinct_field_values_counts = frozendict(distinct_field_values_counts)
 
     def get_class_count(self, class_name):
@@ -114,25 +113,25 @@ class LocalStatistics(Statistics):
                         GraphQL schema.
 
         Returns:
-            - int, count of vertex or edge instances having, or inheriting, the given class name.
+            - int, the count of vertex or edge instances with, or inheriting the given class name
 
         Raises:
-            AssertionError, if the count statistic for the given vertex/edge class does not exist.
+            AssertionError, if statistic for the given vertex/edge class does not exist.
         """
         if class_name not in self._class_counts:
             raise AssertionError(u'Class count statistic is required, but entry not found for: '
                                  u'{}'.format(class_name))
         return self._class_counts[class_name]
 
-    def get_vertex_edge_vertex_count(
+    def get_edge_count_between_vertex_pair(
         self, vertex_source_class_name, edge_class_name, vertex_target_class_name
     ):
-        """Return the count of edges of the given class connecting vertex_source to vertex_target.
+        """Return the count of edges connecting two vertices.
 
-        This statistic is optional, as the estimator can roughly predict this statistic using
+        This statistic is optional, as the estimator can roughly predict this cost using
         get_class_count(). In some cases of traversal between two vertices using an edge connecting
-        the vertices' superclasses, the predicitons made using get_class_count() may be off
-        by several orders of magnitude. In such cases, this statistic should be provided.
+        the vertices' superclasses, the estimates generated using get_class_count() may be off by
+        several orders of magnitude. In such cases, this statistic should be provided.
 
         Args:
             vertex_source_class_name: str, vertex class name.
@@ -140,12 +139,11 @@ class LocalStatistics(Statistics):
             vertex_target_class_name: str, vertex class name.
 
         Returns:
-            - int, count of edges of class edge_class with the two vertex classes as its endpoints
-                   if the statistic exists.
-            - None otherwise.
+            - int, the count of edges if the statistic exists
+            - None otherwise
         """
         statistic_key = (vertex_source_class_name, edge_class_name, vertex_target_class_name)
-        return self._vertex_edge_vertex_counts.get(statistic_key)
+        return self._edge_count_between_vertex_pairs.get(statistic_key)
 
     def get_distinct_field_values_count(self, vertex_name, field_name):
         """Return the count of distinct values a vertex's property field has over all instances.

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -1,6 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from abc import ABCMeta, abstractmethod
 
+from frozendict import frozendict
 import six
 
 
@@ -19,7 +20,7 @@ class Statistics(object):
         raise NotImplementedError()
 
     def __repr__(self):
-        """Return a human-readable str representation of the CompilerEntity object."""
+        """Return a human-readable str representation of the Statistics object."""
         return self.__str__()
 
     @abstractmethod
@@ -31,23 +32,23 @@ class Statistics(object):
                         GraphQL schema.
 
         Returns:
-            - int, the count of vertex or edge instances with, or inheriting the given class name
+            - int, count of vertex or edge instances having, or inheriting, the given class name.
 
         Raises:
-            AssertionError, if statistic for the given vertex/edge class does not exist.
+            AssertionError, if the count statistic for the given vertex/edge class does not exist.
         """
         raise NotImplementedError()
 
     @abstractmethod
-    def get_edge_count_between_vertex_pair(
+    def get_vertex_edge_vertex_count(
         self, vertex_source_class_name, edge_class_name, vertex_target_class_name
     ):
-        """Return the count of edges connecting two vertices.
+        """Return the count of edges of the given class connecting vertex_source to vertex_target.
 
-        This statistic is optional, as the estimator can roughly predict this cost using
+        This statistic is optional, as the estimator can roughly predict this statistic using
         get_class_count(). In some cases of traversal between two vertices using an edge connecting
-        the vertices' superclasses, the estimates generated using get_class_count() may be off by
-        several orders of magnitude. In such cases, this statistic should be provided.
+        the vertices' superclasses, the predicitons made using get_class_count() may be off
+        by several orders of magnitude. In such cases, this statistic should be provided.
 
         Args:
             vertex_source_class_name: str, vertex class name.
@@ -55,28 +56,55 @@ class Statistics(object):
             vertex_target_class_name: str, vertex class name.
 
         Returns:
-            - int, the count of edges if the statistic exists
-            - None otherwise
+            - int, count of edges of class edge_class with the two vertex classes as its endpoints
+                   if the statistic exists.
+            - None otherwise.
+        """
+        return None
+
+    @abstractmethod
+    def get_distinct_field_values_count(self, vertex_name, field_name):
+        """Return the count of distinct values a vertex's property field has over all instances.
+
+        This statistic helps estimate the result size of @filter directives used to filter
+        values using equality operators like '=', '!=', and 'in_collection'.
+
+        Args:
+            vertex_name: str, name of a vertex.
+            field_name: str, name of a vertex field.
+
+        Returns:
+            - int, count of distinct values of that vertex's property field if the statistic exists.
+            - None otherwise.
         """
         return None
 
 
 class LocalStatistics(Statistics):
     """Provides statistics using ones given at initialization."""
-    def __init__(self, class_counts, edge_count_between_vertex_pairs=None):
+    def __init__(
+        self, class_counts, vertex_edge_vertex_counts=None,
+        distinct_field_values_counts=None
+    ):
         """Initializes statistics with the given data.
 
         Args:
             class_counts: dict, str -> int, mapping vertex/edge class name to class count.
-            edge_count_between_vertex_pairs: optional dict, (str, str, str) -> int, mapping
+            vertex_edge_vertex_counts: optional dict, (str, str, str) -> int, mapping
                 tuple of (vertex source class name, edge class name, vertex target class name) to
                 count of edge instances of given class connecting instances of two vertex classes.
+            distinct_field_values_counts: optional dict, (str, str) -> int, mapping vertex class
+                name and property field name to the count of distinct values of that vertex class's
+                property field.
         """
-        if edge_count_between_vertex_pairs is None:
-            edge_count_between_vertex_pairs = dict()
+        if vertex_edge_vertex_counts is None:
+            vertex_edge_vertex_counts = dict()
+        if distinct_field_values_counts is None:
+            distinct_field_values_counts = dict()
 
-        self._class_counts = class_counts
-        self._edge_count_between_vertex_pairs = edge_count_between_vertex_pairs
+        self._class_counts = frozendict(class_counts)
+        self._vertex_edge_vertex_counts = frozendict(vertex_edge_vertex_counts)
+        self._distinct_field_values_counts = frozendict(distinct_field_values_counts)
 
     def get_class_count(self, class_name):
         """Return how many vertex or edge instances have, or inherit, the given class name.
@@ -86,25 +114,25 @@ class LocalStatistics(Statistics):
                         GraphQL schema.
 
         Returns:
-            - int, the count of vertex or edge instances with, or inheriting the given class name
+            - int, count of vertex or edge instances having, or inheriting, the given class name.
 
         Raises:
-            AssertionError, if statistic for the given vertex/edge class does not exist.
+            AssertionError, if the count statistic for the given vertex/edge class does not exist.
         """
         if class_name not in self._class_counts:
             raise AssertionError(u'Class count statistic is required, but entry not found for: '
                                  u'{}'.format(class_name))
         return self._class_counts[class_name]
 
-    def get_edge_count_between_vertex_pair(
+    def get_vertex_edge_vertex_count(
         self, vertex_source_class_name, edge_class_name, vertex_target_class_name
     ):
-        """Return the count of edges connecting two vertices.
+        """Return the count of edges of the given class connecting vertex_source to vertex_target.
 
-        This statistic is optional, as the estimator can roughly predict this cost using
+        This statistic is optional, as the estimator can roughly predict this statistic using
         get_class_count(). In some cases of traversal between two vertices using an edge connecting
-        the vertices' superclasses, the estimates generated using get_class_count() may be off by
-        several orders of magnitude. In such cases, this statistic should be provided.
+        the vertices' superclasses, the predicitons made using get_class_count() may be off
+        by several orders of magnitude. In such cases, this statistic should be provided.
 
         Args:
             vertex_source_class_name: str, vertex class name.
@@ -112,8 +140,26 @@ class LocalStatistics(Statistics):
             vertex_target_class_name: str, vertex class name.
 
         Returns:
-            - int, the count of edges if the statistic exists
-            - None otherwise
+            - int, count of edges of class edge_class with the two vertex classes as its endpoints
+                   if the statistic exists.
+            - None otherwise.
         """
         statistic_key = (vertex_source_class_name, edge_class_name, vertex_target_class_name)
-        return self._edge_count_between_vertex_pairs.get(statistic_key)
+        return self._vertex_edge_vertex_counts.get(statistic_key)
+
+    def get_distinct_field_values_count(self, vertex_name, field_name):
+        """Return the count of distinct values a vertex's property field has over all instances.
+
+        This statistic helps estimate the result size of @filter directives used to filter
+        values using equality operators like '=', '!=', and 'in_collection'.
+
+        Args:
+            vertex_name: str, name of a vertex.
+            field_name: str, name of a vertex field.
+
+        Returns:
+            - int, count of distinct values of that vertex's property field if the statistic exists.
+            - None otherwise.
+        """
+        statistic_key = (vertex_name, field_name)
+        return self._distinct_field_values_counts.get(statistic_key)

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -192,8 +192,7 @@ class CostEstimationTests(unittest.TestCase):
             ('Animal', 'Entity_Related', 'Event'): 0
         }
         statistics = LocalStatistics(
-            count_data, edge_count_between_vertex_pairs=edge_count_data
-        )
+            count_data, edge_count_between_vertex_pairs=edge_count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -133,7 +133,7 @@ class CostEstimationTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_traversal_provided_both_statistics(self):
-        """Test type coercion provided both class_counts and vertex_edge_vertex_counts."""
+        """Test type coercion provided both class_counts and edge_count_between_vertex_pairs."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_input = '''{
             Animal {
@@ -152,12 +152,11 @@ class CostEstimationTests(unittest.TestCase):
             'Event': 7,
             'Entity_Related': 11
         }
-        vertex_edge_vertex_data = {
+        edge_count_data = {
             ('Animal', 'Entity_Related', 'Event'): 2
         }
         statistics = LocalStatistics(
-            count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data
-        )
+            count_data, edge_count_between_vertex_pairs=edge_count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -189,19 +188,19 @@ class CostEstimationTests(unittest.TestCase):
             'Event': 7,
             'Entity_Related': 11
         }
-        vertex_edge_vertex_data = {
+        edge_count_data = {
             ('Animal', 'Entity_Related', 'Event'): 0
         }
         statistics = LocalStatistics(
-            count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data
+            count_data, edge_count_between_vertex_pairs=edge_count_data
         )
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
-        # Vertex_edge_vertex_data tells us that no Entity_Related edges connect Animals and Events,
-        # so the result set is empty.
+        # edge_count_data tells us that no Entity_Related edges connect Animals and Events, so the
+        # result size is 0.0 results.
         expected_cardinality_estimate = 0.0
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
@@ -226,12 +225,11 @@ class CostEstimationTests(unittest.TestCase):
             'Event': 7,
             'Entity_Related': 11
         }
-        vertex_edge_vertex_data = {
+        edge_count_data = {
             ('Animal', 'Entity_Related', 'Event'): 2
         }
         statistics = LocalStatistics(
-            count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data
-        )
+            count_data, edge_count_between_vertex_pairs=edge_count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -269,12 +267,11 @@ class CostEstimationTests(unittest.TestCase):
             'Entity_Related': 11,
             'Location': 13
         }
-        vertex_edge_vertex_data = {
+        edge_count_data = {
             ('Animal', 'Entity_Related', 'Event'): 2
         }
         statistics = LocalStatistics(
-            count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data
-        )
+            count_data, edge_count_between_vertex_pairs=edge_count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params
@@ -587,10 +584,10 @@ class CostEstimationTests(unittest.TestCase):
             'FeedingEvent': 11,
             'BirthEvent': 13
         }
-        vertex_edge_vertex_data = {
+        edge_count_data = {
             ('Animal', 'Animal_BornAt', 'BirthEvent'): 2
         }
-        statistics = LocalStatistics(count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data)
+        statistics = LocalStatistics(count_data, edge_count_between_vertex_pairs=edge_count_data)
 
         cardinality_estimate = estimate_query_result_cardinality(
             schema_graph, statistics, graphql_input, params


### PR DESCRIPTION
- Support for distinct_field_values_count, so we can now predict result costs even when filters are done over non-unique properties!
- Added tests for non-unique filters, and changed old tests' docstrings so that they explicitly state that `distinct_field_values_count` is not provided.
- @reviewers: I'm debating whether to add a `*args=None` argument to the LocalStatistics `__init__` method after class_counts, so that every statistic after class_counts has to be passed as a keyword argument. 