### PR TITLE
Helpers and example schemas for testing split_query

### DIFF
--- a/graphql_compiler/tests/schema_transformation_tests/example_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/example_schema.py
@@ -5,7 +5,7 @@ from graphql import build_ast_schema, parse
 import six
 
 from ...schema_transformation.merge_schemas import (
-    CrossSchemaEdgeDescriptor, FieldReference, merge_schemas
+    CrossSchemaEdgeDescriptor, FieldReference, MergedSchemaDescriptor, merge_schemas
 )
 from ...schema_transformation.rename_schema import rename_schema
 from ..test_helpers import SCHEMA_TEXT
@@ -240,4 +240,37 @@ three_merged_schema = merge_schemas(
             out_edge_only=False,
         ),
     ],
+)
+
+
+stitch_arguments_flipped_schema_str = '''
+schema {
+  query: SchemaQuery
+}
+
+type Animal {
+  uuid: String
+  name: String
+  out_Animal_Creature: Creature @stitch(sink_field: "id", source_field: "uuid")
+}
+
+type Creature {
+  id: String
+  age: Int
+  in_Animal_Creature: Animal @stitch(sink_field: "uuid", source_field: "id")
+}
+
+type SchemaQuery {
+  Animal: Animal
+  Creature: Creature
+}
+
+directive @output(out_name: String!) on FIELD
+'''
+
+
+stitch_arguments_flipped_schema = MergedSchemaDescriptor(
+    schema_ast=parse(stitch_arguments_flipped_schema_str),
+    schema=build_ast_schema(parse(stitch_arguments_flipped_schema_str)),
+    type_name_to_schema_id={'Animal': 'first', 'Creature': 'second'},
 )

--- a/graphql_compiler/tests/schema_transformation_tests/example_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/example_schema.py
@@ -1,6 +1,12 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from graphql import parse
+from collections import OrderedDict
 
+from graphql import build_ast_schema, parse
+import six
+
+from ...schema_transformation.merge_schemas import (
+    CrossSchemaEdgeDescriptor, FieldReference, merge_schemas
+)
 from ...schema_transformation.rename_schema import rename_schema
 from ..test_helpers import SCHEMA_TEXT
 
