### PR TITLE
Code for splitting query one level recursively

### DIFF
--- a/graphql_compiler/schema_transformation/split_query.py
+++ b/graphql_compiler/schema_transformation/split_query.py
@@ -1,7 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from collections import namedtuple, OrderedDict
+from collections import OrderedDict, namedtuple
 from copy import copy
-import six
 
 from graphql.language.ast import (
     Argument, Directive, Document, Field, InlineFragment, InterfaceTypeDefinition, Name,
@@ -9,6 +8,7 @@ from graphql.language.ast import (
 )
 from graphql.language.visitor import TypeInfoVisitor, Visitor, visit
 from graphql.utils.type_info import TypeInfo
+import six
 
 from ..ast_manipulation import get_only_query_definition
 from ..compiler.helpers import strip_non_null_and_list_from_type
@@ -47,19 +47,15 @@ class SubQueryNode(object):
 
 
 def _split_query_ast_one_level_recursive(
-    query_node, ast, type_info, edge_to_stitch_fields, intermediate_out_name_assigner
+    query_node, ast, type_info, edge_to_stitch_fields, name_assigner
 ):
     """Return an AST node with which to replace the input AST in the selections that contain it.
 
-    This function examines the selections of the input AST, and divides them into three sets:
-    property fields, intra-schema vertex fields, and cross-schema vertex fields.
-
-    Each cross-schema vertex field will have its branch removed from the output AST, and made
-    into its own separate query AST. The parent and child property fields used in
-    the stitch will be added to the parent and child ASTs. @output directives will be added
-    to the parent and child property fields, if not already present.
-
-    The function will be called recursively on each intra-schema vertex field.
+    This function examines the selections of the input AST, and recursively calls either
+    _split_query_ast_one_level_recursive_type_coercion or
+    _split_query_ast_one_level_recursive_normal_fields
+    depending on whether the selections contains a single InlineFragment or a number of normal
+    fields.
 
     Args:
         query_node: SubQueryNode, whose list of child query connections may be modified to
@@ -67,23 +63,125 @@ def _split_query_ast_one_level_recursive(
         ast: Field, InlineFragment, or OperationDefinition, the AST that we are trying to split
              into child components. It is not modified by this function
         type_info: TypeInfo, used to get information about the types of fields while traversing
-                   the query ast
+                   the query AST
         edge_to_stitch_fields: Dict[Tuple(str, str), Tuple(str, str)], mapping
                                (type name, vertex field name) to
                                (source field name, sink field name) used in the @stitch directive
                                for each cross schema edge
-        intermediate_out_name_assigner: IntermediateOutNameAssigner, object used to generate
-                                        and keep track of names of newly created @output
-                                        directives
+        name_assigner: IntermediateOutNameAssigner, object used to generate and keep track of
+                       names of newly created @output directives
     """
-    # Split selections into three kinds: property fields, cross schema vertex fields, normal
-    # vertex fields/type coercions
     type_info.enter(ast.selection_set)
+    selections = ast.selection_set.selections
+    if (
+        len(selections) == 1 and
+        isinstance(selections[0], InlineFragment)
+    ):
+        # Case 1: type coercion
+        new_selections = _split_query_ast_one_level_recursive_type_coercion(
+            query_node, selections, type_info, edge_to_stitch_fields, name_assigner
+        )
+    else:
+        # Case 2: normal field
+        new_selections = _split_query_ast_one_level_recursive_normal_fields(
+            query_node, selections, type_info, edge_to_stitch_fields, name_assigner
+        )
+    type_info.leave(ast.selection_set)
+
+    # Return input, or make copy
+    if new_selections is not selections:
+        new_ast = copy(ast)
+        new_ast.selection_set = SelectionSet(selections=new_selections)
+        return new_ast
+    else:
+        return ast
+
+
+def _split_query_ast_one_level_recursive_type_coercion(
+    query_node, selections, type_info, edge_to_stitch_fields, name_assigner
+):
+    """One case of splitting query, selections contains a single inline fragment.
+
+    _split_query_ast_one_level_recursive will be called recursively on the single selection.
+
+    Args:
+        query_node: SubQueryNode, whose list of child query connections may be modified to
+                    include new children
+        selections: List[InlineFragment], containing a single inline fragment (type coercion)
+        type_info: TypeInfo, used to get information about the types of fields while traversing
+                   the query AST
+        edge_to_stitch_fields: Dict[Tuple(str, str), Tuple(str, str)], mapping
+                               (type name, vertex field name) to
+                               (source field name, sink field name) used in the @stitch directive
+                               for each cross schema edge
+        name_assigner: IntermediateOutNameAssigner, object used to generate and keep track of
+                       names of newly created @output directives
+
+    Returns:
+        List[InlineFragment], containing a single inline fragment, used to replace the
+        list of selections in the SelectionSet one level above. If no changes were made, the
+        exact input list object will be returned
+    """
+    if len(selections) != 1:
+        raise AssertionError(u'Selections {} should only contain one element'.format(selections))
+    type_coercion = selections[0]
+    if not isinstance(type_coercion, InlineFragment):
+        raise AssertionError(u'Selection {} should be an inline fragment.'.format(type_coercion))
+
+    type_info.enter(type_coercion)
+    new_type_coercion = _split_query_ast_one_level_recursive(
+        query_node, type_coercion, type_info, edge_to_stitch_fields, name_assigner
+    )
+    type_info.leave(type_coercion)
+
+    if new_type_coercion is not type_coercion:
+        return [new_type_coercion]
+    else:
+        return selections
+
+
+def _split_query_ast_one_level_recursive_normal_fields(
+    query_node, selections, type_info, edge_to_stitch_fields, name_assigner
+):
+    """One case of splitting query, selections contains a number of fields, no inline fragments.
+
+    The input selections will be divided into three sets: property fields, intra-schema vertex
+    fields, and cross-schema vertex fields.
+
+    Each cross-schema vertex field will not be included in the output selections. The AST
+    branch that each cross-schema vertex field leads to will be made into its own separate query
+    AST. The parent and child property fields used in the stich will be added to the parent and
+    child ASTs, if not already present. @outpt directives will be added to these parent and
+    child property fields, if not already present. @filter directives will not be added to
+    child property fields in this step. This is because one may choose to rearrange and reroot
+    the tree of SubQueryNodes to achieve an execution order with better performance. @filter
+    directives should be added only once the tree's structure is fixed.
+
+    _split_query_ast_one_level_recursive will be called recursive on each intra-schema vertex
+    field.
+
+    Args:
+        query_node: SubQueryNode, whose list of child query connections may be modified to
+                    include new children
+        selections: List[Field], containing a number of property fields and vertex fields
+        type_info: TypeInfo, used to get information about the types of fields while traversing
+                   the query AST
+        edge_to_stitch_fields: Dict[Tuple(str, str), Tuple(str, str)], mapping
+                               (type name, vertex field name) to
+                               (source field name, sink field name) used in the @stitch directive
+                               for each cross schema edge
+        name_assigner: IntermediateOutNameAssigner, object used to generate and keep track of
+                       names of newly created @output directives
+
+    Returns:
+        List[Field], with which to replace the list of selections in the SelectionSet one level
+        above. All cross schema edges in the input list will be removed, and in their place,
+        property fields added or modified. If no changes were made, the exact input list object
+        will be returned
+    """
     parent_type_name = type_info.get_parent_type().name
 
-    property_fields_map, vertex_fields = _split_selections_property_and_vertex(
-        ast.selection_set.selections
-    )
+    property_fields_map, vertex_fields = _split_selections_property_and_vertex(selections)
     intra_schema_fields, cross_schema_fields = _split_vertex_fields_intra_and_cross_schema(
         vertex_fields, parent_type_name, edge_to_stitch_fields
     )
@@ -92,77 +190,75 @@ def _split_query_ast_one_level_recursive(
     if len(cross_schema_fields) > 0:
         made_changes = True
 
-    # First, process cross schema fields
+    # First, no changes will be made to property fields
+
+    # Second, process cross schema fields. This will modify our record of property fields, and
+    # create child SubQueryNodes attached to the input SubQueryNode
     for cross_schema_field in cross_schema_fields:
         type_info.enter(cross_schema_field)
-
-        if type_info.get_type() is not None:
-            child_type_name = strip_non_null_and_list_from_type(type_info.get_type()).name
+        child_type = type_info.get_type()
+        if child_type is not None:
+            child_type_name = strip_non_null_and_list_from_type(child_type).name
         else:
-            raise AssertionError(u'')
-
-        parent_field_name, child_field_name = edge_to_stitch_fields[
-            (parent_type_name, cross_schema_field.name.value)
-        ]
+            raise AssertionError(
+                u'The query may be invalid against the schema, causing TypeInfo to lost track '
+                u'of the types of fields.'
+            )
+        stitch_data_key = (parent_type_name, cross_schema_field.name.value)
+        parent_field_name, child_field_name = edge_to_stitch_fields[stitch_data_key]
         _process_cross_schema_field(
             query_node, cross_schema_field, property_fields_map, child_type_name,
-            parent_field_name, child_field_name, intermediate_out_name_assigner
+            parent_field_name, child_field_name, name_assigner
         )
         type_info.leave(cross_schema_field)
 
-    # Then, process intra schema edges by recursing on them
+    # Third, process intra schema edges by recursing on them
     new_intra_schema_fields = []
     for intra_schema_field in intra_schema_fields:
         type_info.enter(intra_schema_field)
         new_intra_schema_field = _split_query_ast_one_level_recursive(
-            query_node, intra_schema_field, type_info, edge_to_stitch_fields,
-            intermediate_out_name_assigner
+            query_node, intra_schema_field, type_info, edge_to_stitch_fields, name_assigner
         )
         if new_intra_schema_field is not intra_schema_field:
             made_changes = True
         new_intra_schema_fields.append(new_intra_schema_field)
         type_info.leave(intra_schema_field)
 
-    type_info.leave(ast.selection_set)
-
-    # Make copy, or return input if unchanged
     if made_changes:
-        # Construct new selections
-        new_ast = copy(ast)
         new_selections = _get_selections_from_property_and_vertex_fields(
             property_fields_map, new_intra_schema_fields
         )
-        new_ast.selection_set = SelectionSet(selections=new_selections)
-        return new_ast
+        return new_selections
     else:
-        return ast
+        return selections
 
 
 def _process_cross_schema_field(
     query_node, cross_schema_field, property_fields_map, child_type_name, parent_field_name,
-    child_field_name, intermediate_out_name_assigner
+    child_field_name, name_assigner
 ):
     """Construct child SubQueryNode from branch, update record of property fields.
 
     Args:
-        query_node: SubQueryNode
-        cross_schema_field: Field, representing an edge crossing schemas, not modified by this
-                            function
+        query_node: SubQueryNode, the "parent" query node. The new child SubQueryNode will be
+                    added as a child of this node
+        cross_schema_field: Field, representing an edge crossing schemas. It is not modified
+                            by this function. The branch that this edge leads to will be used
+                            to create a new SubQueryNode
         property_fields_map: OrderedDict[str, Field], mapping the name of each property field
                              to its representation. It is modified by this function. If no
                              property field of the specified name already exists, one will be
-                             created and added. If one already exists, it will be replace by
+                             created and added. If one already exists, it will be replaced by
                              a new Field object. The new Field will contains directives from
-                             the cross schema vertex field, as well as a generated @output
-                             directive if one doesn't yet exist
+                             the existing field and the cross schema vertex fields, as well
+                             as a generated @output directive if one doesn't yet exist
         child_type_name: str, name of the type that this cross schema field leads to
         parent_field_name: str, name of the property field that the parent (source of the cross
                            schema edge) stitches on
         child_field_name: str, name of the property field that the child (the type that this
                           cross schema field leads to) stitches on
-        intermediate_out_name_assigner: IntermediateOutNameAssigner, object used to generate
-                                        and keep track of names of newly created @output
-                                        directives
+        name_assigner: IntermediateOutNameAssigner, object used to generate and keep track of
+                       names of newly created @output directives
     """
     existing_property_field = property_fields_map.get(parent_field_name, None)
     # Get property field inheriting the right directives
@@ -171,11 +267,11 @@ def _process_cross_schema_field(
     )
     # Add @output if needed, record out_name
     parent_output_name = _get_out_name_optionally_add_output(
-        parent_property_field, intermediate_out_name_assigner
+        parent_property_field, name_assigner
     )
     # Create child query node around ast
     child_query_node, child_output_name = _get_child_query_node_and_out_name(
-        cross_schema_field, child_type_name, child_field_name, intermediate_out_name_assigner
+        cross_schema_field, child_type_name, child_field_name, name_assigner
     )
     # Create and add QueryConnections
     _add_query_connections(
@@ -189,12 +285,12 @@ def _split_selections_property_and_vertex(selections):
     """Split input selections into property fields and vertex fields/type coercions.
 
     Args:
-        selections: List[Union[Field, InlineFragment]], not modified by this function
+        selections: List[Union[Field]], not modified by this function
 
     Returns:
-        Tuple[OrderedDict[str, Field], List[Union[Field, InlineFragment]]]. The first element
-        of the tuple is a map from the names of property fields to their representations. The
-        second element is a list of vertex fields and type coercions
+        Tuple[OrderedDict[str, Field], List[Field]]. The first element of the tuple is a map
+        from the names of property fields to their representations. The second element is a
+        list of vertex fields
 
     Raises:
         GraphQLValidationError if some property field is repeated
@@ -202,7 +298,7 @@ def _split_selections_property_and_vertex(selections):
     if selections is None:
         raise AssertionError(u'Input selections is None, rather than a list.')
     property_fields_map = OrderedDict()
-    vertex_fields = []  # Also includes type coercions
+    vertex_fields = []
     for selection in selections:
         if is_property_field_ast(selection):
             name = selection.name.value
@@ -224,7 +320,7 @@ def _split_vertex_fields_intra_and_cross_schema(
     """Split input list of vertex fields into intra-schema and cross-schema fields.
 
     Args:
-        vertex_fields: List[Union[Field, InlineFragment]], not modified by this function
+        vertex_fields: List[Field], not modified by this function
         parent_type_name: str, name of the type that has the input list of vertex fields as fields
         edge_to_stitch_fields: Dict[Tuple(str, str), Tuple(str, str)], mapping
                                (type name, vertex field name) to
@@ -232,25 +328,21 @@ def _split_vertex_fields_intra_and_cross_schema(
                                for each cross schema edge
 
     Returns:
-        Tuple[List[Union[Field, InlineFragment]], List[Field]]. The first element is a list of
-        intra schema fields, the second element is a list of cross schema fields
+        Tuple[List[Field], List[Field]]. The first element is a list of intra schema fields,
+        the second element is a list of cross schema fields
     """
     intra_schema_fields = []
     cross_schema_fields = []
     for vertex_field in vertex_fields:
         if isinstance(vertex_field, Field):
-            type_and_field = (parent_type_name, vertex_field.name.value)
-            if type_and_field in edge_to_stitch_fields:
+            stitch_data_key = (parent_type_name, vertex_field.name.value)
+            if stitch_data_key in edge_to_stitch_fields:
                 cross_schema_fields.append(vertex_field)
             else:
                 intra_schema_fields.append(vertex_field)
-        elif isinstance(vertex_field, InlineFragment):
-            intra_schema_fields.append(vertex_field)
         else:
             raise AssertionError(
-                u'Input vertex field {} is neither a Field nor an InlineFragment'.format(
-                    vertex_field
-                )
+                u'Input vertex field {} is not a Field'.format(vertex_field)
             )
     return intra_schema_fields, cross_schema_fields
 
@@ -261,19 +353,17 @@ def _get_selections_from_property_and_vertex_fields(property_fields_map, vertex_
     Args:
         property_fields_map: OrderedDict[str, Field], mapping name of field to their
                              representation. It is not modified by this function
-        vertex_fields: List[Union[Field, InlineFragment]]. It is not modified by this function
+        vertex_fields: List[Field]. It is not modified by this function
 
     Returns:
-        List[Union[Field, InlineFragment]], containing all property fields then all vertex fields,
-        in order
+        List[Field], containing all property fields then all vertex fields, in order
     """
     selections = list(six.itervalues(property_fields_map))
     selections.extend(vertex_fields)
     return selections
 
 
-def _get_child_query_node_and_out_name(ast, child_type_name, child_field_name,
-                                       intermediate_out_name_assigner):
+def _get_child_query_node_and_out_name(ast, child_type_name, child_field_name, name_assigner):
     """Create a query node out of ast, return node and unique out_name on field with input name.
 
     Create a new document out of the input AST, that has the same structure as the input. For
@@ -295,24 +385,22 @@ def _get_child_query_node_and_out_name(ast, child_type_name, child_field_name,
     directive on this field, a new @output directive will be added.
 
     Args:
-        ast: type Node, representing the AST that we're using to build a child node. It is not
-             modified by this function
+        ast: Field or InlineFragment, representing the AST that we're using to build a child
+             node. It is not modified by this function
         child_field_name: str. If no field of this name currently exists as a part of the root
                           selections of the input AST, a new field will be created in the AST
                           contained in the output child query node
-        intermediate_out_name_assigner: IntermediateOutNameAssigner, which will be used to
-                                        generate an out_name, if it's necessary to create a
-                                        new @output directive
+        name_assigner: IntermediateOutNameAssigner, object used to generate and keep track of
+                       names of newly created @output directives
 
     Returns:
-        Tuple[SubQueryNode, str], the child sub query node wrapping around the input ast, and
-        the out_name of the @output directive uniquely identifying the field used or stitching
+        Tuple[SubQueryNode, str], the child sub query node wrapping around the input AST, and
+        the out_name of the @output directive uniquely identifying the field used for stitching
         in this sub query node
     """
     # Get type and selections of child AST, taking into account type coercions
     child_selection_set = ast.selection_set
     if (
-        child_selection_set is not None and
         len(child_selection_set.selections) == 1 and
         isinstance(child_selection_set.selections[0], InlineFragment)
     ):
@@ -325,11 +413,11 @@ def _get_child_query_node_and_out_name(ast, child_type_name, child_field_name,
     existing_child_property_field = try_get_ast_by_name_and_type(
         child_selections, child_field_name, Field
     )
-    child_property_field = _get_property_field(existing_child_property_field, child_field_name, [])
-    # Add @output if needed, record out_name
-    child_output_name = _get_out_name_optionally_add_output(
-        child_property_field, intermediate_out_name_assigner
+    child_property_field = _get_property_field(
+        existing_child_property_field, child_field_name, None
     )
+    # Add @output if needed, record out_name
+    child_output_name = _get_out_name_optionally_add_output(child_property_field, name_assigner)
     # Get new child_selections by replacing or adding in new property field
     child_property_fields_map, child_vertex_fields = _split_selections_property_and_vertex(
         child_selections
@@ -347,7 +435,7 @@ def _get_child_query_node_and_out_name(ast, child_type_name, child_field_name,
     return child_query_node, child_output_name
 
 
-def _get_property_field(parent_field, field_name, directives_from_edge):
+def _get_property_field(existing_field, field_name, directives_from_edge):
     """Return a Field object with field_name, sharing directives with any such existing field.
 
     Any valid directives in directives_on_edge will be transferred over to the new field.
@@ -355,9 +443,8 @@ def _get_property_field(parent_field, field_name, directives_from_edge):
     will also contain all directives of the existing field with that name.
 
     Args:
-        selections: List[Union[Field, InlineFragment]]. If there is a field with field_name,
-                    the directives of this field will carry over to the output field. It is
-                    not modified by this function
+        existing_field: Field or None. If it's not None, it is a field with field_name. The
+                        directives of this field will carry output to the output field
         field_name: str, the name of the output field
         directives_from_edge: List[Directive], the directives of a vertex field. The output
                               field will contain all @filter and any @optional directives
@@ -373,9 +460,9 @@ def _get_property_field(parent_field, field_name, directives_from_edge):
     )
 
     # Transfer directives from existing field of the same name
-    if parent_field is not None:
+    if existing_field is not None:
         # Existing field, add all its directives
-        directives_from_existing_field = parent_field.directives
+        directives_from_existing_field = existing_field.directives
         if directives_from_existing_field is not None:
             new_field.directives.extend(directives_from_existing_field)
     # Transfer directives from edge
@@ -403,14 +490,13 @@ def _get_property_field(parent_field, field_name, directives_from_edge):
     return new_field
 
 
-def _get_out_name_optionally_add_output(field, intermediate_out_name_assigner):
+def _get_out_name_optionally_add_output(field, name_assigner):
     """Return out_name of @output on field, creating new @output if needed.
 
     Args:
         field: Field object, whose directives we may modify by adding an @output directive
-        intermediate_out_name_assigner: IntermediateOutNameAssigner, which will be used to
-                                        generate an out_name, if it's necessary to create a
-                                        new @output directive
+        name_assigner: IntermediateOutNameAssigner, object used to generate and keep track of
+                       names of newly created @output directives
 
     Returns:
         str, name of the out_name of the @output directive, either pre-existing or newly
@@ -422,7 +508,7 @@ def _get_out_name_optionally_add_output(field, intermediate_out_name_assigner):
     )
     if output_directive is None:
         # Create and add new directive to field
-        out_name = intermediate_out_name_assigner.assign_and_return_out_name()
+        out_name = name_assigner.assign_and_return_out_name()
         output_directive = _get_output_directive(out_name)
         if field.directives is None:
             field.directives = []

--- a/graphql_compiler/schema_transformation/split_query.py
+++ b/graphql_compiler/schema_transformation/split_query.py
@@ -16,7 +16,7 @@ from ..exceptions import GraphQLValidationError
 from ..schema import FilterDirective, OptionalDirective, OutputDirective
 from .utils import (
     SchemaStructureError, check_query_is_valid_to_split, is_property_field_ast,
-    try_get_ast_by_name_and_type
+    try_get_ast_by_name_and_type, try_get_inline_fragment
 )
 
 
@@ -70,19 +70,20 @@ def _split_query_ast_one_level_recursive(
                                for each cross schema edge
         name_assigner: IntermediateOutNameAssigner, object used to generate and keep track of
                        names of newly created @output directives
+
+    Returns:
+        Field, InlineFragment, or OperationDefinition, the AST with which to replace the input
+        AST in the selections that contain it
     """
     type_info.enter(ast.selection_set)
     selections = ast.selection_set.selections
-    if (
-        len(selections) == 1 and
-        isinstance(selections[0], InlineFragment)
-    ):
+    if try_get_inline_fragment(selections) is not None:
         # Case 1: type coercion
         new_selections = _split_query_ast_one_level_recursive_type_coercion(
             query_node, selections, type_info, edge_to_stitch_fields, name_assigner
         )
     else:
-        # Case 2: normal field
+        # Case 2: normal fields
         new_selections = _split_query_ast_one_level_recursive_normal_fields(
             query_node, selections, type_info, edge_to_stitch_fields, name_assigner
         )
@@ -122,11 +123,7 @@ def _split_query_ast_one_level_recursive_type_coercion(
         list of selections in the SelectionSet one level above. If no changes were made, the
         exact input list object will be returned
     """
-    if len(selections) != 1:
-        raise AssertionError(u'Selections {} should only contain one element'.format(selections))
-    type_coercion = selections[0]
-    if not isinstance(type_coercion, InlineFragment):
-        raise AssertionError(u'Selection {} should be an inline fragment.'.format(type_coercion))
+    type_coercion = try_get_inline_fragment(selections)
 
     type_info.enter(type_coercion)
     new_type_coercion = _split_query_ast_one_level_recursive(
@@ -181,19 +178,16 @@ def _split_query_ast_one_level_recursive_normal_fields(
     """
     parent_type_name = type_info.get_parent_type().name
 
-    property_fields_map, vertex_fields = _split_selections_property_and_vertex(selections)
-    intra_schema_fields, cross_schema_fields = _split_vertex_fields_intra_and_cross_schema(
-        vertex_fields, parent_type_name, edge_to_stitch_fields
-    )
-
     made_changes = False
-    if len(cross_schema_fields) > 0:
-        made_changes = True
 
-    # First, no changes will be made to property fields
+    # First, collection all property fields, but don't make any changes to them yet
+    property_fields_map, vertex_fields = _split_selections_property_and_vertex(selections)
 
     # Second, process cross schema fields. This will modify our record of property fields, and
     # create child SubQueryNodes attached to the input SubQueryNode
+    intra_schema_fields, cross_schema_fields = _split_vertex_fields_intra_and_cross_schema(
+        vertex_fields, parent_type_name, edge_to_stitch_fields
+    )
     for cross_schema_field in cross_schema_fields:
         type_info.enter(cross_schema_field)
         child_type = type_info.get_type()
@@ -201,8 +195,11 @@ def _split_query_ast_one_level_recursive_normal_fields(
             child_type_name = strip_non_null_and_list_from_type(child_type).name
         else:
             raise AssertionError(
-                u'The query may be invalid against the schema, causing TypeInfo to lost track '
-                u'of the types of fields.'
+                u'The query may be invalid against the schema, causing TypeInfo to lose track '
+                u'of the types of fields. This occurs at the cross schema field "{}", while '
+                u'splitting the AST "{}"'.format(
+                    cross_schema_field, query_node.query_ast
+                )
             )
         stitch_data_key = (parent_type_name, cross_schema_field.name.value)
         parent_field_name, child_field_name = edge_to_stitch_fields[stitch_data_key]
@@ -210,6 +207,7 @@ def _split_query_ast_one_level_recursive_normal_fields(
             query_node, cross_schema_field, property_fields_map, child_type_name,
             parent_field_name, child_field_name, name_assigner
         )
+        made_changes = True  # Cross schema edges are removed from the output, causing changes
         type_info.leave(cross_schema_field)
 
     # Third, process intra schema edges by recursing on them
@@ -224,6 +222,7 @@ def _split_query_ast_one_level_recursive_normal_fields(
         new_intra_schema_fields.append(new_intra_schema_field)
         type_info.leave(intra_schema_field)
 
+    # Return input, or make copy
     if made_changes:
         new_selections = _get_selections_from_property_and_vertex_fields(
             property_fields_map, new_intra_schema_fields
@@ -400,13 +399,10 @@ def _get_child_query_node_and_out_name(ast, child_type_name, child_field_name, n
     """
     # Get type and selections of child AST, taking into account type coercions
     child_selection_set = ast.selection_set
-    if (
-        len(child_selection_set.selections) == 1 and
-        isinstance(child_selection_set.selections[0], InlineFragment)
-    ):
-        type_coercion_inline_fragment = child_selection_set.selections[0]
-        child_type_name = type_coercion_inline_fragment.type_condition.name.value
-        child_selection_set = type_coercion_inline_fragment.selection_set
+    type_coercion = try_get_inline_fragment(child_selection_set.selections)
+    if type_coercion is not None:
+        child_type_name = type_coercion.type_condition.name.value
+        child_selection_set = type_coercion.selection_set
     child_selections = child_selection_set.selections
 
     # Get existing field with name in child

--- a/graphql_compiler/schema_transformation/split_query.py
+++ b/graphql_compiler/schema_transformation/split_query.py
@@ -3,20 +3,14 @@ from collections import namedtuple
 from copy import copy
 
 from graphql.language.ast import (
-    Argument, Directive, Document, Field, InlineFragment, InterfaceTypeDefinition, Name,
-    ObjectTypeDefinition, OperationDefinition, SelectionSet, StringValue
+    Argument, Directive, Document, Field, InlineFragment, Name, OperationDefinition, SelectionSet,
+    StringValue
 )
-from graphql.language.visitor import TypeInfoVisitor, Visitor, visit
-from graphql.utils.type_info import TypeInfo
 
-from ..ast_manipulation import get_only_query_definition
 from ..compiler.helpers import strip_non_null_and_list_from_type
 from ..exceptions import GraphQLValidationError
 from ..schema import FilterDirective, OptionalDirective, OutputDirective
-from .utils import (
-    SchemaStructureError, check_query_is_valid_to_split, is_property_field_ast,
-    try_get_ast_by_name_and_type
-)
+from .utils import SchemaStructureError, is_property_field_ast, try_get_ast_by_name_and_type
 
 
 QueryConnection = namedtuple(

--- a/graphql_compiler/schema_transformation/split_query.py
+++ b/graphql_compiler/schema_transformation/split_query.py
@@ -1,11 +1,22 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
+from copy import copy
 
 from graphql.language.ast import (
-    Argument, Directive, Document, Field, Name, OperationDefinition, SelectionSet, StringValue
+    Argument, Directive, Document, Field, InlineFragment, InterfaceTypeDefinition, Name,
+    ObjectTypeDefinition, OperationDefinition, SelectionSet, StringValue
 )
+from graphql.language.visitor import TypeInfoVisitor, Visitor, visit
+from graphql.utils.type_info import TypeInfo
 
-from ..schema import OutputDirective
+from ..ast_manipulation import get_only_query_definition
+from ..compiler.helpers import strip_non_null_and_list_from_type
+from ..exceptions import GraphQLValidationError
+from ..schema import FilterDirective, OptionalDirective, OutputDirective
+from .utils import (
+    SchemaStructureError, check_query_is_valid_to_split, is_property_field_ast,
+    try_get_ast_by_name_and_type
+)
 
 
 QueryConnection = namedtuple(
@@ -32,6 +43,340 @@ class SubQueryNode(object):
         # SubQueryNode or None, the query that the current query depends on
         self.child_query_connections = []
         # List[SubQueryNode], the queries that depend on the current query
+
+
+def _split_query_ast_one_level_recursive(
+    query_node, ast, parent_selections, type_info, edge_to_stitch_fields,
+    intermediate_out_name_assigner
+):
+    """Return a Node to replace the input AST by in the selections one level above.
+
+    - If the input AST starts with a cross schema vertex field, the output will be a Field object
+      representing the property field used in the stitch
+      - If a property field of the expected name already exists in the selections one level
+        above (in parent_selections), the new Field will contain any existing directives of
+        this field
+    - Otherwise, the process will be repeated on child selections (if any) of the input AST
+      - If no child selection is modified, the exact same object as the input AST will be returned
+      - If some child selection is modified, a copy of the AST with the new selections will be
+        returned
+        - If a modified child selection is a property field
+          - If a property field of the same name already exists, the new field will replace the
+            existing field
+          - Otherwise, the property field will be inserted into selections after the last existing
+            property field
+        - Otherwise, the modified selection will be appended to selections
+
+    Args:
+        query_node: SubQueryNode, whose list of child query connections may be modified to include
+                    children
+        ast: type Node, the AST that we are trying to split into child components. It is not
+             modified by this function
+        parent_selections: List[Node], containing all property fields (and possibly some vertex
+                           fields) in the level of selections that contains the input ast. It
+                           is not modified by this function
+        type_info: TypeInfo, used to get information about the types of fields while traversing
+                   the query ast
+        edge_to_stitch_fields: Dict[Tuple(str, str), Tuple(str, str)], mapping
+                               (type name, vertex field name) to
+                               (source field name, sink field name) used in the @stitch directive
+                               for each cross schema edge
+        intermediate_out_name_assigner: IntermediateOutNameAssigner, object used to generate
+                                        and keep track of names of newly created @output
+                                        directives
+
+    Returns:
+        Node object to replace the input AST in the selections one level above. If the output
+        is unchanged from the input AST, the exact same object will be returned
+    """
+    # Check if there is a split here. If so, split AST, make child query node, return property
+    # field. If not, recurse on all child selections (if any)
+    if isinstance(ast, Field):
+        parent_type_name = type_info.get_parent_type().name
+        edge_field_name = ast.name.value
+        if (parent_type_name, edge_field_name) in edge_to_stitch_fields:
+            # parent_field_name and child_field_name are names of property fields in the stitch
+            parent_field_name, child_field_name = \
+                edge_to_stitch_fields[(parent_type_name, edge_field_name)]
+            # Get parent field with existing directives
+            parent_property_field = _get_property_field(
+                parent_selections, parent_field_name, ast.directives
+            )
+            # Add @output if needed, record out_name
+            parent_output_name = _get_out_name_optionally_add_output(
+                parent_property_field, intermediate_out_name_assigner
+            )
+            # Create child query node around ast
+            child_query_node, child_output_name = _get_child_query_node_and_out_name(
+                ast, type_info, child_field_name, intermediate_out_name_assigner
+            )
+            # Create and add QueryConnections
+            _add_query_connections(
+                query_node, child_query_node, parent_output_name, child_output_name
+            )
+            # Return parent property field used in the stitch, to be added in selections above
+            return parent_property_field
+
+    # No split here
+    if ast.selection_set is None:  # Property field, nothing to recurse on
+        return ast
+    selections = ast.selection_set.selections
+
+    new_selections = []
+    made_changes = False
+
+    type_info.enter(ast.selection_set)
+    for selection in selections:  # Recurse on children
+        type_info.enter(selection)
+        # By the time we reach any cross schema vertex fields, new_selections contains all
+        # property fields, including any new property fields created by previous cross schema
+        # vertex fields, and therefore will not create duplicate new fields
+        new_selection = _split_query_ast_one_level_recursive(
+            query_node, selection, new_selections, type_info, edge_to_stitch_fields,
+            intermediate_out_name_assigner
+        )
+
+        if new_selection is not selection:
+            made_changes = True
+            if is_property_field_ast(new_selection):
+                # If a property field is returned and is different from the input, then this is
+                # a property field used in stitching. If no existing field has this name, insert
+                # the new property field to end of property fields. If some existing field has
+                # this name, replace the existing field with the returned field
+                new_selections = _replace_or_insert_property_field(new_selections, new_selection)
+                # The current actual selection is ignored, since it leads to a cut-off branch
+            else:
+                # Changes were made somewhere down the line, append changed version to end
+                new_selections.append(new_selection)
+        else:
+            new_selections.append(new_selection)
+        type_info.leave(selection)
+    type_info.leave(ast.selection_set)
+
+    if made_changes:
+        ast_copy = copy(ast)
+        ast_copy.selection_set = SelectionSet(selections=new_selections)
+        return ast_copy
+    else:
+        return ast
+
+
+def _get_child_query_node_and_out_name(ast, type_info, child_field_name,
+                                       intermediate_out_name_assigner):
+    """Create a query node out of ast, return node and unique out_name on field with input name.
+
+    Create a new document out of the input AST, that has the same structure as the input. For
+    instance, if the input AST can be represented by
+        out_Human {
+          name
+        }
+    where out_Human is a vertex field going to type Human, the resulting document will be
+        {
+          Human {
+            name
+          }
+        }
+    If the input AST starts with a type coercion, the resulting document will start with the
+    coerced type, rather than the original union or interface type.
+
+    The output child_node will be wrapped around this new Document. In addition, if no field
+    of child_field_name currently exists, such a field will be added. If there is no @output
+    directive on this field, a new @output directive will be added.
+
+    Args:
+        ast: type Node, representing the AST that we're using to build a child node. It is not
+             modified by this function
+        type_info: TypeInfo, at the location of the ast
+        child_field_name: str. If no field of this name currently exists as a part of the root
+                          selections of the input AST, a new field will be created in the AST
+                          contained in the output child query node
+        intermediate_out_name_assigner: IntermediateOutNameAssigner, which will be used to
+                                        generate an out_name, if it's necessary to create a
+                                        new @output directive
+
+    Returns:
+        Tuple[SubQueryNode, str], the child sub query node wrapping around the input ast, and
+        the out_name of the @output directive uniquely identifying the field used or stitching
+        in this sub query node
+    """
+    child_type_name, child_selections = _get_child_type_and_selections(ast, type_info)
+    # Get existing field with name in child
+    child_property_field = _get_property_field(child_selections, child_field_name, [])
+    # Add @output if needed, record out_name
+    child_output_name = _get_out_name_optionally_add_output(
+        child_property_field, intermediate_out_name_assigner
+    )
+    # Get new child_selections
+    child_selections = _replace_or_insert_property_field(child_selections, child_property_field)
+    # Wrap around
+    # NOTE: if child_type_name does not actually exist as a root field (not all types are
+    # required to have a corresponding root vertex field), then this query will be invalid
+    child_query_ast = _get_query_document(child_type_name, child_selections)
+    child_query_node = SubQueryNode(child_query_ast)
+
+    return child_query_node, child_output_name
+
+
+def _get_property_field(selections, field_name, directives_from_edge):
+    """Return a Field object with field_name, sharing directives with any such existing field.
+
+    Any valid directives in directives_on_edge will be transferred over to the new field.
+    If there is an existing Field in selection with field_name, the returned new Field
+    will also contain all directives of the existing field with that name.
+
+    Args:
+        selections: List[Union[Field, InlineFragment]]. If there is a field with field_name,
+                    the directives of this field will carry over to the output field. It is
+                    not modified by this function
+        field_name: str, the name of the output field
+        directives_from_edge: List[Directive], the directives of a vertex field. The output
+                              field will contain all @filter and any @optional directives
+                              from this list
+
+    Returns:
+        Field object, with field_name as its name, containing directives from any field in the
+        input selections with the same name and directives from the input list of directives
+    """
+    new_field = Field(
+        name=Name(value=field_name),
+        directives=[],
+    )
+
+    # Check parent_selection for existing field of given name
+    parent_field = try_get_ast_by_name_and_type(selections, field_name, Field)
+    if parent_field is not None:
+        # Existing field, add all its directives
+        directives_from_existing_field = parent_field.directives
+        if directives_from_existing_field is not None:
+            new_field.directives.extend(directives_from_existing_field)
+
+    # Transfer directives from edge
+    if directives_from_edge is not None:
+        for directive in directives_from_edge:
+            if directive.name.value == OutputDirective.name:  # output illegal on vertex field
+                raise GraphQLValidationError(
+                    u'Directive "{}" is not allowed on a vertex field, as @output directives '
+                    u'can only exist on property fields.'.format(directive)
+                )
+            elif directive.name.value == OptionalDirective.name:
+                if try_get_ast_by_name_and_type(
+                    new_field.directives, OptionalDirective.name, Directive
+                ) is None:
+                    # New optional directive
+                    new_field.directives.append(directive)
+            elif directive.name.value == FilterDirective.name:
+                new_field.directives.append(directive)
+            else:
+                raise AssertionError(
+                    u'Unreachable code reached. Directive "{}" is of an unsupported type, and '
+                    u'was not caught in a prior validation step.'.format(directive)
+                )
+
+    return new_field
+
+
+def _get_child_type_and_selections(ast, type_info):
+    """Get the type (root field) and selection set of the input AST.
+
+    For instance, if the root of the AST is a vertex field that goes to type Animal, the
+    returned type name will be Animal.
+
+    If the input AST is a type coercion, the root field name will be the coerced type rather
+    than the union or interface type, and the selection set will contain actual fields
+    rather than a single inline fragment.
+
+    Args:
+        ast: type Node, the AST that, if split off into its own Document, would have the the
+             type (named the same as the root vertex field) and root selections that this
+             function outputs
+        type_info: TypeInfo, used to check for the type that fields lead to
+
+    Returns:
+        Tuple[str, List[Union[Field, InlineFragment]]], name and selections of the root
+        vertex field of the input AST if it were made into its own separate Document
+    """
+    child_type = type_info.get_type()  # GraphQLType
+    if child_type is None:
+        raise SchemaStructureError(
+            u'The provided merged schema descriptor may be invalid, as the type '
+            u'corresponding to the field "{}" under type "{}" cannot be '
+            u'found.'.format(ast.name.value, type_info.get_parent_type())
+        )
+    child_type_name = strip_non_null_and_list_from_type(child_type).name
+
+    child_selection_set = ast.selection_set
+    # Adjust for type coercion
+    if (
+        child_selection_set is not None and
+        len(child_selection_set.selections) == 1 and
+        isinstance(child_selection_set.selections[0], InlineFragment)
+    ):
+        type_coercion_inline_fragment = child_selection_set.selections[0]
+        child_type_name = type_coercion_inline_fragment.type_condition.name.value
+        child_selection_set = type_coercion_inline_fragment.selection_set
+
+    return child_type_name, child_selection_set.selections
+
+
+def _replace_or_insert_property_field(selections, new_field):
+    """Return a copy of the input selections, with new_field added or replacing existing field.
+
+    If there is an existing field with the same name as new_field, replace. Otherwise, insert
+    new_field after the last existing property field.
+
+    Inputs are not modified.
+
+    Args:
+        selections: List[Union[Field, InlineFragment]], where all property fields occur
+                    before all vertex fields and inline fragments
+        new_field: Field object, to be inserted into selections
+
+    Returns:
+        List[Union[Field, InlineFragment]]
+    """
+    selections = copy(selections)
+    for index, selection in enumerate(selections):
+        if (
+            isinstance(selection, Field) and
+            selection.name.value == new_field.name.value
+        ):
+            selections[index] = new_field
+            return selections
+        if not is_property_field_ast(selection):
+            selections.insert(index, new_field)
+            return selections
+    # No vertex fields and no property fields of the same name
+    selections.append(new_field)
+    return selections
+
+
+def _get_out_name_optionally_add_output(field, intermediate_out_name_assigner):
+    """Return out_name of @output on field, creating new @output if needed.
+
+    Args:
+        field: Field object, whose directives we may modify by adding an @output directive
+        intermediate_out_name_assigner: IntermediateOutNameAssigner, which will be used to
+                                        generate an out_name, if it's necessary to create a
+                                        new @output directive
+
+    Returns:
+        str, name of the out_name of the @output directive, either pre-existing or newly
+        generated
+    """
+    # Check for existing directive
+    output_directive = try_get_ast_by_name_and_type(
+        field.directives, OutputDirective.name, Directive
+    )
+    if output_directive is None:
+        # Create and add new directive to field
+        out_name = intermediate_out_name_assigner.assign_and_return_out_name()
+        output_directive = _get_output_directive(out_name)
+        if field.directives is None:
+            field.directives = []
+        field.directives.append(output_directive)
+        return out_name
+    else:
+        return output_directive.arguments[0].value.value  # Location of value of out_name
 
 
 def _get_output_directive(out_name):

--- a/graphql_compiler/schema_transformation/split_query.py
+++ b/graphql_compiler/schema_transformation/split_query.py
@@ -1,0 +1,118 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+from collections import namedtuple
+
+from graphql.language.ast import (
+    Argument, Directive, Document, Field, Name, OperationDefinition, SelectionSet, StringValue
+)
+
+from ..schema import OutputDirective
+
+
+QueryConnection = namedtuple(
+    'QueryConnection', (
+        'sink_query_node',  # SubQueryNode
+        'source_field_out_name',
+        # str, the unique out name on the @output of the the source property field in the stitch
+        'sink_field_out_name',
+        # str, the unique out name on the @output of the the sink property field in the stitch
+    )
+)
+
+
+class SubQueryNode(object):
+    def __init__(self, query_ast):
+        """Represents one piece of a larger query, targeting one schema.
+
+        Args:
+            query_ast: Document, representing one piece of a query
+        """
+        self.query_ast = query_ast
+        self.schema_id = None  # str, identifying the schema that this query targets
+        self.parent_query_connection = None
+        # SubQueryNode or None, the query that the current query depends on
+        self.child_query_connections = []
+        # List[SubQueryNode], the queries that depend on the current query
+
+
+def _get_output_directive(out_name):
+    """Return a Directive representing an @output with the input out_name."""
+    return Directive(
+        name=Name(value=OutputDirective.name),
+        arguments=[
+            Argument(
+                name=Name(value=u'out_name'),
+                value=StringValue(value=out_name),
+            ),
+        ],
+    )
+
+
+def _get_query_document(root_vertex_field_name, root_selections):
+    """Return a Document representing a query with the specified name and selections."""
+    return Document(
+        definitions=[
+            OperationDefinition(
+                operation='query',
+                selection_set=SelectionSet(
+                    selections=[
+                        Field(
+                            name=Name(value=root_vertex_field_name),
+                            selection_set=SelectionSet(
+                                selections=root_selections,
+                            ),
+                            directives=[],
+                        )
+                    ]
+                )
+            )
+        ]
+    )
+
+
+def _add_query_connections(parent_query_node, child_query_node, parent_field_out_name,
+                           child_field_out_name):
+    """Modify parent and child SubQueryNodes by adding QueryConnections between them."""
+    if child_query_node.parent_query_connection is not None:
+        raise AssertionError(
+            u'The input child query node already has a parent connection, {}'.format(
+                child_query_node.parent_query_connection
+            )
+        )
+    if any(
+        query_connection_from_parent.sink_query_node is child_query_node
+        for query_connection_from_parent in parent_query_node.child_query_connections
+    ):
+        raise AssertionError(
+            u'The input parent query node already has the child query node in a child query '
+            u'connection.'
+        )
+    # Create QueryConnections
+    new_query_connection_from_parent = QueryConnection(
+        sink_query_node=child_query_node,
+        source_field_out_name=parent_field_out_name,
+        sink_field_out_name=child_field_out_name,
+    )
+    new_query_connection_from_child = QueryConnection(
+        sink_query_node=parent_query_node,
+        source_field_out_name=child_field_out_name,
+        sink_field_out_name=parent_field_out_name,
+    )
+    # Add QueryConnections
+    parent_query_node.child_query_connections.append(new_query_connection_from_parent)
+    child_query_node.parent_query_connection = new_query_connection_from_child
+
+
+class IntermediateOutNameAssigner(object):
+    """Used to generate and keep track of out_name of @output directives."""
+
+    def __init__(self):
+        """Create assigner with empty records."""
+        self.intermediate_output_names = set()
+        self.intermediate_output_count = 0
+
+    def assign_and_return_out_name(self):
+        """Assign and return name, increment count, add name to records."""
+        out_name = '__intermediate_output_' + str(self.intermediate_output_count)
+        self.intermediate_output_count += 1
+        self.intermediate_output_names.add(out_name)
+        return out_name

--- a/graphql_compiler/schema_transformation/split_query.py
+++ b/graphql_compiler/schema_transformation/split_query.py
@@ -3,21 +3,14 @@ from collections import OrderedDict, namedtuple
 from copy import copy
 
 from graphql.language.ast import (
-    Argument, Directive, Document, Field, InlineFragment, InterfaceTypeDefinition, Name,
-    ObjectTypeDefinition, OperationDefinition, SelectionSet, StringValue
+    Argument, Directive, Document, Field, Name, OperationDefinition, SelectionSet, StringValue
 )
-from graphql.language.visitor import TypeInfoVisitor, Visitor, visit
-from graphql.utils.type_info import TypeInfo
 import six
 
-from ..ast_manipulation import get_only_query_definition
 from ..compiler.helpers import strip_non_null_and_list_from_type
 from ..exceptions import GraphQLValidationError
 from ..schema import FilterDirective, OptionalDirective, OutputDirective
-from .utils import (
-    SchemaStructureError, check_query_is_valid_to_split, is_property_field_ast,
-    try_get_ast_by_name_and_type, try_get_inline_fragment
-)
+from .utils import is_property_field_ast, try_get_ast_by_name_and_type, try_get_inline_fragment
 
 
 QueryConnection = namedtuple(

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -156,6 +156,43 @@ def try_get_ast_by_name_and_type(asts, target_name, target_type):
     return None
 
 
+def try_get_inline_fragment(selections):
+    """Return the unique inline fragment contained in selections, or None.
+
+    Args:
+        selections: List[Union[Field, InlineFragment]] or None
+
+    Returns:
+        InlineFragment if one is found in selections, None otherwise
+
+    Raises:
+        GraphQLValidationError if selections contains a InlineFragment along with a nonzero
+        number of fields, or contains multiple InlineFragments
+    """
+    if selections is None:
+        return None
+    inline_fragments_in_selection = [
+        selection
+        for selection in selections
+        if isinstance(selection, InlineFragment)
+    ]
+    if len(inline_fragments_in_selection) == 0:
+        return None
+    elif len(inline_fragments_in_selection) == 1:
+        if len(selections) == 1:
+            return inline_fragments_in_selection[0]
+        else:
+            raise GraphQLValidationError(
+                u'Input selections "{}" contains both InlineFragments and Fields, which may not '
+                u'coexist in one selection.'.format(selections)
+            )
+    else:
+        raise GraphQLValidationError(
+            u'Input selections "{}" contains multiple InlineFragments, which is not allowed.'
+            u''.format(selections)
+        )
+
+
 def get_copy_of_node_with_new_name(node, new_name):
     """Return a node with new_name as its name and otherwise identical to the input node.
 


### PR DESCRIPTION
This code has most of the complexity of split query. The overall flow is somewhat similar to the structural sharing code in macro systems.

There are two base cases for recursion: 
A property field -- nothing to recurse on, return the input object.
A cross schema vertex field -- in this case, we want to cut off the vertex field, and add in (if necessary) the property field used in the stitch, with an `@output` added if necessary. In this case, return a Field object representing the property field. There's some extra complexity due to the fact that this property field may already exist, in which case we copy over any existing directives on that field. We also need to create a child QueryNode when a branch is cut off.

In the recursive case, we repeat the process on child selections. There's some complexity here as well, since we can't just append the new, possibly changed child selection to our new list of selections. For instance, take the query
```
{
  Human {
    name @output(out_name: "name")
    friend {
      stuff
    }
    out_Human_Person {
      stuff
    }
  }
}
```
where out_Human_Person is a cross schema vertex field, stitching on field `id` on Human and field ID on Person.
If we're at the `Human` node, the function is going to be recursively called on its child selections, including `out_Human_Person`. The function called on `out_Human_Person` is going to return a property field representing `id`. We need to insert the new field in the appropriate place in selections, instead of just appending it. In the case that `id` already existed as a field, we need to replace the field rather than insert a new one.