### PR TITLE
Split renaming and validation

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -1,14 +1,14 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
-from copy import deepcopy
 
-from graphql import build_ast_schema
+from graphql import build_ast_schema, parse
+from graphql.language.printer import print_ast
 from graphql.language.visitor import Visitor, visit
 import six
 
 from .utils import (
-    SchemaNameConflictError, SchemaStructureError, check_ast_schema_is_valid,
-    check_type_name_is_valid, get_query_type_name, get_scalar_names
+    SchemaNameConflictError, check_ast_schema_is_valid, check_type_name_is_valid,
+    get_query_type_name, get_scalar_names
 )
 
 
@@ -43,28 +43,23 @@ def rename_schema(ast, renamings):
         in the map.
 
     Raises:
-        InvalidTypeNameError if the schema contains an invalid type name, or if the user attempts
-        to rename a type to an invalid name. A name is considered invalid if it does not consist
-        of alphanumeric characters and underscores, if it starts with a numeric character, or
-        if it starts with double underscores
-        SchemaStructureError if the schema does not have the expected form; in particular, if
-        the AST does not represent a valid schema, if any query type field does not have the
-        same name as the type that it queries, if the schema contains type extensions or
-        input object definitions, or if the schema contains mutations or subscriptions
-        SchemaNameConflictError if there are conflicts between the renamed types or fields
+        - InvalidTypeNameError if the schema contains an invalid type name, or if the user attempts
+          to rename a type to an invalid name. A name is considered invalid if it does not consist
+          of alphanumeric characters and underscores, if it starts with a numeric character, or
+          if it starts with double underscores
+        - SchemaStructureError if the schema does not have the expected form; in particular, if
+          the AST does not represent a valid schema, if any query type field does not have the
+          same name as the type that it queries, if the schema contains type extensions or
+          input object definitions, or if the schema contains mutations or subscriptions
+        - SchemaNameConflictError if there are conflicts between the renamed types or fields
     """
-    ast = deepcopy(ast)
+    # Prevent modifying input
+    ast = parse(print_ast(ast))  # much faster than deepcopy
 
-    # Check that the AST can be built into a valid schema
-    try:
-        # May raise Exception -- see graphql/utils/build_ast_schema.py
-        schema = build_ast_schema(ast)
-    except Exception as e:
-        raise SchemaStructureError(u'Input is not a valid schema. Message: {}'.format(e))
+    # Check input schema satisfies various structural requirements
+    check_ast_schema_is_valid(ast)
 
-    # Check additional structural requirements
-    check_ast_schema_is_valid(ast, schema)
-
+    schema = build_ast_schema(ast)
     query_type = get_query_type_name(schema)
     scalars = get_scalar_names(schema)
 
@@ -104,9 +99,9 @@ def _rename_types(ast, renamings, query_type, scalars):
         including those that were not renamed.
 
     Raises:
-        InvalidTypeNameError if the schema contains an invalid type name, or if the user attempts
-        to rename a type to an invalid name
-        SchemaNameConflictError if the rename causes name conflicts
+        - InvalidTypeNameError if the schema contains an invalid type name, or if the user attempts
+          to rename a type to an invalid name
+        - SchemaNameConflictError if the rename causes name conflicts
     """
     visitor = RenameSchemaTypesVisitor(renamings, query_type, scalars)
     visit(ast, visitor)
@@ -139,20 +134,30 @@ class RenameSchemaTypesVisitor(Visitor):
         'Document',
         'EnumValue',
         'EnumValueDefinition',
+        'Field',
         'FieldDefinition',
         'FloatValue',
+        'FragmentDefinition',
+        'FragmentSpread',
+        'InlineFragment',
+        'InputObjectTypeDefinition',
         'InputValueDefinition',
         'IntValue',
         'ListType',
         'ListValue',
         'Name',
         'NonNullType',
+        'ObjectField',
+        'ObjectValue',
+        'OperationDefinition',
         'OperationTypeDefinition',
-        'SchemaDefinition',
-        'StringValue',
-    })
-    check_name_validity_types = frozenset({
         'ScalarTypeDefinition',
+        'SchemaDefinition',
+        'SelectionSet',
+        'StringValue',
+        'TypeExtensionDefinition',
+        'Variable',
+        'VariableDefinition',
     })
     rename_types = frozenset({
         'EnumTypeDefinition',
@@ -160,22 +165,6 @@ class RenameSchemaTypesVisitor(Visitor):
         'NamedType',
         'ObjectTypeDefinition',
         'UnionTypeDefinition',
-    })
-    unexpected_types = frozenset({
-        'Field',
-        'FragmentDefinition',
-        'FragmentSpread',
-        'InlineFragment',
-        'ObjectField',
-        'ObjectValue',
-        'OperationDefinition',
-        'SelectionSet',
-        'Variable',
-        'VariableDefinition',
-    })
-    disallowed_types = frozenset({
-        'InputObjectTypeDefinition',
-        'TypeExtensionDefinition',
     })
 
     def __init__(self, renamings, query_type, scalar_types):