@@ -10,4 +16,228 @@ basic_schema = parse(SCHEMA_TEXT)
 
 basic_renamed_schema = rename_schema(
     basic_schema, {'Animal': 'NewAnimal', 'Entity': 'NewEntity', 'BirthEvent': 'NewBirthEvent'}
+)
+
+
+basic_additional_schema = '''
+schema {
+  query: SchemaQuery
+}
+
+type Creature {
+  age: Int
+  id: String
+  friend: [Creature]
+}
+
+type SchemaQuery {
+  Creature: Creature
+}
+'''
+
+
+basic_merged_schema = merge_schemas(
+    OrderedDict([
+        ('first', basic_schema),
+        ('second', parse(basic_additional_schema)),
+    ]),
+    [
+        CrossSchemaEdgeDescriptor(
+            edge_name='Animal_Creature',
+            outbound_field_reference=FieldReference(
+                schema_id='first',
+                type_name='Animal',
+                field_name='uuid',
+            ),
+            inbound_field_reference=FieldReference(
+                schema_id='second',
+                type_name='Creature',
+                field_name='id'
+            ),
+            out_edge_only=False,
+        ),
+    ],
+)
+
+
+interface_additional_schema = '''
+schema {
+  query: SchemaQuery
+}
+
+interface Creature {
+  id: String
+  age: Int
+}
+
+type Cat implements Creature {
+  id: String
+  age: Int
+  meow: String
+}
+
+type Dog implements Creature {
+  id: String
+  age: Int
+  bark: String
+}
+
+type SchemaQuery {
+  Creature: Creature
+  Cat: Cat
+  Dog: Dog
+}
+'''
+
+
+interface_merged_schema = merge_schemas(
+    OrderedDict([
+        ('first', basic_schema),
+        ('second', parse(interface_additional_schema)),
+    ]),
+    [
+        CrossSchemaEdgeDescriptor(
+            edge_name='Animal_Creature',
+            outbound_field_reference=FieldReference(
+                schema_id='first',
+                type_name='Animal',
+                field_name='uuid',
+            ),
+            inbound_field_reference=FieldReference(
+                schema_id='second',
+                type_name='Creature',
+                field_name='id'
+            ),
+            out_edge_only=False,
+        ),
+    ],
+)
+
+
+def _get_type_equivalence_hints(schema_id_to_ast, type_equivalence_hints_names):
+    """Get type_equivalence_hints for input into merge_schemas.
+
+    Args:
+        schema_id_to_ast: Dict[str, Document]
+        type_equivalence_hints_names: Dict[str, str]
+
+    Returns:
+        Dict[GraphQLObjectType, GraphQLUnionType]
+    """
+    name_to_type = {}
+    for ast in six.itervalues(schema_id_to_ast):
+        schema = build_ast_schema(ast)
+        name_to_type.update(schema.get_type_map())
+    type_equivalence_hints = {}
+    for object_type_name, union_type_name in six.iteritems(type_equivalence_hints_names):
+        object_type = name_to_type[object_type_name]
+        union_type = name_to_type[union_type_name]
+        type_equivalence_hints[object_type] = union_type
+    return type_equivalence_hints
+
+
+union_additional_schema = '''
+schema {
+  query: SchemaQuery
+}
+
+type Creature {
+  id: String
+  age: Int
+}
+
+type Cat {
+  id: String
+  age: Int
+}
+
+union CreatureOrCat = Creature | Cat
+
+type SchemaQuery {
+  Creature: Creature
+  Cat: Cat
+}
+'''
+
+
+union_schema_id_to_ast = OrderedDict([
+    ('first', basic_schema),
+    ('second', parse(union_additional_schema)),
+])
+
+
+union_merged_schema = merge_schemas(
+    union_schema_id_to_ast,
+    [
+        CrossSchemaEdgeDescriptor(
+            edge_name='Animal_Creature',
+            outbound_field_reference=FieldReference(
+                schema_id='first',
+                type_name='Animal',
+                field_name='uuid',
+            ),
+            inbound_field_reference=FieldReference(
+                schema_id='second',
+                type_name='Creature',
+                field_name='id'
+            ),
+            out_edge_only=False,
+        ),
+    ],
+    _get_type_equivalence_hints(union_schema_id_to_ast, {'Creature': 'CreatureOrCat'})
+)
+
+
+third_additional_schema = '''
+schema {
+  query: SchemaQuery
+}
+
+type Critter {
+  size: Int
+  ID: String
+}
+
+type SchemaQuery {
+  Critter: Critter
+}
+'''
+
+
+three_merged_schema = merge_schemas(
+    OrderedDict([
+        ('first', basic_schema),
+        ('second', parse(basic_additional_schema)),
+        ('third', parse(third_additional_schema)),
+    ]),
+    [
+        CrossSchemaEdgeDescriptor(
+            edge_name='Animal_Creature',
+            outbound_field_reference=FieldReference(
+                schema_id='first',
+                type_name='Animal',
+                field_name='uuid',
+            ),
+            inbound_field_reference=FieldReference(
+                schema_id='second',
+                type_name='Creature',
+                field_name='id'
+            ),
+            out_edge_only=False,
+        ),
+        CrossSchemaEdgeDescriptor(
+            edge_name='Animal_Critter',
+            outbound_field_reference=FieldReference(
+                schema_id='first',
+                type_name='Animal',
+                field_name='uuid',
+            ),
+            inbound_field_reference=FieldReference(
+                schema_id='third',
+                type_name='Critter',
+                field_name='ID'
+            ),
+            out_edge_only=False,
+        ),
+    ],
 )

--- a/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import unittest
 
 from graphql import print_ast
+import six
 
 
 # The below namedtuple is used to check the structure of SubQueryNodes in tests

