### PR TITLE
Implement make_query_plan, which adds filter directives

### DIFF
--- a/graphql_compiler/schema_transformation/make_query_plan.py
+++ b/graphql_compiler/schema_transformation/make_query_plan.py
@@ -1,0 +1,274 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+from collections import namedtuple
+from copy import copy
+
+from graphql import print_ast
+from graphql.language import ast as ast_types
+
+from ..ast_manipulation import get_only_query_definition
+from ..exceptions import GraphQLValidationError
+from ..schema import FilterDirective, OutputDirective
+
+
+SubQueryPlan = namedtuple(
+    'SubQueryPlan', (
+        'query_ast',  # Document, representing a piece of the overall query with directives added
+        'schema_id',  # str, identifying the schema that this query piece targets
+        'parent_query_plan',  # SubQueryPlan, the query that the current query depends on
+        'child_query_plans',  # List[SubQueryPlan], the queries that depend on the current query
+    )
+)
+
+
+OutputJoinDescriptor = namedtuple(
+    'OutputJoinDescriptor', (
+        'output_names',  # Tuple[str, str], (parent output name, child output name)
+        # May be expanded to have more attributes, e.g. is_optional, describing how the join
+        # should be made
+    )
+)
+
+
+QueryPlanDescriptor = namedtuple(
+    'QueryPlanDescriptor', (
+        'root_sub_query_plan',  # SubQueryPlan
+        'intermediate_output_names',  # frozenset[str], names of outputs to be removed at the end
+        'output_join_descriptors',
+        # List[OutputJoinDescriptor], describing which outputs should be joined and how
+    )
+)
+
+
+def make_query_plan(root_sub_query_node, intermediate_output_names):
+    """Return a QueryPlanDescriptor, whose query ASTs have @filters added.
+
+    For each parent of parent and child SubQueryNodes, a new @filter directive will be added
+    in the child AST. It will be added on the field whose @output directive has the out_name
+    equal to the child's out name as specified in the QueryConnection. The newly added @filter
+    will be a 'in_collection' type filter, and the name of the local variabe is guaranteed to
+    be the same as the out_name of the @output on the parent.
+
+    ASTs contained in the input node and its children nodes will not be modified.
+
+    Args:
+        root_sub_query_node: SubQueryNode, representing the base of a query split into pieces
+                             that we want to turn into a query plan
+
+    Returns:
+        QueryPlanDescriptor namedtuple, containing a tree of SubQueryPlans that wrap
+        around each individual query AST, the set of intermediate output names that are
+        to be removed at the end, and information on which outputs are to be connect to which
+        in what manner
+    """
+    output_join_descriptors = []
+
+    root_sub_query_plan = SubQueryPlan(
+        query_ast=root_sub_query_node.query_ast,
+        schema_id=root_sub_query_node.schema_id,
+        parent_query_plan=None,
+        child_query_plans=[],
+    )
+
+    _make_query_plan_recursive(root_sub_query_node, root_sub_query_plan, output_join_descriptors)
+
+    return QueryPlanDescriptor(
+        root_sub_query_plan=root_sub_query_plan,
+        intermediate_output_names=intermediate_output_names,
+        output_join_descriptors=output_join_descriptors,
+    )
+
+
+def _make_query_plan_recursive(sub_query_node, sub_query_plan, output_join_descriptors):
+    """Recursively copy the structure of sub_query_node onto sub_query_plan.
+
+    For each child connection contained in sub_query_node, create a new SubQueryPlan for
+    the corresponding child SubQueryNode, add appropriate @filter directive to the child AST,
+    and attach the new SubQueryPlan to the list of children of the input sub query plan.
+
+    Args:
+        sub_query_node: SubQueryNode, whose descendents are copied over onto sub_query_plan.
+                        It is not modified by this function
+        sub_query_plan: SubQueryPlan, whose list of child query plans and query AST are
+                        modified
+    """
+    # Iterate through child connections of query node
+    for child_query_connection in sub_query_node.child_query_connections:
+        child_sub_query_node = child_query_connection.sink_query_node
+        parent_out_name = child_query_connection.source_field_out_name
+        child_out_name = child_query_connection.sink_field_out_name
+
+        child_query_type = get_only_query_definition(
+            child_sub_query_node.query_ast, GraphQLValidationError
+        )
+        child_query_type_with_filter = _add_filter_at_field_with_output(
+            child_query_type, child_out_name, parent_out_name
+            # @filter's local variable is named the same as the out_name of the parent's @output
+        )
+        if child_query_type is child_query_type_with_filter:
+            raise AssertionError(
+                u'An @output directive with out_name "{}" is unexpectedly not found in the '
+                u'AST "{}".'.format(child_out_name, child_query_type)
+            )
+        else:
+            new_child_query_ast = ast_types.Document(
+                definitions=[child_query_type_with_filter]
+            )
+
+        # Create new SubQueryPlan for child
+        child_sub_query_plan = SubQueryPlan(
+            query_ast=new_child_query_ast,
+            schema_id=child_sub_query_node.schema_id,
+            parent_query_plan=sub_query_plan,
+            child_query_plans=[],
+        )
+
+        # Add new SubQueryPlan to parent's child list
+        sub_query_plan.child_query_plans.append(child_sub_query_plan)
+
+        # Add information about this edge
+        new_output_join_descriptor = OutputJoinDescriptor(
+            output_names=(parent_out_name, child_out_name),
+        )
+        output_join_descriptors.append(new_output_join_descriptor)
+
+        # Recursively repeat on child SubQueryPlans
+        _make_query_plan_recursive(
+            child_sub_query_node, child_sub_query_plan, output_join_descriptors
+        )
+
+
+def _add_filter_at_field_with_output(ast, field_out_name, input_filter_name):
+    """Return an AST with @filter added at the field with the specified @output, if found.
+
+    Args:
+        ast: Field, InlineFragment, or OperationDefinition, an AST Node type that occurs in
+             the selections of a SelectionSet. It is not modified by this function
+        field_out_name: str, the out_name of an @output directive. This function will create
+                        a new @filter directive on the field that has an @output directive
+                        with this out_name
+        input_filter_name: str, the name of the local variable in the new @filter directive
+                           created
+
+    Returns:
+        Field, InlineFragment, or OperationDefinition, identical to the input ast except
+        with an @filter added at the specified field if such a field is found. If no changes
+        were made, this is the same object as the input
+    """
+    if not isinstance(ast, (
+        ast_types.Field, ast_types.InlineFragment, ast_types.OperationDefinition
+    )):
+        raise AssertionError(
+            u'Input ast is of type "{}", which should not be a selection.'
+            u''.format(type(ast).__name__)
+        )
+
+    if isinstance(ast, ast_types.Field):
+        # Check whether this field has the expected directive, if so, modify and return
+        if (
+            ast.directives is not None and
+            any(
+                _is_output_directive_with_name(directive, field_out_name)
+                for directive in ast.directives
+            )
+        ):
+            new_directives = copy(ast.directives)
+            new_directives.append(_get_in_collection_filter_directive(input_filter_name))
+            new_ast = copy(ast)
+            new_ast.directives = new_directives
+            return new_ast
+
+    if ast.selection_set is None:  # Nothing to recurse on
+        return ast
+
+    # Otherwise, recurse and look for field with desired out_name
+    made_changes = False
+    new_selections = []
+    for selection in ast.selection_set.selections:
+        new_selection = _add_filter_at_field_with_output(
+            selection, field_out_name, input_filter_name
+        )
+        if new_selection is not selection:  # Changes made somewhere down the line
+            if not made_changes:
+                made_changes = True
+            else:
+                # Change has already been made, but there is a new change. Implies that multiple
+                # fields have the @output directive with the desired name
+                raise GraphQLValidationError(
+                    u'There are multiple @output directives with the out_name "{}"'.format(
+                        field_out_name
+                    )
+                )
+        new_selections.append(new_selection)
+
+    if made_changes:
+        new_ast = copy(ast)
+        new_ast.selection_set = ast_types.SelectionSet(selections=new_selections)
+        return new_ast
+    else:
+        return ast
+
+
+def _is_output_directive_with_name(directive, out_name):
+    """Return whether or not the input is an @output directive with the desired out_name."""
+    if not isinstance(directive, ast_types.Directive):
+        raise AssertionError(u'Input "{}" is not a directive.'.format(directive))
+    return (
+        directive.name.value == OutputDirective.name and
+        directive.arguments[0].value.value == out_name
+    )
+
+
+def _get_in_collection_filter_directive(input_filter_name):
+    """Create a @filter directive with in_collecion operation and the desired variable name."""
+    return ast_types.Directive(
+        name=ast_types.Name(value=FilterDirective.name),
+        arguments=[
+            ast_types.Argument(
+                name=ast_types.Name(value='op_name'),
+                value=ast_types.StringValue(value='in_collection'),
+            ),
+            ast_types.Argument(
+                name=ast_types.Name(value='value'),
+                value=ast_types.ListValue(
+                    values=[
+                        ast_types.StringValue(value=u'$' + input_filter_name),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+def print_query_plan(query_plan_descriptor):
+    """Return a string describing query plan."""
+    query_plan_str = u''
+    plan_and_depth = _get_plan_and_depth_in_dfs_order(query_plan_descriptor.root_sub_query_plan)
+
+    for query_plan, depth in plan_and_depth:
+        line_separation = u'\n' + u' ' * 8 * depth
+        query_plan_str += line_separation
+
+        query_str = u'Execute in schema named "{}":\n'.format(query_plan.schema_id)
+        query_str += print_ast(query_plan.query_ast)
+        query_str = query_str.replace(u'\n', line_separation)
+        query_plan_str += query_str
+
+    query_plan_str += u'\n\n'
+    query_plan_str += u'Join together outputs as follows: '
+    query_plan_str += str(query_plan_descriptor.output_join_descriptors) + u'\n\n'
+    query_plan_str += u'Remove the following outputs at the end: '
+    query_plan_str += str(query_plan_descriptor.intermediate_output_names) + u'\n'
+
+    return query_plan_str
+
+
+def _get_plan_and_depth_in_dfs_order(query_plan):
+    """Helper for print_query_plan and other functions needing dfs order traversal."""
+    def _get_plan_and_depth_in_dfs_order_helper(query_plan, depth):
+        plan_and_depth_in_dfs_order = [(query_plan, depth)]
+        for child_query_plan in query_plan.child_query_plans:
+            plan_and_depth_in_dfs_order.extend(
+                _get_plan_and_depth_in_dfs_order_helper(child_query_plan, depth + 1)
+            )
+        return plan_and_depth_in_dfs_order
+    return _get_plan_and_depth_in_dfs_order_helper(query_plan, 0)

--- a/graphql_compiler/schema_transformation/make_query_plan.py
+++ b/graphql_compiler/schema_transformation/make_query_plan.py
@@ -3,7 +3,10 @@ from collections import namedtuple
 from copy import copy
 
 from graphql import print_ast
-from graphql.language import ast as ast_types
+from graphql.language.ast import (
+    Argument, Directive, Document, Field, InlineFragment, ListValue, Name, OperationDefinition,
+    SelectionSet, StringValue
+)
 
 from ..ast_manipulation import get_only_query_definition
 from ..exceptions import GraphQLValidationError
@@ -45,7 +48,7 @@ def make_query_plan(root_sub_query_node, intermediate_output_names):
     For each parent of parent and child SubQueryNodes, a new @filter directive will be added
     in the child AST. It will be added on the field whose @output directive has the out_name
     equal to the child's out name as specified in the QueryConnection. The newly added @filter
-    will be a 'in_collection' type filter, and the name of the local variabe is guaranteed to
+    will be a 'in_collection' type filter, and the name of the local variable is guaranteed to
     be the same as the out_name of the @output on the parent.
 
     ASTs contained in the input node and its children nodes will not be modified.
@@ -83,7 +86,7 @@ def _make_query_plan_recursive(sub_query_node, sub_query_plan, output_join_descr
 
     For each child connection contained in sub_query_node, create a new SubQueryPlan for
     the corresponding child SubQueryNode, add appropriate @filter directive to the child AST,
-    and attach the new SubQueryPlan to the list of children of the input sub query plan.
+    and attach the new SubQueryPlan to the list of children of the input sub-query plan.
 
     Args:
         sub_query_node: SubQueryNode, whose descendents are copied over onto sub_query_plan.
@@ -110,7 +113,7 @@ def _make_query_plan_recursive(sub_query_node, sub_query_plan, output_join_descr
                 u'AST "{}".'.format(child_out_name, child_query_type)
             )
         else:
-            new_child_query_ast = ast_types.Document(
+            new_child_query_ast = Document(
                 definitions=[child_query_type_with_filter]
             )
 
@@ -154,15 +157,13 @@ def _add_filter_at_field_with_output(ast, field_out_name, input_filter_name):
         with an @filter added at the specified field if such a field is found. If no changes
         were made, this is the same object as the input
     """
-    if not isinstance(ast, (
-        ast_types.Field, ast_types.InlineFragment, ast_types.OperationDefinition
-    )):
+    if not isinstance(ast, (Field, InlineFragment, OperationDefinition)):
         raise AssertionError(
-            u'Input ast is of type "{}", which should not be a selection.'
+            u'Input AST is of type "{}", which should not be a selection.'
             u''.format(type(ast).__name__)
         )
 
-    if isinstance(ast, ast_types.Field):
+    if isinstance(ast, Field):
         # Check whether this field has the expected directive, if so, modify and return
         if (
             ast.directives is not None and
@@ -202,7 +203,7 @@ def _add_filter_at_field_with_output(ast, field_out_name, input_filter_name):
 
     if made_changes:
         new_ast = copy(ast)
-        new_ast.selection_set = ast_types.SelectionSet(selections=new_selections)
+        new_ast.selection_set = SelectionSet(selections=new_selections)
         return new_ast
     else:
         return ast
@@ -210,7 +211,7 @@ def _add_filter_at_field_with_output(ast, field_out_name, input_filter_name):
 
 def _is_output_directive_with_name(directive, out_name):
     """Return whether or not the input is an @output directive with the desired out_name."""
-    if not isinstance(directive, ast_types.Directive):
+    if not isinstance(directive, Directive):
         raise AssertionError(u'Input "{}" is not a directive.'.format(directive))
     return (
         directive.name.value == OutputDirective.name and
@@ -220,18 +221,18 @@ def _is_output_directive_with_name(directive, out_name):
 
 def _get_in_collection_filter_directive(input_filter_name):
     """Create a @filter directive with in_collecion operation and the desired variable name."""
-    return ast_types.Directive(
-        name=ast_types.Name(value=FilterDirective.name),
+    return Directive(
+        name=Name(value=FilterDirective.name),
         arguments=[
-            ast_types.Argument(
-                name=ast_types.Name(value='op_name'),
-                value=ast_types.StringValue(value='in_collection'),
+            Argument(
+                name=Name(value='op_name'),
+                value=StringValue(value='in_collection'),
             ),
-            ast_types.Argument(
-                name=ast_types.Name(value='value'),
-                value=ast_types.ListValue(
+            Argument(
+                name=Name(value='value'),
+                value=ListValue(
                     values=[
-                        ast_types.StringValue(value=u'$' + input_filter_name),
+                        StringValue(value=u'$' + input_filter_name),
                     ],
                 ),
             ),
@@ -239,27 +240,26 @@ def _get_in_collection_filter_directive(input_filter_name):
     )
 
 
-def print_query_plan(query_plan_descriptor):
+def print_query_plan(query_plan_descriptor, indentation_depth=4):
     """Return a string describing query plan."""
-    query_plan_str = u''
+    query_plan_strings = [u'']
     plan_and_depth = _get_plan_and_depth_in_dfs_order(query_plan_descriptor.root_sub_query_plan)
 
     for query_plan, depth in plan_and_depth:
-        line_separation = u'\n' + u' ' * 8 * depth
-        query_plan_str += line_separation
+        line_separation = u'\n' + u' ' * indentation_depth * depth
+        query_plan_strings.append(line_separation)
 
         query_str = u'Execute in schema named "{}":\n'.format(query_plan.schema_id)
         query_str += print_ast(query_plan.query_ast)
         query_str = query_str.replace(u'\n', line_separation)
-        query_plan_str += query_str
+        query_plan_strings.append(query_str)
 
-    query_plan_str += u'\n\n'
-    query_plan_str += u'Join together outputs as follows: '
-    query_plan_str += str(query_plan_descriptor.output_join_descriptors) + u'\n\n'
-    query_plan_str += u'Remove the following outputs at the end: '
-    query_plan_str += str(query_plan_descriptor.intermediate_output_names) + u'\n'
+    query_plan_strings.append(u'\n\nJoin together outputs as follows: ')
+    query_plan_strings.append(str(query_plan_descriptor.output_join_descriptors))
+    query_plan_strings.append(u'\n\nRemove the following outputs at the end: ')
+    query_plan_strings.append(str(query_plan_descriptor.intermediate_output_names) + u'\n')
 
-    return query_plan_str
+    return ''.join(query_plan_strings)
 
 
 def _get_plan_and_depth_in_dfs_order(query_plan):


### PR DESCRIPTION
The print_query_plan part isn't done super carefully, it's partly copied from the prototype code. If we take query str 
```
            {
              Animal {
                out_Animal_Creature {
                  age @output(out_name: "age")
                }
              }
            }
```
and do `print_query_plan(make_query_plan(split_query(parse(query_str), merged_schema_descriptor)))`, we get 
```
Execute in schema named "first":
{
  Animal {
    uuid @output(out_name: "__intermediate_output_0")
  }
}

        Execute in schema named "second":
        {
          Creature {
            age @output(out_name: "age")
            id @output(out_name: "__intermediate_output_1") @filter(op_name: "in_collection", value: ["$__intermediate_output_0"])
          }
        }
        

Join together outputs as follows: [OutputJoinDescriptor(output_names=('__intermediate_output_0', '__intermediate_output_1'))]

Remove the following outputs at the end: frozenset({'__intermediate_output_0', '__intermediate_output_1'})
```
just to show what it's like.