@@ -208,12 +197,11 @@ class RenameSchemaTypesVisitor(Visitor):
                   element such as type, interface, or scalar (user defined or builtin)
 
         Raises:
-            InvalidTypeNameError if either the node's current name or renamed name is invalid
-            SchemaNameConflictError if the newly renamed node causes name conflicts with
-            existing types, scalars, or builtin types
+            - InvalidTypeNameError if either the node's current name or renamed name is invalid
+            - SchemaNameConflictError if the newly renamed node causes name conflicts with
+              existing types, scalars, or builtin types
         """
         name_string = node.value
-        check_type_name_is_valid(name_string)
 
         if name_string == self.query_type or name_string in self.scalar_types:
             return
@@ -246,22 +234,9 @@ class RenameSchemaTypesVisitor(Visitor):
         if node_type in self.noop_types:
             # Do nothing, continue traversal
             return None
-        elif node_type in self.check_name_validity_types:
-            # Check the current name is valid, do not rename, continue traversal
-            check_type_name_is_valid(node.name.value)
         elif node_type in self.rename_types:
             # Rename and put into record the name attribute of current node; continue traversal
             self._rename_name_and_add_to_record(node.name)
-        elif node_type in self.unexpected_types:
-            # Node type unexpected in schema definition, raise error
-            raise SchemaStructureError(
-                u'Node type "{}" unexpected in schema AST'.format(node_type)
-            )
-        elif node_type in self.disallowed_types:
-            # Node type possible in schema definition but disallowed, raise error
-            raise SchemaStructureError(
-                u'Node type "{}" not allowed'.format(node_type)
-            )
         else:
             # All Node types should've been taken care of, this line should never be reached
             raise AssertionError(u'Missed type: "{}"'.format(node_type))

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -1,8 +1,8 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
+from copy import deepcopy
 
-from graphql import build_ast_schema, parse
-from graphql.language.printer import print_ast
+from graphql import build_ast_schema
 from graphql.language.visitor import Visitor, visit
 import six
 
@@ -54,7 +54,7 @@ def rename_schema(ast, renamings):
         - SchemaNameConflictError if there are conflicts between the renamed types or fields
     """
     # Prevent modifying input
-    ast = parse(print_ast(ast))  # much faster than deepcopy
+    ast = deepcopy(ast)
 
     # Check input schema satisfies various structural requirements
     check_ast_schema_is_valid(ast)

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -1,6 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 import re
 
+from graphql import build_ast_schema
 from graphql.language.ast import NamedType
 from graphql.language.visitor import Visitor, visit
 from graphql.type.definition import GraphQLScalarType
@@ -45,8 +46,8 @@ def check_type_name_is_valid(name):
         name: str
 
     Raises:
