### PR TITLE
Make non-public function use an underscored name.

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -943,7 +943,7 @@ def _compile_output_step(query_metadata_table):
     return blocks.ConstructResult(output_fields)
 
 
-def validate_schema_and_ast(schema, ast):
+def _validate_schema_and_ast(schema, ast):
     """Validate the supplied graphql schema and ast.
 
     This method wraps around graphql-core's validation to enforce a stricter requirement of the
@@ -1064,7 +1064,7 @@ def ast_to_ir(schema, ast, type_equivalence_hints=None):
 
     In the case of implementation bugs, could also raise ValueError, TypeError, or AssertionError.
     """
-    validation_errors = validate_schema_and_ast(schema, ast)
+    validation_errors = _validate_schema_and_ast(schema, ast)
     if validation_errors:
         raise GraphQLValidationError(u'String does not validate: {}'.format(validation_errors))
 


### PR DESCRIPTION
`validate_schema_and_ast` was not in the `Public API` section of the file, but did not have an underscored name either. Fix the name to make it more obvious that it is not meant to be public.