### PR TITLE
Remove deepcopy from merge_schemas

### DIFF
--- a/graphql_compiler/schema_transformation/merge_schemas.py
+++ b/graphql_compiler/schema_transformation/merge_schemas.py
@@ -1,6 +1,5 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
-from copy import deepcopy
 
 from graphql import build_ast_schema
 from graphql.language import ast as ast_types
@@ -62,6 +61,8 @@ def merge_schemas(schemas_dict):
     from input schemas. The fields of its query type will be the union of the fields of the
     query types of each input schema.
 
+    Note that the output AST will share mutable objects with input ASTs.
+
     Args:
         schemas_dict: OrderedDict[str, Document], where keys are names/identifiers of schemas,
                       and values are ASTs describing schemas. The ASTs will not be modified
@@ -92,9 +93,6 @@ def merge_schemas(schemas_dict):
     directives = {}  # Dict[str, DirectiveDefinition]
 
     for cur_schema_id, cur_ast in six.iteritems(schemas_dict):
-        # Prevent aliasing between output and input
-        cur_ast = deepcopy(cur_ast)
-
         # Check input schema satisfies various structural requirements
         check_ast_schema_is_valid(cur_ast)
 


### PR DESCRIPTION
Input and output ASTs will share objects but input ASTs shouldn't be modified. Merging is much faster without copying. 