### PR TITLE
merge_schemas now requires at least two input schemas

### DIFF
--- a/graphql_compiler/schema_transformation/merge_schemas.py
+++ b/graphql_compiler/schema_transformation/merge_schemas.py
@@ -80,7 +80,7 @@ def merge_schemas(schema_id_to_ast, cross_schema_edges, type_equivalence_hints=N
 
     Raises:
         - ValueError if some schema identifier is not a nonempty string of alphanumeric
-          characters and underscores
+          characters and underscores, or if there are no more than one input schema to merge
         - SchemaStructureError if the schema does not have the expected form; in particular, if
           the AST does not represent a valid schema, if any query type field does not have the
           same name as the type that it queries, if the schema contains type extensions or
@@ -93,8 +93,8 @@ def merge_schemas(schema_id_to_ast, cross_schema_edges, type_equivalence_hints=N
           refers nonexistent schemas, types, fields, or connects non-scalar or non-matching
           fields
     """
-    if len(schema_id_to_ast) == 0:
-        raise ValueError(u'Expected a nonzero number of schemas to merge.')
+    if len(schema_id_to_ast) <= 1:
+        raise ValueError(u'Expected at least two schemas to merge.')
 
     query_type = 'RootSchemaQuery'
     merged_schema_ast = _get_basic_schema_ast(query_type)  # Document

--- a/graphql_compiler/tests/schema_transformation_tests/test_merge_schemas.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_merge_schemas.py
@@ -486,6 +486,7 @@ class TestMergeSchemasNoCrossSchemaEdges(unittest.TestCase):
             merge_schemas(
                 OrderedDict([
                     ('', parse(ISS.basic_schema)),
+                    ('enum', parse(ISS.enum_schema)),
                 ]),
                 [],
             )
@@ -493,6 +494,7 @@ class TestMergeSchemasNoCrossSchemaEdges(unittest.TestCase):
             merge_schemas(
                 OrderedDict([
                     ('hello\n', parse(ISS.basic_schema)),
+                    ('enum', parse(ISS.enum_schema)),
                 ]),
                 [],
             )
@@ -500,6 +502,7 @@ class TestMergeSchemasNoCrossSchemaEdges(unittest.TestCase):
             merge_schemas(
                 OrderedDict([
                     ('<script>alert("hello world")</script>', parse(ISS.basic_schema)),
+                    ('enum', parse(ISS.enum_schema)),
                 ]),
                 [],
             )
@@ -507,6 +510,7 @@ class TestMergeSchemasNoCrossSchemaEdges(unittest.TestCase):
             merge_schemas(
                 OrderedDict([
                     ('\t\b', parse(ISS.basic_schema)),
+                    ('enum', parse(ISS.enum_schema)),
                 ]),
                 [],
             )
@@ -514,6 +518,21 @@ class TestMergeSchemasNoCrossSchemaEdges(unittest.TestCase):
             merge_schemas(
                 OrderedDict([
                     (42, parse(ISS.basic_schema)),
+                    ('enum', parse(ISS.enum_schema)),
+                ]),
+                [],
+            )
+
+    def test_too_few_input_schemas(self):
+        with self.assertRaises(ValueError):
+            merge_schemas(
+                OrderedDict(),
+                [],
+            )
+        with self.assertRaises(ValueError):
+            merge_schemas(
+                OrderedDict([
+                    ('first', parse(ISS.basic_schema)),
                 ]),
                 [],
             )


### PR DESCRIPTION
Having only one schema in input is no longer allowed. Existing tests that had only one input schema are fixed. New test is added to check behavior when 0 or 1 schemas are added as input.