### PR TITLE
Add type_equivalence_hints to schema_info

### DIFF
--- a/graphql_compiler/schema/sqlalchemy_schema.py
+++ b/graphql_compiler/schema/sqlalchemy_schema.py
@@ -35,6 +35,23 @@ SQLAlchemySchemaInfo = namedtuple('SQLAlchemySchemaInfo', (
     # GraphQLSchema
     'schema',
 
+    # optional dict of GraphQL interface or type -> GraphQL union.
+    # Used as a workaround for GraphQL's lack of support for
+    # inheritance across "types" (i.e. non-interfaces), as well as a
+    # workaround for Gremlin's total lack of inheritance-awareness.
+    # The key-value pairs in the dict specify that the "key" type
+    # is equivalent to the "value" type, i.e. that the GraphQL type or
+    # interface in the key is the most-derived common supertype
+    # of every GraphQL type in the "value" GraphQL union.
+    # Recursive expansion of type equivalence hints is not performed,
+    # and only type-level correctness of this argument is enforced.
+    # See README.md for more details on everything this parameter does.
+    # *****
+    # Be very careful with this option, as bad input here will
+    # lead to incorrect output queries being generated.
+    # *****
+    'type_equivalence_hints',
+
     # sqlalchemy.engine.interfaces.Dialect, specifying the dialect we are compiling for
     # (e.g. sqlalchemy.dialects.mssql.dialect()).
     'dialect',
@@ -51,13 +68,29 @@ SQLAlchemySchemaInfo = namedtuple('SQLAlchemySchemaInfo', (
 ))
 
 
-def make_sqlalchemy_schema_info(schema, dialect, tables, join_descriptors, validate=True):
+def make_sqlalchemy_schema_info(schema, type_equivalence_hints, dialect, tables,
+                                join_descriptors, validate=True):
     """Make a SQLAlchemySchemaInfo if the input provided is valid.
 
     See the documentation of SQLAlchemyschemaInfo for more detailed documentation of the args.
 
     Args:
         schema: GraphQLSchema
+        type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
+                                Used as a workaround for GraphQL's lack of support for
+                                inheritance across "types" (i.e. non-interfaces), as well as a
+                                workaround for Gremlin's total lack of inheritance-awareness.
+                                The key-value pairs in the dict specify that the "key" type
+                                is equivalent to the "value" type, i.e. that the GraphQL type or
+                                interface in the key is the most-derived common supertype
+                                of every GraphQL type in the "value" GraphQL union.
+                                Recursive expansion of type equivalence hints is not performed,
+                                and only type-level correctness of this argument is enforced.
+                                See README.md for more details on everything this parameter does.
+                                *****
+                                Be very careful with this option, as bad input here will
+                                lead to incorrect output queries being generated.
+                                *****
         dialect: sqlalchemy.engine.interfaces.Dialect
         tables: dict mapping every graphql object type or interface type name in the schema to
                 a sqlalchemy table
@@ -106,4 +139,4 @@ def make_sqlalchemy_schema_info(schema, dialect, tables, join_descriptors, valid
                                                      u'for property field {}'
                                                      .format(type_name, field_name))
 
-    return SQLAlchemySchemaInfo(schema, dialect, tables, join_descriptors)
+    return SQLAlchemySchemaInfo(schema, type_equivalence_hints, dialect, tables, join_descriptors)

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -423,10 +423,11 @@ def get_sqlalchemy_schema_info():
         ('Event', 'Union__BirthEvent__Event__FeedingEvent'),
         ('FoodOrSpecies', 'Union__Food__FoodOrSpecies__Species'),
     ]
-    subclasses = compute_subclass_sets(schema, type_equivalence_hints={
+    type_equivalence_hints = {
         schema.get_type(key): schema.get_type(value)
         for key, value in type_equivalence_hint_list
-    })
+    }
+    subclasses = compute_subclass_sets(schema, type_equivalence_hints=type_equivalence_hints)
     for type_name, union_name in type_equivalence_hint_list:
         subclasses[union_name] = subclasses[type_name]
         subclasses[union_name].add(type_name)
@@ -514,7 +515,7 @@ def get_sqlalchemy_schema_info():
                 join_descriptors.setdefault(subclass, {})[edge_name] = join_info
 
     return make_sqlalchemy_schema_info(
-        schema, mssql.dialect(), tables, join_descriptors)
+        schema, type_equivalence_hints, mssql.dialect(), tables, join_descriptors)
 
 
 def generate_schema_graph(orientdb_client):


### PR DESCRIPTION
The `SQLAlchemySchemaInfo` claims to be ` Complete schema information sufficient to compile GraphQL queries to SQLAlchemy`. It is not complete without `type_equivalence_hints`. This will also save a lot of plumbing (we always march the schema and the hints together everywhere).