-        InvalidTypeNameError if the name doesn't consist of only alphanumeric characters and
-        underscores, starts with a numeric character, or starts with double underscores
+        - InvalidTypeNameError if the name doesn't consist of only alphanumeric characters and
+          underscores, starts with a numeric character, or starts with double underscores
     """
     if not isinstance(name, str):
         raise InvalidTypeNameError(u'Name "{}" is not a string.'.format(name))
@@ -91,6 +92,57 @@ def get_scalar_names(schema):
     return scalars
 
 
+class CheckValidTypesAndNamesVisitor(Visitor):
+    """Check that the AST does not contain invalid types or types with invalid names.
+
+    If AST contains invalid types, raise SchemaStructureError; if AST contains types with
+    invalid names, raise InvalidTypeNameError.
+    """
+    disallowed_types = frozenset({  # types not supported in renaming or merging
+        'InputObjectTypeDefinition',
+        'TypeExtensionDefinition',
+    })
+    unexpected_types = frozenset({  # types not expected to be found in schema definition
+        'Field',
+        'FragmentDefinition',
+        'FragmentSpread',
+        'InlineFragment',
+        'ObjectField',
+        'ObjectValue',
+        'OperationDefinition',
+        'SelectionSet',
+        'Variable',
+        'VariableDefinition',
+    })
+    check_name_validity_types = frozenset({  # nodes whose name need to be checked
+        'EnumTypeDefinition',
+        'InterfaceTypeDefinition',
+        'ObjectTypeDefinition',
+        'ScalarTypeDefinition',
+        'UnionTypeDefinition',
+    })
+
+    def enter(self, node, key, parent, path, ancestors):
+        """Raise error if node is of a invalid type or has an invalid name.
+
+        Raises:
+            - SchemaStructureError if the node is an InputObjectTypeDefinition,
+              TypeExtensionDefinition, or a type that shouldn't exist in a schema definition
+            - InvalidTypeNameError if a node has an invalid name
+        """
+        node_type = type(node).__name__
+        if node_type in self.disallowed_types:
+            raise SchemaStructureError(
+                u'Node type "{}" not allowed.'.format(node_type)
+            )
+        elif node_type in self.unexpected_types:
+            raise SchemaStructureError(
+                u'Node type "{}" unexpected in schema AST'.format(node_type)
+            )
+        elif node_type in self.check_name_validity_types:
+            check_type_name_is_valid(node.name.value)
+
+
 class CheckQueryTypeFieldsNameMatchVisitor(Visitor):
     """Check that every query type field's name is identical to the type it queries.
 
@@ -119,8 +171,8 @@ class CheckQueryTypeFieldsNameMatchVisitor(Visitor):
         """If inside the query type, check that the field and queried type names match.
 
         Raises:
-            SchemaStructureError if the field name is not identical to the name of the type
-            that it queries
+            - SchemaStructureError if the field name is not identical to the name of the type
+              that it queries
         """
         if self.in_query_type:
             field_name = node.name.value
@@ -136,35 +188,28 @@ class CheckQueryTypeFieldsNameMatchVisitor(Visitor):
                 )
 
 
-def _check_query_type_fields_name_match(ast, query_type):
-    """Check every query type field's name is identical to the type it queries.
-
-    Args:
-        ast: Document representing a schema
-        query_type: str, name of the query type
-
-    Raises:
-        SchemaStructureError if any query type field name is not identical to the name of the
-        type that it queries
-    """
-    visitor = CheckQueryTypeFieldsNameMatchVisitor(query_type)
-    visit(ast, visitor)
-
-
-def check_ast_schema_is_valid(ast, schema):
+def check_ast_schema_is_valid(ast):
     """Check the schema satisfies structural requirements for rename and merge.
 
-    In particular, check that the schema contains no mutations, no subscriptions, and all query
-    type field names match the types they query.
+    In particular, check that the schema contains no mutations, no subscriptions, no
+    InputObjectTypeDefinitions, no TypeExtensionDefinitions, all type names are valid and not
+    reserved (not starting with double underscores), and all query type field names match the
+    types they query.
 
     Args:
         ast: Document, representing a schema
-        schema: GraphQLSchema, representing the same schema as ast
 
     Raises:
-        SchemaStructureError if the schema contains mutations, contains subscriptions, or some
-        query type field name does not match the type it queries.
+        - SchemaStructureError if the AST cannot be built into a valid schema, if the schema
+          contains mutations, subscriptions, InputObjectTypeDefinitions, TypeExtensionsDefinitions,
+          or if any query type field does not match the queried type.
+        - InvalidTypeNameError if a type has a type name that is invalid or reserved
     """
+    try:
+        schema = build_ast_schema(ast)
+    except Exception as e:  # Can't be more specific -- see graphql/utils/build_ast_schema.py
+        raise SchemaStructureError(u'Input is not a valid schema. Message: {}'.format(e))
+
     if schema.get_mutation_type() is not None:
         raise SchemaStructureError(
             u'Renaming schemas that contain mutations is currently not supported.'
@@ -174,6 +219,7 @@ def check_ast_schema_is_valid(ast, schema):
             u'Renaming schemas that contain subscriptions is currently not supported.'
         )
 
-    query_type = get_query_type_name(schema)
+    visit(ast, CheckValidTypesAndNamesVisitor())
 
-    _check_query_type_fields_name_match(ast, query_type)
+    query_type = get_query_type_name(schema)
+    visit(ast, CheckQueryTypeFieldsNameMatchVisitor(query_type))


### PR DESCRIPTION
All validation of input schema now lives inside util.py file.

Other changes: replace deepcopy with parse and print_ast for performance; indent some doc strings for readability

One test that checks type coverage will fail, since the sets like `check_name_validity_types` and `unexpected_types` and such have been removed.