### PR TITLE
Query pagination skeleton

### DIFF
--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -309,7 +309,6 @@ def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, pa
         raise AssertionError(u'Received negative estimate {} for cardinality of query {}: {}'
                              .format(result_size, graphql_query, params))
 
-
     # Since using a // b returns the fraction rounded down, we instead use (a + b - 1) // b, which
     # returns the fraction value rounded up, which is the desired functionality.
     num_pages = int((result_size + page_size - 1) // page_size)

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -293,11 +293,14 @@ def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, pa
 
     Returns:
         int, estimated number of pages if the query were executed.
+
+    Raises:
+        ValueError if page_size is below 1.
     """
     if page_size < 1:
-        raise AssertionError(u'Could not estimate number of pages for query {}'
-                             u' with page size lower than 1: {} {}'
-                             .format(graphql_query, page_size, params))
+        raise ValueError(u'Could not estimate number of pages for query {}'
+                         u' with page size lower than 1: {} {}'
+                         .format(graphql_query, page_size, params))
 
     result_size = estimate_query_result_cardinality(
         schema_graph, statistics, graphql_query, params

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -286,7 +286,7 @@ def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, pa
 
     Args:
         schema_graph: SchemaGraph instance.
-        statistics: Statistics object
+        statistics: Statistics object.
         graphql_query: str, valid GraphQL query to be estimated.
         params: dict, parameters for the given query.
         page_size: int, desired number of result rows per page.

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -294,11 +294,23 @@ def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, pa
     Returns:
         int, estimated number of pages if the query were executed.
     """
+    if page_size < 1:
+        raise AssertionError(u'Could not estimate number of pages for query {}'
+                             u' with page size lower than 1: {} {}'
+                             .format(graphql_query, page_size, params))
+
     result_size = estimate_query_result_cardinality(
         schema_graph, statistics, graphql_query, params
     )
+    if result_size < 0.0:
+        raise AssertionError(u'Received negative estimate {} for cardinality of query {}: {}'
+                             .format(result_size, graphql_query, params))
+
 
     # Since using a // b returns the fraction rounded down, we instead use (a + b - 1) // b, which
     # returns the fraction value rounded up, which is the desired functionality.
     num_pages = int((result_size + page_size - 1) // page_size)
+    if num_pages == 0:
+        num_pages = 1
+
     return num_pages

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -298,7 +298,7 @@ def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, pa
         schema_graph, statistics, graphql_query, params
     )
 
-    # Since using a // b Returns the fraction rounded down, we instead use (a + b - 1) // b, which
+    # Since using a // b returns the fraction rounded down, we instead use (a + b - 1) // b, which
     # returns the fraction value rounded up, which is the desired functionality.
     num_pages = int((result_size + page_size - 1) // page_size)
     return num_pages

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -272,3 +272,33 @@ def estimate_query_result_cardinality(
     expected_query_result_cardinality = root_counts * results_per_root
 
     return expected_query_result_cardinality
+
+
+def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, page_size):
+    """Estimate how many pages of results will be generated for a given query.
+
+    Using the cardinality estimator, we generate an estimate for the query result cardinality i.e.
+    the number of result rows, then divide (rounding up) by the page_size to get the approximate
+    number of pages that the query will produce.
+    For example, if a query were estimated to return 12000 result rows, and the desired page size is
+    5000, then the query can be divided into ceil(12000/5000)=3 pages, each with a result size below
+    (or equal to) 5000 results.
+
+    Args:
+        schema_graph: SchemaGraph instance.
+        statistics: Statistics object
+        graphql_query: str, valid GraphQL query to be estimated.
+        params: dict, parameters for the given query.
+        page_size: int, desired number of result rows per page.
+
+    Returns:
+        int, estimated number of pages if the query were executed.
+    """
+    result_size = estimate_query_result_cardinality(
+        schema_graph, statistics, graphql_query, params
+    )
+
+    # Since using a // b Returns the fraction rounded down, we instead use (a + b - 1) // b, which
+    # returns the fraction value rounded up, which is the desired functionality.
+    num_pages = int((result_size + page_size - 1) // page_size)
+    return num_pages

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -1,3 +1,4 @@
+# Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
 from graphql.language.printer import print_ast

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -38,16 +38,16 @@ def split_into_next_page_query_and_continuation_query(
 
     Returns:
         (QueryAndParameters, QueryAndParameters), describing two queries: one that when executed
-        will return roughly a page of results, and another that will return the rest of the results
-        of the original query. The union of the two queries' result data is equivalent to the given
-        query and parameter's result data. There are no guarantees on the order of the result rows
-        for the two generated queries.
+        will return roughly a page of results of the original query, and another that will return
+        the rest of the results of the original query. The union of the two queries' result data is
+        equivalent to the given query and parameter's result data. There are no guarantees on the
+        order of the result rows for the two generated queries.
     """
     parameterized_queries = generate_parameterized_queries(
         schema_graph, statistics, query_ast, parameters
     )
 
-    hydrated_parameters = _hydrate_parameters_of_parameterized_query(
+    hydrated_parameters = hydrate_parameters_of_parameterized_query(
         schema_graph, statistics, parameterized_queries, num_pages
     )
 

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -3,32 +3,32 @@ from collections import namedtuple
 
 from graphql.language.printer import print_ast
 
+from graphql_compiler.ast_manipulation import safe_parse_graphql
 from graphql_compiler.cost_estimation.cardinality_estimator import estimate_number_of_pages
 from graphql_compiler.query_pagination.parameter_generator import (
-    hydrate_parameters_of_parameterized_query
+    generate_parameters_for_parameterized_query
 )
 from graphql_compiler.query_pagination.query_parameterizer import generate_parameterized_queries
 
 
-PaginationQueries = namedtuple(
-    'PaginationQueries',
+QueryStringWithParameters = namedtuple(
+    'QueryStringWithParameters',
     (
-        'next_page_query',          # Document, AST for the query that along with
-                                    # next_page_parameters is expected to return the next page of
-                                    # page of results of the original query.
-        'next_page_parameters',     # dict, parameters with which to execute the next page query.
-        'continuation_query',       # Document or None, AST for the query that along with
-                                    # continuation_parameters returns the rest of the results of the
-                                    # original query, or None if the original query was not split
-                                    # into two queries.
-        'continuation_parameters',  # dict or None, parameters with which to execute the
-                                    # continuation query, or None if the continuation query was not
-                                    # generated.
-    )
+        'query_string',     # str, describing a GraphQL query.
+        'parameters',       # dict, parameters for executing the given query.
+    ),
+)
+
+ASTWithParameters = namedtuple(
+    'ASTWithParameters',
+    (
+        'query_ast',        # Document, AST describing a GraphQL query.
+        'parameters',       # dict, parameters for executing the given query.
+    ),
 )
 
 
-def split_into_next_page_query_and_continuation_query(
+def _split_into_next_page_query_and_continuation_query(
     schema_graph, statistics, query_ast, parameters, num_pages
 ):
     """Split a query into two equivalent queries, one of which will return roughly a page of data.
@@ -47,13 +47,11 @@ def split_into_next_page_query_and_continuation_query(
         num_pages: int, number of pages to split the query into.
 
     Returns:
-        PaginationQueries namedtuple, describing two queries: the first is described in
-        next_page_query and next_page_parameters, which when executed will return roughly a page of
-        results of the original query; while the second query is described in continuation_query and
-        continuation_parameters, which will return the rest of the results of the original query.
-        The union of the two queries' result data is equivalent to the given query and parameter's
-        result data. There are no guarantees on the order of the result rows for the two generated
-        queries.
+        tuple of (ASTWithParameters namedtuple, ASTWithParameters namedtuple), describing two
+        queries: the first query when executed will return roughly a page of results of the original
+        query; the second query will return the rest of the results of the original query. The union
+        of the two queries' result data is equivalent to the given query and parameter's result
+        data. There are no guarantees on the order of the result rows for the two generated queries.
     """
     if num_pages <= 1:
         raise AssertionError(u'Could not split query {} into pagination queries for the next page'
@@ -64,28 +62,28 @@ def split_into_next_page_query_and_continuation_query(
         schema_graph, statistics, query_ast, parameters
     )
 
-    hydrated_parameters = hydrate_parameters_of_parameterized_query(
+    pagination_parameters = generate_parameters_for_parameterized_query(
         schema_graph, statistics, parameterized_queries, num_pages
     )
 
-    result_pagination = PaginationQueries(
+    next_page_ast_with_parameters = ASTWithParameters(
         parameterized_queries.next_page_query,
-        hydrated_parameters.next_page_parameters,
+        pagination_parameters.next_page_parameters,
+    )
+    continuation_ast_with_parameters = ASTWithParameters(
         parameterized_queries.continuation_query,
-        hydrated_parameters.continuation_parameterst,
+        pagination_parameters.continuation_parameters,
     )
 
-    return result_pagination
+    return next_page_ast_with_parameters, continuation_ast_with_parameters
 
 
-def paginate_query(schema_graph, statistics, query_ast, parameters, page_size):
-    """Return two query ASTs usable for pagination whose union is equivalent to the given query.
+def paginate_query_ast(schema_graph, statistics, query_ast, parameters, page_size):
+    """Generates a query fetching a page of results and the cursor for a GraphQL query AST.
 
-    The first query when executed will return approximately page_size results, while the second
-    query will return the rest of the results. In case the given query is estimated to return less
-    than a page of data, the query will not be split.
     Since the cost estimator may underestimate or overestimate the actual number of pages, you
-    should expect the actual number of results to be within two orders of magnitude of the estimate.
+    should expect the actual number of results of the page query to be within two orders of
+    magnitude of the estimate.
 
     Args:
         schema_graph: SchemaGraph instance.
@@ -95,28 +93,24 @@ def paginate_query(schema_graph, statistics, query_ast, parameters, page_size):
         page_size: int, describes the desired number of result rows per page.
 
     Returns:
-        PaginationQueries namedtuple, describing one or two queries that paginate over the original
-        query, containing:
-            - next_page_query and next_page_parameters describe a query that will return roughly a
-              page of results for the original query.
-            - continuation_query and continuation_parameters describe a query that will return the
-              rest of the results of the original query. If the original query is expected to return
-              only a page or less of results, then continuation_query and continuation_parameters
-              will have a value of None.
+        tuple containing two elements:
+            - ASTWithParameters namedtuple, describing a query expected to return roughly a page
+              of result data of the original query.
+            - ASTWithParameters namedtuple or None, describing a query that returns the rest of the
+              result data of the original query. If the original query is expected to return only a
+              page or less of results, then this element will have value None.
 
     Raises:
         ValueError if page_size is below 1.
     """
     if page_size < 1:
         raise ValueError(
-            u'Could not page GraphQL query {} with page size {}.'.format(query_ast, page_size)
+            u'Could not page query {} with page size lower than 1: {}'.format(query_ast, page_size)
         )
 
     # Initially, assume the query does not need to be paged i.e. will return one page of results.
-    result_queries = PaginationQueries(
-        query_ast,
-        parameters,
-        None,
+    result_queries = (
+        ASTWithParameters(query_ast, parameters),
         None,
     )
 
@@ -127,8 +121,51 @@ def paginate_query(schema_graph, statistics, query_ast, parameters, page_size):
         schema_graph, statistics, graphql_query_string, parameters, page_size
     )
     if num_pages > 1:
-        result_queries = split_into_next_page_query_and_continuation_query(
+        result_queries = _split_into_next_page_query_and_continuation_query(
             schema_graph, statistics, query_ast, parameters, num_pages
         )
 
     return result_queries
+
+
+def paginate_query(schema_graph, statistics, query_string, parameters, page_size):
+    """Generates a query fetching a page of results and the cursor for a GraphQL query string.
+
+    Since the cost estimator may underestimate or overestimate the actual number of pages, you
+    should expect the actual number of results of the page query to be within two orders of
+    magnitude of the estimate.
+
+    Args:
+        schema_graph: SchemaGraph instance.
+        statistics: Statistics object.
+        query_string: str, valid GraphQL query to be paginated.
+        parameters: dict, parameters with which query will be estimated.
+        page_size: int, describes the desired number of result rows per page.
+
+    Returns:
+        tuple containing queries for going over the original query in a paginated fashion:
+            - QueryStringWithParameters namedtuple, query expected to return roughly a page of
+              result data of the original query.
+            - QueryStringWithParameters namedtuple or None, query returning the rest of the result
+              data of the original query. If the original query is expected to return only a page or
+              less of results, then this element will have value None.
+
+    Raises:
+        ValueError if page_size is below 1.
+    """
+    query_ast = safe_parse_graphql(query_string)
+
+    next_page_ast_with_parameters, continuation_ast_with_parameters = paginate_query_ast(
+        schema_graph, statistics, query_ast, parameters, page_size
+    )
+
+    next_page_query_with_parameters = QueryStringWithParameters(
+        print_ast(next_page_ast_with_parameters.query_ast),
+        next_page_ast_with_parameters.parameters,
+    )
+    continuation_query_with_parameters = QueryStringWithParameters(
+        print_ast(continuation_ast_with_parameters.query_ast),
+        continuation_ast_with_parameters.parameters,
+    )
+
+    return next_page_query_with_parameters, continuation_query_with_parameters

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -6,7 +6,7 @@ from graphql.language.printer import print_ast
 from graphql_compiler.ast_manipulation import safe_parse_graphql
 from graphql_compiler.cost_estimation.cardinality_estimator import estimate_number_of_pages
 from graphql_compiler.query_pagination.query_splitter import (
-    split_into_page_query_and_remainder_query
+    ASTWithParameters, split_into_page_query_and_remainder_query
 )
 
 
@@ -14,14 +14,6 @@ QueryStringWithParameters = namedtuple(
     'QueryStringWithParameters',
     (
         'query_string',     # str, describing a GraphQL query.
-        'parameters',       # dict, parameters for executing the given query.
-    ),
-)
-
-ASTWithParameters = namedtuple(
-    'ASTWithParameters',
-    (
-        'query_ast',        # Document, AST describing a GraphQL query.
         'parameters',       # dict, parameters for executing the given query.
     ),
 )

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -5,10 +5,9 @@ from graphql.language.printer import print_ast
 
 from graphql_compiler.ast_manipulation import safe_parse_graphql
 from graphql_compiler.cost_estimation.cardinality_estimator import estimate_number_of_pages
-from graphql_compiler.query_pagination.parameter_generator import (
-    generate_parameters_for_parameterized_query
+from graphql_compiler.query_pagination.query_splitter import (
+    split_into_page_query_and_remainder_query
 )
-from graphql_compiler.query_pagination.query_parameterizer import generate_parameterized_queries
 
 
 QueryStringWithParameters = namedtuple(
@@ -28,58 +27,8 @@ ASTWithParameters = namedtuple(
 )
 
 
-def _split_into_next_page_query_and_continuation_query(
-    schema_graph, statistics, query_ast, parameters, num_pages
-):
-    """Split a query into two equivalent queries, one of which will return roughly a page of data.
-
-    First, two parameterized queries are generated that contain filters usable for pagination i.e.
-    filters with which the number of results can be constrained. Parameters for these filters are
-    then generated such that one of the new queries will return roughly a page of results, while the
-    other query will generate the rest of the results. This ensures that the two new queries' result
-    data is equivalent to the original query's result data.
-
-    Args:
-        schema_graph: SchemaGraph instance.
-        statistics: Statistics object.
-        query_ast: Document, AST of the GraphQL query that will be split.
-        parameters: dict, parameters with which query will be estimated.
-        num_pages: int, number of pages to split the query into.
-
-    Returns:
-        tuple of (ASTWithParameters namedtuple, ASTWithParameters namedtuple), describing two
-        queries: the first query when executed will return roughly a page of results of the original
-        query; the second query will return the rest of the results of the original query. The union
-        of the two queries' result data is equivalent to the given query and parameter's result
-        data. There are no guarantees on the order of the result rows for the two generated queries.
-    """
-    if num_pages <= 1:
-        raise AssertionError(u'Could not split query {} into pagination queries for the next page'
-                             u' of results, as the number of pages {} must be greater than 1: {}'
-                             .format(query_ast, num_pages, parameters))
-
-    parameterized_queries = generate_parameterized_queries(
-        schema_graph, statistics, query_ast, parameters
-    )
-
-    pagination_parameters = generate_parameters_for_parameterized_query(
-        schema_graph, statistics, parameterized_queries, num_pages
-    )
-
-    next_page_ast_with_parameters = ASTWithParameters(
-        parameterized_queries.next_page_query,
-        pagination_parameters.next_page_parameters,
-    )
-    continuation_ast_with_parameters = ASTWithParameters(
-        parameterized_queries.continuation_query,
-        pagination_parameters.continuation_parameters,
-    )
-
-    return next_page_ast_with_parameters, continuation_ast_with_parameters
-
-
 def paginate_query_ast(schema_graph, statistics, query_ast, parameters, page_size):
-    """Generates a query fetching a page of results and the cursor for a GraphQL query AST.
+    """Generate a query fetching a page of results and the remainder query for a query AST.
 
     Since the cost estimator may underestimate or overestimate the actual number of pages, you
     should expect the actual number of results of the page query to be within two orders of
@@ -121,7 +70,7 @@ def paginate_query_ast(schema_graph, statistics, query_ast, parameters, page_siz
         schema_graph, statistics, graphql_query_string, parameters, page_size
     )
     if num_pages > 1:
-        result_queries = _split_into_next_page_query_and_continuation_query(
+        result_queries = split_into_page_query_and_remainder_query(
             schema_graph, statistics, query_ast, parameters, num_pages
         )
 
@@ -129,7 +78,7 @@ def paginate_query_ast(schema_graph, statistics, query_ast, parameters, page_siz
 
 
 def paginate_query(schema_graph, statistics, query_string, parameters, page_size):
-    """Generates a query fetching a page of results and the cursor for a GraphQL query string.
+    """Generate a query fetching a page of results and the remainder query for a query string.
 
     Since the cost estimator may underestimate or overestimate the actual number of pages, you
     should expect the actual number of results of the page query to be within two orders of
@@ -146,26 +95,24 @@ def paginate_query(schema_graph, statistics, query_string, parameters, page_size
         tuple containing queries for going over the original query in a paginated fashion:
             - QueryStringWithParameters namedtuple, query expected to return roughly a page of
               result data of the original query.
-            - QueryStringWithParameters namedtuple or None, query returning the rest of the result
-              data of the original query. If the original query is expected to return only a page or
-              less of results, then this element will have value None.
-
-    Raises:
-        ValueError if page_size is below 1.
+            - QueryStringWithParameters namedtuple or None. If the given query was estimated to
+              return more than a page of results, this element is a QueryStringWithParameters
+              namedtuple describing a query for the rest of the result data. Otherwise, this element
+              is None.
     """
     query_ast = safe_parse_graphql(query_string)
 
-    next_page_ast_with_parameters, continuation_ast_with_parameters = paginate_query_ast(
+    next_page_ast_with_parameters, remainder_ast_with_parameters = paginate_query_ast(
         schema_graph, statistics, query_ast, parameters, page_size
     )
 
-    next_page_query_with_parameters = QueryStringWithParameters(
+    page_query_with_parameters = QueryStringWithParameters(
         print_ast(next_page_ast_with_parameters.query_ast),
         next_page_ast_with_parameters.parameters,
     )
-    continuation_query_with_parameters = QueryStringWithParameters(
-        print_ast(continuation_ast_with_parameters.query_ast),
-        continuation_ast_with_parameters.parameters,
+    remainder_query_with_parameters = QueryStringWithParameters(
+        print_ast(remainder_ast_with_parameters.query_ast),
+        remainder_ast_with_parameters.parameters,
     )
 
-    return next_page_query_with_parameters, continuation_query_with_parameters
+    return page_query_with_parameters, remainder_query_with_parameters

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -1,0 +1,117 @@
+from collections import namedtuple
+
+from graphql.language.printer import print_ast
+
+from graphql_compiler.cost_estimation.cardinality_estimator import estimate_number_of_pages
+from graphql_compiler.query_pagination.parameter_generator import (
+    hydrate_parameters_of_parameterized_query
+)
+from graphql_compiler.query_pagination.query_parameterizer import generate_parameterized_queries
+
+
+QueryAndParameters = namedtuple(
+    'QueryAndParameters',
+    (
+        'query_ast',
+        'parameters',
+    ),
+)
+
+
+def split_into_next_page_query_and_continuation_query(
+    schema_graph, statistics, query_ast, parameters, num_pages
+):
+    """Split a query into two equivalent queries, one of which will return roughly a page of data.
+
+    First, two parameterized queries are generated that contain filters usable for pagination i.e.
+    filters with which the number of results can be constrained. Parameters for these filters are
+    then generated such that one of the new queries will return roughly a page of results, while the
+    other query will generate the rest of the results. This ensures that the two new queries' result
+    data is equivalent to the original query's result data.
+
+    Args:
+        schema_graph: SchemaGraph instance.
+        statistics: Statistics object.
+        query_ast: Document, AST of the GraphQL query that will be split.
+        parameters: dict, parameters with which query will be estimated.
+        num_pages: int, number of pages to split the query into.
+
+    Returns:
+        (QueryAndParameters, QueryAndParameters), describing two queries: one that when executed
+        will return roughly a page of results, and another that will return the rest of the results
+        of the original query. The union of the two queries' result data is equivalent to the given
+        query and parameter's result data. There are no guarantees on the order of the result rows
+        for the two generated queries.
+    """
+    parameterized_queries = generate_parameterized_queries(
+        schema_graph, statistics, query_ast, parameters
+    )
+
+    hydrated_parameters = _hydrate_parameters_of_parameterized_query(
+        schema_graph, statistics, parameterized_queries, num_pages
+    )
+
+    next_page_query_with_parameters = QueryAndParameters(
+        parameterized_queries.next_page_query,
+        hydrated_parameters.next_page_parameters,
+    )
+
+    continuation_query_with_parameters = QueryAndParameters(
+        parameterized_queries.continuation_query,
+        hydrated_parameters.continuation_parameters,
+    )
+
+    return (next_page_query_with_parameters, continuation_query_with_parameters)
+
+
+def paginate_query(schema_graph, statistics, query_ast, parameters, page_size):
+    """Return two query ASTs usable for pagination whose union is equivalent to the given query.
+
+    The first query when executed will return approximately page_size results, while the second
+    query will return the rest of the results. In case the given query is estimated to return less
+    than a page of data, the query will not be split.
+    Since the cost estimator may underestimate or overestimate the actual number of pages, you
+    should expect the actual number of results to be within two orders of magnitude of the estimate.
+
+    Args:
+        schema_graph: SchemaGraph instance.
+        statistics: Statistics object.
+        query_ast: Document, AST of the GraphQL query that is being paginated.
+        parameters: dict, parameters with which query will be estimated.
+        page_size: int, describes the desired number of result rows per page.
+
+    Returns:
+        - tuple containing two elements:
+            - The first element is a QueryAndParameters namedtuple, describing a query expected to
+              return roughly a page of result data of the original query.
+            - The second element is either:
+                - QueryAndParameters namedtuple, describing a query that returns the rest of the
+                  result data of the original query.
+                - None if the original query is expected to return a page or less of result data.
+
+    Raises:
+        ValueError if page_size is below 1.
+    """
+    if page_size < 1:
+        raise ValueError(
+            u'Could not page GraphQL query {} with page size {}.'.format(query_ast, page_size)
+        )
+
+    # Initially, assume the query does not need to be paged i.e. will return one page of results.
+    result_queries = tuple([
+        QueryAndParameters(query_ast, parameters),
+        None
+    ])
+
+    # HACK(vlad): Since the current cost estimator expects GraphQL queries given as a string, we
+    #             print the given AST and provide that to the cost estimator.
+    graphql_query_string = print_ast(query_ast)
+    num_pages = estimate_number_of_pages(
+        schema_graph, statistics, graphql_query_string, parameters, page_size
+    )
+    if num_pages > 1:
+        result_queries = split_into_next_page_query_and_continuation_query(
+            schema_graph, statistics, query_ast, parameters, num_pages
+        )
+
+    return result_queries

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -2,8 +2,8 @@
 from collections import namedtuple
 
 
-HydratedParameters = namedtuple(
-    'HydratedParameters',
+PaginationParameters = namedtuple(
+    'PaginationParameters',
     (
         'next_page_parameters',     # dict, parameters with which to execute the next page
                                     # parameterized query.
@@ -13,7 +13,7 @@ HydratedParameters = namedtuple(
 )
 
 
-def hydrate_parameters_of_parameterized_query(
+def generate_parameters_for_parameterized_query(
     schema_graph, statistics, parameterized_pagination_queries, num_pages
 ):
     """Generate parameters combining the user's parameters and parameters for paging.
@@ -22,12 +22,12 @@ def hydrate_parameters_of_parameterized_query(
         schema_graph: SchemaGraph instance.
         statistics: Statistics object.
         parameterized_pagination_queries: ParameterizedPaginationQueries namedtuple, parameterized
-                                          queries whose parameters will be hydrated with pagination
+                                          queries whose parameters will be generated with pagination
                                           parameters.
         num_pages: int, number of pages to split the query into.
 
     Returns:
-        HydratedParameters namedtuple, containing two dicts with which to execute the next page
+        PaginationParameters namedtuple, containing two dicts with which to execute the next page
         query and the continuation query respectively. The next page query parameters are generated
         such that only a page of result data is generated of the original pagination query, while
         the continuation query parameters generate the rest of the original query's result data.

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -1,3 +1,4 @@
+# Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
 

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -1,0 +1,34 @@
+from collections import namedtuple
+
+
+HydratedParameters = namedtuple(
+    'HydratedParameters',
+    (
+        'next_page_parameters',     # dict, parameters with which to execute the next page
+                                    # parameterized query.
+        'continuation_parameters',  # dict, parameters with which to execute the parameterized
+                                    # continuation query.
+    ),
+)
+
+
+def hydrate_parameters_of_parameterized_query(
+    schema_graph, statistics, parameterized_pagination_queries, num_pages
+):
+    """Generate parameters combining the user's parameters and parameters for paging.
+
+    Args:
+        schema_graph: SchemaGraph instance.
+        statistics: Statistics object.
+        parameterized_pagination_queries: ParameterizedPaginationQueries namedtuple, parameterized
+                                          queries whose parameters will be hydrated with pagination
+                                          parameters.
+        num_pages: int, number of pages to split the query into.
+
+    Returns:
+        HydratedParameters namedtuple, containing two dicts with which to execute the next page
+        query and the continuation query respectively. The next page query parameters are generated
+        such that only a page of result data is generated of the original pagination query, while
+        the continuation query parameters generate the rest of the original query's result data.
+    """
+    raise NotImplementedError()

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -1,5 +1,4 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from collections import namedtuple
 
 
 def generate_parameters_for_parameterized_query(

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -2,34 +2,25 @@
 from collections import namedtuple
 
 
-PaginationParameters = namedtuple(
-    'PaginationParameters',
-    (
-        'next_page_parameters',     # dict, parameters with which to execute the next page
-                                    # parameterized query.
-        'continuation_parameters',  # dict, parameters with which to execute the parameterized
-                                    # continuation query.
-    ),
-)
-
-
 def generate_parameters_for_parameterized_query(
     schema_graph, statistics, parameterized_pagination_queries, num_pages
 ):
-    """Generate parameters combining the user's parameters and parameters for paging.
+    """Generate parameters for the given parameterized pagination queries.
 
     Args:
         schema_graph: SchemaGraph instance.
         statistics: Statistics object.
         parameterized_pagination_queries: ParameterizedPaginationQueries namedtuple, parameterized
-                                          queries whose parameters will be generated with pagination
-                                          parameters.
+                                          queries for which parameters are being generated.
         num_pages: int, number of pages to split the query into.
 
     Returns:
-        PaginationParameters namedtuple, containing two dicts with which to execute the next page
-        query and the continuation query respectively. The next page query parameters are generated
-        such that only a page of result data is generated of the original pagination query, while
-        the continuation query parameters generate the rest of the original query's result data.
+        two dicts:
+            - dict, parameters with which to execute the page query. The next page query's
+              parameters are generated such that only a page of the original query's result data is
+              produced when executed.
+            - dict, parameters with which to execute the remainder query. The remainder query
+              parameters are generated such that they produce the remainder of the original query's
+              result data when executed.
     """
     raise NotImplementedError()

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -1,0 +1,55 @@
+from collections import namedtuple
+
+
+RESERVED_PARAMETER_PREFIX = '_paged_'
+
+ParameterizedPaginationQuery = namedtuple(
+    'ParameterizedPaginationQuery',
+    (
+        'next_page_query',          # Document, AST of query that will return the next page of
+                                    # results when hydrated with pagination parameters.
+        'continuation_query',       # Document, AST of query that will return the remainder of
+                                    # results when hydrated with pagination parameters.
+        'pagination_filters',       # List[PaginationFilter], filters usable for pagination.
+        'user_parameters',          # dict, parameters that the user has defined for other filters.
+    ),
+)
+
+PaginationFilter = namedtuple(
+    'PaginationFilter',
+    (
+        'vertex_field',                 # str, vertex class to which the property field belongs to.
+        'property_field',               # str, name of the property field filtering is done over.
+        'next_page_query_filter',       # Directive, filter usable for pagination in the
+                                        # next page query.
+        'continuation_query_filter',    # Directive, filter usable for pagination in the
+                                        # continuation query.
+        'related_filters',              # List[Directive], filter directives that are on the same
+                                        # vertex and property field.
+    ),
+)
+
+
+def generate_parameterized_queries(schema_graph, statistics, query_ast, parameters):
+    """Generate two parameterized queries that can be hydrated to paginate over the original query.
+
+    In order to paginate arbitrary GraphQL queries, additional filters may need to be added to be
+    able to limit the number of results in the original query. This function creates two new queries
+    with additional filters stored as PaginationFilters with which the query result size can be
+    controlled.
+
+    Args:
+        schema_graph: SchemaGraph instance.
+        statistics: Statistics object.
+        query_ast: Document, query that is being paginated.
+        parameters: dict, list of parameters for the given query.
+
+    Returns:
+        ParameterizedPaginationQuery namedtuple, describing two new query ASTs that have additional
+        filters stored as PaginationFilters with which the query result size can be controlled.
+        Note that these filters are returned parameterized i.e. values for the filters' parameters
+        have yet to be generated. Additionally, a dict containing user-defined parameters is stored.
+        Since this function may modify the user parameters to ensure better pagination, the
+        user_parameters dict may differ from the one provided as an argument to this function.
+    """
+    raise NotImplementedError()

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -19,7 +19,7 @@ ParameterizedPaginationQueries = namedtuple(
 PaginationFilter = namedtuple(
     'PaginationFilter',
     (
-        'vertex_field',                 # str, vertex class to which the property field belongs to.
+        'vertex_class',                 # str, vertex class to which the property field belongs to.
         'property_field',               # str, name of the property field filtering is done over.
         'next_page_query_filter',       # Directive, filter directive with '<' operator usable
                                         # for pagination in the next page query.

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -14,9 +14,9 @@ ParameterizedPaginationQueries = namedtuple(
     'ParameterizedPaginationQueries',
     (
         'next_page_query',          # Document, AST of query that will return the next page of
-                                    # results when hydrated with pagination parameters.
+                                    # results when combined with pagination parameters.
         'remainder_query',          # Document, AST of query that will return the remainder of
-                                    # results when hydrated with pagination parameters.
+                                    # results when combined with pagination parameters.
         'pagination_filters',       # List[PaginationFilter], filters usable for pagination.
         'user_parameters',          # dict, parameters that the user has defined for other filters.
     ),
@@ -43,7 +43,7 @@ PaginationFilter = namedtuple(
 
 
 def generate_parameterized_queries(schema_graph, statistics, query_ast, parameters):
-    """Generate two parameterized queries that can be hydrated to paginate over the original query.
+    """Generate two parameterized queries that can be used to paginate over a given query.
 
     In order to paginate arbitrary GraphQL queries, additional filters may need to be added to be
     able to limit the number of results in the original query. This function creates two new queries

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -47,11 +47,11 @@ def generate_parameterized_queries(schema_graph, statistics, query_ast, paramete
         parameters: dict, list of parameters for the given query.
 
     Returns:
-        ParameterizedPaginationQueries namedtuple, describing two new query ASTs that have additional
-        filters stored as PaginationFilters with which the query result size can be controlled.
-        Note that these filters are returned parameterized i.e. values for the filters' parameters
-        have yet to be generated. Additionally, a dict containing user-defined parameters is stored.
-        Since this function may modify the user parameters to ensure better pagination, the
-        user_parameters dict may differ from the one provided as an argument to this function.
+        ParameterizedPaginationQueries namedtuple, describing two new query ASTs that have
+        additional filters stored as PaginationFilters with which the query result size can be
+        controlled. Note that these filters are returned parameterized i.e. values for the filters'
+        parameters have yet to be generated. Additionally, a dict containing user-defined parameters
+        is stored. Since this function may modify the user parameters to ensure better pagination,
+        the user_parameters dict may differ from the one provided as an argument to this function.
     """
     raise NotImplementedError()

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -1,3 +1,4 @@
+# Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
 

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -4,27 +4,37 @@ from collections import namedtuple
 
 RESERVED_PARAMETER_PREFIX = '_paged_'
 
+# ParameterizedPaginationQueries namedtuple, describing two query ASTs that have PaginationFilters
+# describing filters with which the query result size can be controlled. Note that these filters are
+# returned parameterized i.e. values for the filters' parameters have yet to be generated.
+# Additionally, a dict containing user-defined parameters is stored. Since this function may modify
+# the user parameters to ensure better pagination, the user_parameters dict may differ from the
+# original query's parameters that were provided to the paginator.
 ParameterizedPaginationQueries = namedtuple(
     'ParameterizedPaginationQueries',
     (
         'next_page_query',          # Document, AST of query that will return the next page of
                                     # results when hydrated with pagination parameters.
-        'continuation_query',       # Document, AST of query that will return the remainder of
+        'remainder_query',          # Document, AST of query that will return the remainder of
                                     # results when hydrated with pagination parameters.
         'pagination_filters',       # List[PaginationFilter], filters usable for pagination.
         'user_parameters',          # dict, parameters that the user has defined for other filters.
     ),
 )
 
+# PaginationFilter namedtuples document filters usable for pagination purposes within the larger
+# context of a ParameterizedPaginationQueries namedtuple. These filters may either be added by the
+# query parameterizer, or filters that the user has added whose parameter values may be modified for
+# generating paginated queries.
 PaginationFilter = namedtuple(
     'PaginationFilter',
     (
         'vertex_class',                 # str, vertex class to which the property field belongs to.
         'property_field',               # str, name of the property field filtering is done over.
         'next_page_query_filter',       # Directive, filter directive with '<' operator usable
-                                        # for pagination in the next page query.
-        'continuation_query_filter',    # Directive, filter directive with '>=' operator usable
-                                        # for pagination in the continuation query.
+                                        # for pagination in the page query.
+        'remainder_query_filter',       # Directive, filter directive with '>=' operator usable
+                                        # for pagination in the remainder query.
         'related_filters',              # List[Directive], filter directives that share the same
                                         # vertex and property field as the next_page_query_filter,
                                         # and are used to generate more accurate pages.
@@ -47,11 +57,6 @@ def generate_parameterized_queries(schema_graph, statistics, query_ast, paramete
         parameters: dict, list of parameters for the given query.
 
     Returns:
-        ParameterizedPaginationQueries namedtuple, describing two new query ASTs that have
-        additional filters stored as PaginationFilters with which the query result size can be
-        controlled. Note that these filters are returned parameterized i.e. values for the filters'
-        parameters have yet to be generated. Additionally, a dict containing user-defined parameters
-        is stored. Since this function may modify the user parameters to ensure better pagination,
-        the user_parameters dict may differ from the one provided as an argument to this function.
+        ParameterizedPaginationQueries namedtuple
     """
     raise NotImplementedError()

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -4,8 +4,8 @@ from collections import namedtuple
 
 RESERVED_PARAMETER_PREFIX = '_paged_'
 
-ParameterizedPaginationQuery = namedtuple(
-    'ParameterizedPaginationQuery',
+ParameterizedPaginationQueries = namedtuple(
+    'ParameterizedPaginationQueries',
     (
         'next_page_query',          # Document, AST of query that will return the next page of
                                     # results when hydrated with pagination parameters.
@@ -21,12 +21,13 @@ PaginationFilter = namedtuple(
     (
         'vertex_field',                 # str, vertex class to which the property field belongs to.
         'property_field',               # str, name of the property field filtering is done over.
-        'next_page_query_filter',       # Directive, filter usable for pagination in the
-                                        # next page query.
-        'continuation_query_filter',    # Directive, filter usable for pagination in the
-                                        # continuation query.
-        'related_filters',              # List[Directive], filter directives that are on the same
-                                        # vertex and property field.
+        'next_page_query_filter',       # Directive, filter directive with '<' operator usable
+                                        # for pagination in the next page query.
+        'continuation_query_filter',    # Directive, filter directive with '>=' operator usable
+                                        # for pagination in the continuation query.
+        'related_filters',              # List[Directive], filter directives that share the same
+                                        # vertex and property field as the next_page_query_filter,
+                                        # and are used to generate more accurate pages.
     ),
 )
 
@@ -46,7 +47,7 @@ def generate_parameterized_queries(schema_graph, statistics, query_ast, paramete
         parameters: dict, list of parameters for the given query.
 
     Returns:
-        ParameterizedPaginationQuery namedtuple, describing two new query ASTs that have additional
+        ParameterizedPaginationQueries namedtuple, describing two new query ASTs that have additional
         filters stored as PaginationFilters with which the query result size can be controlled.
         Note that these filters are returned parameterized i.e. values for the filters' parameters
         have yet to be generated. Additionally, a dict containing user-defined parameters is stored.

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -1,0 +1,58 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+from collections import namedtuple
+
+from graphql_compiler.query_pagination.parameter_generator import (
+    generate_parameters_for_parameterized_query
+)
+from graphql_compiler.query_pagination.query_parameterizer import generate_parameterized_queries
+from graphql_compiler.query_pagination import ASTWithParameters
+
+
+def split_into_page_query_and_remainder_query(
+    schema_graph, statistics, query_ast, parameters, num_pages
+):
+    """Split a query into two equivalent queries, one of which will return roughly a page of data.
+
+    First, two parameterized queries are generated that contain filters usable for pagination i.e.
+    filters with which the number of results can be constrained. Parameters for these filters are
+    then generated such that one of the new queries will return roughly a page of results, while the
+    other query will generate the rest of the results. This ensures that the two new queries' result
+    data is equivalent to the original query's result data.
+
+    Args:
+        schema_graph: SchemaGraph instance.
+        statistics: Statistics object.
+        query_ast: Document, AST of the GraphQL query that will be split.
+        parameters: dict, parameters with which query will be estimated.
+        num_pages: int, number of pages to split the query into.
+
+    Returns:
+        tuple of (ASTWithParameters namedtuple, ASTWithParameters namedtuple), describing two
+        queries: the first query when executed will return roughly a page of results of the original
+        query; the second query will return the rest of the results of the original query. The union
+        of the two queries' result data is equivalent to the given query and parameter's result
+        data. There are no guarantees on the order of the result rows for the two generated queries.
+    """
+    if num_pages <= 1:
+        raise AssertionError(u'Could not split query {} into pagination queries for the next page'
+                             u' of results, as the number of pages {} must be greater than 1: {}'
+                             .format(query_ast, num_pages, parameters))
+
+    parameterized_queries = generate_parameterized_queries(
+        schema_graph, statistics, query_ast, parameters
+    )
+
+    next_page_parameters, remainder_parameters = generate_parameters_for_parameterized_query(
+        schema_graph, statistics, parameterized_queries, num_pages
+    )
+
+    next_page_ast_with_parameters = ASTWithParameters(
+        parameterized_queries.page_query,
+        next_page_parameters,
+    )
+    remainder_ast_with_parameters = ASTWithParameters(
+        parameterized_queries.remainder_query,
+        remainder_parameters,
+    )
+
+    return next_page_ast_with_parameters, remainder_ast_with_parameters

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -5,7 +5,15 @@ from graphql_compiler.query_pagination.parameter_generator import (
     generate_parameters_for_parameterized_query
 )
 from graphql_compiler.query_pagination.query_parameterizer import generate_parameterized_queries
-from graphql_compiler.query_pagination import ASTWithParameters
+
+
+ASTWithParameters = namedtuple(
+    'ASTWithParameters',
+    (
+        'query_ast',        # Document, AST describing a GraphQL query.
+        'parameters',       # dict, parameters for executing the given query.
+    ),
+)
 
 
 def split_into_page_query_and_remainder_query(

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -3,7 +3,6 @@ import unittest
 
 import pytest
 
-from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.statistics import LocalStatistics
 from ...query_pagination import QueryStringWithParameters, paginate_query
 from ..test_helpers import generate_schema_graph

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -14,12 +14,12 @@ from ..test_helpers import generate_schema_graph
 # pylint: disable=no-member
 @pytest.mark.slow
 class QueryPaginationTests(unittest.TestCase):
-    """Test the cost estimation module using standard input data when possible."""
+    """Test the query pagination module."""
 
     # TODO: These tests can be sped up by having an existing test SchemaGraph object.
     @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_basic_pagination(self):
-        """"Ensure we correctly estimate the cardinality of the query root."""
+        """"Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         test_data = '''{
             Animal {
@@ -36,7 +36,7 @@ class QueryPaginationTests(unittest.TestCase):
         statistics = LocalStatistics(count_data)
 
         # Since query pagination is still a skeleton, we expect a NotImplementedError for this test.
-        # Once query pagination is implemented, the result of this call should be equal to
+        # Once query pagination is fully implemented, the result of this call should be equal to
         # expected_query_list.
         # pylint: disable=unused-variable
         with self.assertRaises(NotImplementedError):

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -5,7 +5,7 @@ import pytest
 
 from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.statistics import LocalStatistics
-from ...query_pagination import paginate_query
+from ...query_pagination import QueryAndParameters, paginate_query
 from ..test_helpers import generate_schema_graph
 
 
@@ -23,12 +23,11 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         test_data = '''{
             Animal {
-                uuid @filter(op_name: ">", value: ["$keva_brat"])
-                name @output(out_name: "animal") @filter(op_name: ">", value: ["$keva_brat"])
+                name @output(out_name: "animal")
             }
         }'''
         test_ast = safe_parse_graphql(test_data)
-        parameters = {'keva_brat': 'keva_kolku_dojde_sat'}
+        parameters = {}
 
         count_data = {
             'Animal': 4,
@@ -36,33 +35,37 @@ class QueryPaginationTests(unittest.TestCase):
 
         statistics = LocalStatistics(count_data)
 
-        paginated_queries = paginate_query(
-            schema_graph, statistics, test_ast, parameters, 1
-        )
+        # Since query pagination is still a skeleton, we expect a NotImplementedError for this test.
+        # Once query pagination is implemented, the result of this call should be equal to
+        # expected_query_list.
+        # pylint: disable=unused-variable
+        with self.assertRaises(NotImplementedError):
+            paginated_queries = paginate_query(                     # noqa: unused-variable
+                schema_graph, statistics, test_ast, parameters, 1
+            )
 
-        expected_query_list = [
-            (
+        expected_query_list = (                                     # noqa: unused-variable
+            QueryAndParameters(
                 '''{
                     Animal {
-                        uuid @filter(op_name: "<", value: ["$_paged_upper_param_on_Animal"])
+                        uuid @filter(op_name: "<", value: ["$_paged_upper_param_on_Animal_uuid"])
                         name @output(out_name: "animal")
                     }
                 }''',
                 {
-                    '_paged_upper_param_on_Animal': '40000000-0000-0000-0000-000000000000',
+                    '_paged_upper_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
                 }
             ),
-            (
+            QueryAndParameters(
                 '''{
                     Animal {
-                        uuid @filter(op_name: ">=", value: ["$_paged_lower_param_on_Animal"])
+                        uuid @filter(op_name: ">=", value: ["$_paged_lower_param_on_Animal_uuid"])
                         name @output(out_name: "animal")
                     }
                 }''',
                 {
-                    '_paged_lower_param_on_Animal': '40000000-0000-0000-0000-000000000000',
+                    '_paged_lower_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
                 }
             )
-        ]
-
-        self.assertEqual(expected_query_list, paginated_queries)
+        )
+        # pylint: enable=unused-variable

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -5,7 +5,7 @@ import pytest
 
 from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.statistics import LocalStatistics
-from ...query_pagination import QueryAndParameters, paginate_query
+from ...query_pagination import PaginationQueries, paginate_query
 from ..test_helpers import generate_schema_graph
 
 
@@ -44,28 +44,24 @@ class QueryPaginationTests(unittest.TestCase):
                 schema_graph, statistics, test_ast, parameters, 1
             )
 
-        expected_query_list = (                                     # noqa: unused-variable
-            QueryAndParameters(
-                '''{
-                    Animal {
-                        uuid @filter(op_name: "<", value: ["$_paged_upper_param_on_Animal_uuid"])
-                        name @output(out_name: "animal")
-                    }
-                }''',
-                {
-                    '_paged_upper_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
+        expected_query_list = PaginationQueries(                    # noqa: unused-variable
+            '''{
+                Animal {
+                    uuid @filter(op_name: "<", value: ["$_paged_upper_param_on_Animal_uuid"])
+                    name @output(out_name: "animal")
                 }
-            ),
-            QueryAndParameters(
-                '''{
-                    Animal {
-                        uuid @filter(op_name: ">=", value: ["$_paged_lower_param_on_Animal_uuid"])
-                        name @output(out_name: "animal")
-                    }
-                }''',
-                {
-                    '_paged_lower_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
+            }''',
+            {
+                '_paged_upper_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
+            },
+            '''{
+                Animal {
+                    uuid @filter(op_name: ">=", value: ["$_paged_lower_param_on_Animal_uuid"])
+                    name @output(out_name: "animal")
                 }
-            )
+            }''',
+            {
+                '_paged_lower_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
+            },
         )
         # pylint: enable=unused-variable

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -5,7 +5,7 @@ import pytest
 
 from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.statistics import LocalStatistics
-from ...query_pagination import PaginationQueries, paginate_query
+from ...query_pagination import QueryStringWithParameters, paginate_query
 from ..test_helpers import generate_schema_graph
 
 
@@ -26,7 +26,6 @@ class QueryPaginationTests(unittest.TestCase):
                 name @output(out_name: "animal")
             }
         }'''
-        test_ast = safe_parse_graphql(test_data)
         parameters = {}
 
         count_data = {
@@ -41,27 +40,31 @@ class QueryPaginationTests(unittest.TestCase):
         # pylint: disable=unused-variable
         with self.assertRaises(NotImplementedError):
             paginated_queries = paginate_query(                     # noqa: unused-variable
-                schema_graph, statistics, test_ast, parameters, 1
+                schema_graph, statistics, test_data, parameters, 1
             )
 
-        expected_query_list = PaginationQueries(                    # noqa: unused-variable
-            '''{
-                Animal {
-                    uuid @filter(op_name: "<", value: ["$_paged_upper_param_on_Animal_uuid"])
-                    name @output(out_name: "animal")
-                }
-            }''',
-            {
-                '_paged_upper_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
-            },
-            '''{
-                Animal {
-                    uuid @filter(op_name: ">=", value: ["$_paged_lower_param_on_Animal_uuid"])
-                    name @output(out_name: "animal")
-                }
-            }''',
-            {
-                '_paged_lower_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
-            },
+        expected_query_list = (                                     # noqa: unused-variable
+            QueryStringWithParameters(
+                '''{
+                    Animal {
+                        uuid @filter(op_name: "<", value: ["$_paged_upper_param_on_Animal_uuid"])
+                        name @output(out_name: "animal")
+                    }
+                }''',
+                {
+                    '_paged_upper_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
+                },
+            ),
+            QueryStringWithParameters(
+                '''{
+                    Animal {
+                        uuid @filter(op_name: ">=", value: ["$_paged_lower_param_on_Animal_uuid"])
+                        name @output(out_name: "animal")
+                    }
+                }''',
+                {
+                    '_paged_lower_param_on_Animal_uuid': '40000000-0000-0000-0000-000000000000',
+                },
+            ),
         )
         # pylint: enable=unused-variable

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1,0 +1,68 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+import unittest
+
+import pytest
+
+from ...ast_manipulation import safe_parse_graphql
+from ...cost_estimation.statistics import LocalStatistics
+from ...query_pagination import paginate_query
+from ..test_helpers import generate_schema_graph
+
+
+# The following TestCase class uses the 'snapshot_orientdb_client' fixture
+# which pylint does not recognize as a class member.
+# pylint: disable=no-member
+@pytest.mark.slow
+class QueryPaginationTests(unittest.TestCase):
+    """Test the cost estimation module using standard input data when possible."""
+
+    # TODO: These tests can be sped up by having an existing test SchemaGraph object.
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
+    def test_basic_pagination(self):
+        """"Ensure we correctly estimate the cardinality of the query root."""
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        test_data = '''{
+            Animal {
+                uuid @filter(op_name: ">", value: ["$keva_brat"])
+                name @output(out_name: "animal") @filter(op_name: ">", value: ["$keva_brat"])
+            }
+        }'''
+        test_ast = safe_parse_graphql(test_data)
+        parameters = {'keva_brat': 'keva_kolku_dojde_sat'}
+
+        count_data = {
+            'Animal': 4,
+        }
+
+        statistics = LocalStatistics(count_data)
+
+        paginated_queries = paginate_query(
+            schema_graph, statistics, test_ast, parameters, 1
+        )
+
+        expected_query_list = [
+            (
+                '''{
+                    Animal {
+                        uuid @filter(op_name: "<", value: ["$_paged_upper_param_on_Animal"])
+                        name @output(out_name: "animal")
+                    }
+                }''',
+                {
+                    '_paged_upper_param_on_Animal': '40000000-0000-0000-0000-000000000000',
+                }
+            ),
+            (
+                '''{
+                    Animal {
+                        uuid @filter(op_name: ">=", value: ["$_paged_lower_param_on_Animal"])
+                        name @output(out_name: "animal")
+                    }
+                }''',
+                {
+                    '_paged_lower_param_on_Animal': '40000000-0000-0000-0000-000000000000',
+                }
+            )
+        ]
+
+        self.assertEqual(expected_query_list, paginated_queries)


### PR DESCRIPTION
Using cost estimation and AST manipulation, we can effectively paginate arbitrary queries. I've created a directory `query_pagination` that has a skeleton for this functionality. 

The user interface is the following: the user calls `paginate_query` with their query, parameters, and relevant information for pagination. We then modify their query and parameters, generating two pairs of query and parameters. These two query/parameters' union is guaranteed to be equivalent to the user's original query, but with a twist: the first query we provide is estimated to return roughly a page of data. The user can then do whatever with these two queries. If they want to generate more than one query, they call `paginate_query` with the latter of the two queries we've provided.

Currently, the design behind pagination is the following:
1. The user provides us with a query and parameters to paginate and desired number of results per page.
2. We discover the number of pages this query will generate using the cost estimator's new function `estimate_number_of_pages`. If there's only one page expected for this query, we just return the user's query.
3. We add (or use the user's!) filters for pagination via `query_pagination/query_parameterizer/generate_parameterized_queries`. Note that the filters we add are not hydrated i.e. they do not have parameter values. We will generate them in the following step.
4. Using the pagination filters from the previous step, statistics, and knowledge about the user's parameters, we generate parameters for the two queries via `query_pagination/parameter_generator/hydrate_parameters_of_parameterized_query`.
5. We now have two queries, and their parameters, and return them to the user.

What's left now: Step 3 and Step 4 are currently not implemented in this PR. I do have working versions of them, so which is why I believe this skeleton works. I'll refine them a bit more, and will launch them in a separate PR.

@ reviewers: I've included a test in `tests/snapshot_tests/test_query_pagination` for the skeleton which may or may not be subject to change.