### PR TITLE
Add tests involving cross schema edges but no subclasses

### DIFF
--- a/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
+++ b/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
@@ -279,3 +279,17 @@ class InputSchemaStrings(object):
           Giraffe: Giraffe
         }
     ''')
+
+    same_field_schema = dedent('''\
+        schema {
+          query: SchemaQuery
+        }
+
+        type Person {
+          identifier: String
+        }
+
+        type SchemaQuery {
+          Person: Person
+        }
+    ''')

--- a/graphql_compiler/tests/schema_transformation_tests/test_merge_schemas.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_merge_schemas.py
@@ -3,14 +3,13 @@ from collections import OrderedDict
 from textwrap import dedent
 import unittest
 
-from graphql import build_ast_schema, parse
+from graphql import parse
 from graphql.language.printer import print_ast
-import six
 
 from ...schema_transformation.merge_schemas import (
     CrossSchemaEdgeDescriptor, FieldReference, merge_schemas
 )
-from ...schema_transformation.utils import InvalidCrossSchemaEdgeError, SchemaNameConflictError
+from ...schema_transformation.utils import SchemaNameConflictError
 from .input_schema_strings import InputSchemaStrings as ISS
 
 


### PR DESCRIPTION
These are tests involving simple and valid cross schema edges.
There are two more classes of tests coming up: invalid edges, and edges that involve interfaces and unions (and thus one edge creates new vertex fields on more than two types)