--- a/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
@@ -1,15 +1,8 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
-from textwrap import dedent
 import unittest
 
-from graphql import parse, print_ast
-
-from ...exceptions import GraphQLValidationError
-from ...schema_transformation.split_query import split_query
-from .example_schema import (
-    basic_merged_schema, interface_merged_schema, three_merged_schema, union_merged_schema
-)
+from graphql import print_ast
 
 
 # The below namedtuple is used to check the structure of SubQueryNodes in tests

--- a/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
@@ -6,41 +6,42 @@ from graphql import print_ast
 
 
 # The below namedtuple is used to check the structure of SubQueryNodes in tests
-ExampleQueryNode = namedtuple(
-    'ExampleQueryNode', (
+ExpectedQueryNode = namedtuple(
+    'ExpectedQueryNode', (
         'query_str',
         'schema_id',
         'child_query_nodes_and_out_names',
-        # List[Tuple[ExampleQueryNode, str, str]]
-        # child example query node, parent out name, child out name
+        # List[Tuple[ExpectedQueryNode, str, str]]
+        # child expected query node, parent out name, child out name
     )
 )
 
 
 class TestSplitQuery(unittest.TestCase):
-    def _check_query_node_structure(self, root_query_node, root_example_query_node):
-        """Check root_query_node has no parent and has the same structure as the example input."""
-        self.assertIs(root_query_node.parent_query_connection, None)
-        self._check_query_node_structure_helper(root_query_node, root_example_query_node)
+    def _check_query_node_structure(self, root_query_node, root_expected_query_node):
+        """Check root_query_node has no parent and has the same structure as the expected input."""
+        self.assertIsNone(root_query_node.parent_query_connection)
+        self._check_query_node_structure_helper(root_query_node, root_expected_query_node)
 
-    def _check_query_node_structure_helper(self, query_node, example_query_node):
-        """Check query_node has the same structure as example_query_node."""
+    def _check_query_node_structure_helper(self, query_node, expected_query_node):
+        """Check query_node has the same structure as expected_query_node."""
         # Check AST and id of the parent
-        self.assertEqual(print_ast(query_node.query_ast), example_query_node.query_str)
-        self.assertEqual(query_node.schema_id, example_query_node.schema_id)
+        self.assertEqual(print_ast(query_node.query_ast), expected_query_node.query_str)
+        self.assertEqual(query_node.schema_id, expected_query_node.schema_id)
         # Check number of children matches
-        self.assertEqual(len(query_node.child_query_connections),
-                         len(example_query_node.child_query_nodes_and_out_names))
-        for i in range(len(query_node.child_query_connections)):
+        child_query_connections = query_node.child_query_connections
+        expected_child_data = expected_query_node.child_query_nodes_and_out_names
+        self.assertEqual(len(child_query_connections), len(expected_child_data))
+        for i, (child_query_connection, expected_child_data_piece) in enumerate(
+            six.moves.zip(child_query_connections, expected_child_data)
+        ):
             # Check child and parent connections
-            child_query_connection = query_node.child_query_connections[i]
             child_query_node = child_query_connection.sink_query_node
-            child_example_query_node, parent_out_name, child_out_name = \
-                example_query_node.child_query_nodes_and_out_names[i]
+            child_expected_query_node, parent_out_name, child_out_name = expected_child_data_piece
             self._check_query_node_edge(query_node, i, child_query_node, parent_out_name,
                                         child_out_name)
             # Recurse
-            self._check_query_node_structure_helper(child_query_node, child_example_query_node)
+            self._check_query_node_structure_helper(child_query_node, child_expected_query_node)
 
     def _check_query_node_edge(self, parent_query_node, parent_to_child_edge_index,
                                child_query_node, parent_out_name, child_out_name):

--- a/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
@@ -46,8 +46,9 @@ class TestSplitQuery(unittest.TestCase):
     def _check_query_node_edge(self, parent_query_node, parent_to_child_edge_index,
                                child_query_node, parent_out_name, child_out_name):
         """Check the edge between parent and child is symmetric, with the right output names."""
-        parent_to_child_connection = \
-            parent_query_node.child_query_connections[parent_to_child_edge_index]
+        parent_to_child_connection = parent_query_node.child_query_connections[
+            parent_to_child_edge_index
+        ]
         child_to_parent_connection = child_query_node.parent_query_connection
 
         self.assertIs(parent_to_child_connection.sink_query_node, child_query_node)

--- a/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_split_query.py
@@ -1,0 +1,70 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+from collections import namedtuple
+from textwrap import dedent
+import unittest
+
+from graphql import parse, print_ast
+
+from ...exceptions import GraphQLValidationError
+from ...schema_transformation.split_query import split_query
+from .example_schema import (
+    basic_merged_schema, interface_merged_schema, three_merged_schema, union_merged_schema
+)
+
+
+# The below namedtuple is used to check the structure of SubQueryNodes in tests
+ExampleQueryNode = namedtuple(
+    'ExampleQueryNode', (
+        'query_str',
+        'schema_id',
+        'child_query_nodes_and_out_names',
+        # List[Tuple[ExampleQueryNode, str, str]]
+        # child example query node, parent out name, child out name
+    )
+)
+
+
+class TestSplitQuery(unittest.TestCase):
+    def _check_query_node_structure(self, root_query_node, root_example_query_node):
+        """Check root_query_node has no parent and has the same structure as the example input."""
+        self.assertIs(root_query_node.parent_query_connection, None)
+        self._check_query_node_structure_helper(root_query_node, root_example_query_node)
+
+    def _check_query_node_structure_helper(self, query_node, example_query_node):
+        """Check query_node has the same structure as example_query_node."""
+        # Check AST and id of the parent
+        self.assertEqual(print_ast(query_node.query_ast), example_query_node.query_str)
+        self.assertEqual(query_node.schema_id, example_query_node.schema_id)
+        # Check number of children matches
+        self.assertEqual(len(query_node.child_query_connections),
+                         len(example_query_node.child_query_nodes_and_out_names))
+        for i in range(len(query_node.child_query_connections)):
+            # Check child and parent connections
+            child_query_connection = query_node.child_query_connections[i]
+            child_query_node = child_query_connection.sink_query_node
+            child_example_query_node, parent_out_name, child_out_name = \
+                example_query_node.child_query_nodes_and_out_names[i]
+            self._check_query_node_edge(query_node, i, child_query_node, parent_out_name,
+                                        child_out_name)
+            # Recurse
+            self._check_query_node_structure_helper(child_query_node, child_example_query_node)
+
+    def _check_query_node_edge(self, parent_query_node, parent_to_child_edge_index,
+                               child_query_node, parent_out_name, child_out_name):
+        """Check the edge between parent and child is symmetric, with the right output names."""
+        parent_to_child_connection = \
+            parent_query_node.child_query_connections[parent_to_child_edge_index]
+        child_to_parent_connection = child_query_node.parent_query_connection
+
+        self.assertIs(parent_to_child_connection.sink_query_node, child_query_node)
+        self.assertIs(child_to_parent_connection.sink_query_node, parent_query_node)
+        self.assertEqual(parent_to_child_connection.source_field_out_name, parent_out_name)
+        self.assertEqual(child_to_parent_connection.sink_field_out_name, parent_out_name)
+        self.assertEqual(parent_to_child_connection.sink_field_out_name, child_out_name)
+        self.assertEqual(child_to_parent_connection.source_field_out_name, child_out_name)
+
+    def _get_intermediate_outputs_set(self, number_of_outputs):
+        output_names = set(
+            '__intermediate_output_' + str(count) for count in range(number_of_outputs)
+        )
+        return frozenset(output_names)


### PR DESCRIPTION
See the draft PR on split_query tests to get a sense of how the helpers `_check_query_node_structure` and `_get_intermediate_outputs_set` are used.