### PR TITLE
Remove context from duplicate output name error message

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -318,8 +318,7 @@ def _compile_property_ast(schema, current_schema_type, ast, location,
         # Schema validation has ensured that the fields below exist.
         output_name = output_directive.arguments[0].value.value
         if context['metadata'].get_output_info(output_name):
-            raise GraphQLCompilationError(u'Cannot reuse output name: '
-                                          u'{}, {}'.format(output_name, context))
+            raise GraphQLCompilationError(u'Cannot reuse output name: {}'.format(output_name))
         validate_output_name(output_name)
 
         graphql_type = strip_non_null_from_type(current_schema_type)


### PR DESCRIPTION
We should not display compiler internals in error messages so I removed the context from the error message. 

Also, in a similar note to this PR, let's attempt to validate against duplicate output and tag names before splitting queries in future PRs. 