### PR TITLE
Split query validation for inline fragments

### DIFF
--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -317,34 +317,38 @@ def check_ast_schema_is_valid(ast):
     visit(ast, CheckQueryTypeFieldsNameMatchVisitor(query_type))
 
 
-def is_property_field_ast(selection):
-    """Return True if selection is a property field, False if a vertex field or type coercion.
+def is_property_field_ast(field):
+    """Return True if selection is a property field, False if a vertex field.
 
     Args:
-        selection: type Field or InlineFragment. An element occuring inside a SelectionSet
+        field: Field object. It is considered to be a property field if it has no further
+               selections
 
     Returns:
-        True if the selection is a property field, False if it's a vertex field or type coercion
+        True if the selection is a property field, False if it's a vertex field.
     """
-    if isinstance(selection, InlineFragment):
-        return False
-    if isinstance(selection, Field):
+    if isinstance(field, Field):
         if (
-            selection.selection_set is None or
-            selection.selection_set.selections is None or
-            selection.selection_set.selections == []
+            field.selection_set is None or
+            field.selection_set.selections is None or
+            field.selection_set.selections == []
         ):
             return True
         else:
             return False
     else:
         raise AssertionError(
-            u'Input selection "{}" is not of type Field or InlineFragment.'.format(selection)
+            u'Input selection "{}" is not a Field.'.format(field)
         )
 
 
 class CheckQueryIsValidToSplitVisitor(Visitor):
-    """Check the query only has supported directives, and its fields are correctly ordered."""
+    """Check the query is valid.
+
+    In particular, check that it only contains supported directives, its property fields come
+    before vertex fields in every scope, and that any scope containing a InlineFragment has
+    nothing else in scope.
+    """
     # This is very restrictive for now. Other cases (e.g. tags not crossing boundaries) are
     # also ok, but temporarily not allowed
     supported_directives = frozenset((
@@ -362,20 +366,41 @@ class CheckQueryIsValidToSplitVisitor(Visitor):
             )
 
     def enter_SelectionSet(self, node, *args):
-        """Check property fields occur before vertex fields and type coercions in selection."""
-        seen_non_property_field = False  # Whether we're seen a vertex field/type coercion
-        for field in node.selections:
-            if is_property_field_ast(field):
-                if seen_non_property_field:
+        """Check selections are valid.
+
+        If selections contains an InlineFragment, check that it is the only inline fragment in
+        scope. Otherwise, check that property fields occur before vertex fields.
+
+        Args:
+            node: SelectionSet
+        """
+        selections = node.selections
+        if (
+            len(selections) == 1 and
+            isinstance(selections[0], InlineFragment)
+        ):
+            return None
+        else:
+            seen_vertex_field = False  # Whether we're seen a vertex field
+            for field in selections:
+                if isinstance(field, InlineFragment):
                     raise GraphQLValidationError(
-                        u'In the selections {}, the property field {} occurs after a vertex '
-                        u'field or a type coercion statement, which is not allowed, as all '
-                        u'property fields must appear before all vertex fields.'.format(
-                            node.selections, field
+                        u'Inline fragments must be the only selection in scope. However, in '
+                        u'selections {}, an InlineFragment coexists with other selections.'.format(
+                            selections
                         )
                     )
-            else:
-                seen_non_property_field = True
+                if is_property_field_ast(field):
+                    if seen_vertex_field:
+                        raise GraphQLValidationError(
+                            u'In the selections {}, the property field {} occurs after a vertex '
+                            u'field or a type coercion statement, which is not allowed, as all '
+                            u'property fields must appear before all vertex fields.'.format(
+                                node.selections, field
+                            )
+                        )
+                else:
+                    seen_vertex_field = True
 
 
 def check_query_is_valid_to_split(schema, query_ast):

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -379,7 +379,7 @@ class CheckQueryIsValidToSplitVisitor(Visitor):
             len(selections) == 1 and
             isinstance(selections[0], InlineFragment)
         ):
-            return None
+            return
         else:
             seen_vertex_field = False  # Whether we're seen a vertex field
             for field in selections:


### PR DESCRIPTION
Check that inline fragments are alone in their scope. Helper is_property_field is also changed to only accept Fields instead of Fields and InlineFragments (previously I wrote the helper to accept both because I thought they can coexist)