### PR TITLE
Add reminder to install dependencies after adding package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,3 +96,8 @@ lockfiles for both Python versions. The easiest way to do so is with the followi
 ```
 ./scripts/make_pipenv_lockfiles.sh
 ```
+Then, re-run 
+```
+pipenv sync --dev
+```
+to install the relevant dependencies.


### PR DESCRIPTION
Previously the instructions just said to run the script and I didn't
realize this didn't work until I'd run `pipenv sync --dev`.