### PR TITLE
Define backends

### DIFF
--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -1,11 +1,12 @@
-from compiler import (
-    emit_cypher, emit_gremlin, emit_match, emit_sql, ir_lowering_cypher, ir_lowering_gremlin,
+# Copyright 2019-present Kensho Technologies, LLC.
+from collections import namedtuple
+
+from .compiler import (
+    emit_cypher, emit_gremlin, emit_match, ir_lowering_cypher, ir_lowering_gremlin,
     ir_lowering_match, ir_lowering_sql
 )
-from compiler.compiler_frontend import graphql_to_ir
-
-from schema import schema_info
-from tests import test_helpers  # TODO(bojanserafimov): Move these helpers out of test helpers
+from .schema import schema_info
+from .tests import test_helpers  # TODO(bojanserafimov): Move these helpers out of test helpers
 
 
 # A backend is a compilation target (a language we can compile to)
@@ -37,7 +38,7 @@ Backend = namedtuple('Backend', (
 
 
 gremlin_backend = Backend(
-    language='Gremlin'
+    language='Gremlin',
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_gremlin.lower_ir,
     emit_func=emit_gremlin.emit_code_from_ir,
@@ -45,7 +46,7 @@ gremlin_backend = Backend(
 )
 
 match_backend = Backend(
-    language='MATCH'
+    language='MATCH',
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_match.lower_ir,
     emit_func=emit_match.emit_code_from_ir,
@@ -53,7 +54,7 @@ match_backend = Backend(
 )
 
 cypher_backend = Backend(
-    language='Cypher'
+    language='Cypher',
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_cypher.lower_ir,
     emit_func=emit_cypher.emit_code_from_ir,
@@ -62,8 +63,8 @@ cypher_backend = Backend(
 
 sql_backend = Backend(
     language='SQL',
-    schemaInfoClass=schema_info.SqlAlchemySchemaInfo,
+    schemaInfoClass=schema_info.SQLAlchemySchemaInfo,
     lower_func=ir_lowering_sql.lower_ir,
-    emit_func=emit_sql.emit_sql,
+    emit_func=NotImplementedError(),
     compare_queries=test_helpers.compare_sql,
 )

--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -32,15 +32,6 @@ Backend = namedtuple('Backend', (
 
     # An instance of SchemaInfoClass whose schema is the test_schema.
     'test_schema_info',
-
-    # Given a SchemaInfo and a connection pool to a database, modify the database such
-    # that the schema_inspector will be able to reconstruct the same schema.
-    'setup_schema'
-
-    # Given a SchemaInfo, a dict representation of some data, and a connection pool to a
-    # database with the same schema, modify the database such that the data_inspector will
-    # reconstruct the same data.
-    'setup_data'
 ))
 
 
@@ -50,8 +41,6 @@ gremlin_backend = Backend(
     lower_func=ir_lowering_gremlin.lower_ir,
     emit_func=emit_gremlin.emit_code_from_ir,
     test_schema_info=NotImplementedError(),
-    setup_schema=NotImplementedError(),
-    setup_data=NotImplementedError(),
 )
 
 match_backend = Backend(
@@ -60,8 +49,6 @@ match_backend = Backend(
     lower_func=ir_lowering_match.lower_ir,
     emit_func=emit_match.emit_code_from_ir,
     test_schema_info=NotImplementedError(),
-    setup_schema=NotImplementedError(),
-    setup_data=NotImplementedError(),
 )
 
 cypher_backend = Backend(
@@ -70,8 +57,6 @@ cypher_backend = Backend(
     lower_func=ir_lowering_cypher.lower_ir,
     emit_func=emit_cypher.emit_code_from_ir,
     test_schema_info=NotImplementedError(),
-    setup_schema=NotImplementedError(),
-    setup_data=NotImplementedError(),
 )
 
 sql_backend = Backend(
@@ -80,6 +65,4 @@ sql_backend = Backend(
     lower_func=ir_lowering_sql.lower_ir,
     emit_func=emit_sql.emit_sql,
     test_schema_info=get_sqlalchemy_schema_info(),
-    setup_schema=NotImplementedError(),
-    setup_data=NotImplementedError(),
 )

--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -7,6 +7,10 @@ from compiler.compiler_frontend import graphql_to_ir
 from schema import schema_info
 
 
+# A backend is a compilation target (a language we can compile to)
+#
+# This class defines all the necessary and sufficient functionality a backend should implement
+# in order to fit into our generic testing framework.
 Backend = namedtuple('Backend', (
     # String, the internal name of this language.
     'language',

--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -3,7 +3,7 @@ from compiler import (
     ir_lowering_match, ir_lowering_sql
 )
 from compiler.compiler_frontend import graphql_to_ir
-from tests import test_helpers  # TODO Move these helpers out of test helpers
+from tests import test_helpers  # TODO(bojanserafimov): Move these helpers out of test helpers
 
 from schema import schema_info
 

--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -1,0 +1,80 @@
+from compiler import (
+    emit_cypher, emit_gremlin, emit_match, emit_sql, ir_lowering_cypher, ir_lowering_gremlin,
+    ir_lowering_match, ir_lowering_sql
+)
+from compiler.compiler_frontend import graphql_to_ir
+
+from schema import schema_info
+
+
+Backend = namedtuple('Backend', (
+    # String, the internal name of this language.
+    'language',
+
+    # The subclass of SchemaInfo appropriate for this backend.
+    'SchemaInfoClass',
+
+    # Given a SchemaInfoClass and an IR that respects its schema, return a lowered IR with
+    # the same semantics.
+    'lower_func',
+
+    # Given a SchemaInfoClass and a lowered IR that respects its schema, emit a query
+    # in this language with the same semantics.
+    'emit_func',
+
+    # Given a connection pool and a query in this language, run the query with retries
+    # and return the results.
+    'run_func',
+
+    # An instance of SchemaInfoClass whose schema is the test_schema.
+    'test_schema_info',
+
+    # Given a SchemaInfo and a connection pool to a database, modify the database such
+    # that the schema_inspector will be able to reconstruct the same schema.
+    'setup_schema'
+
+    # Given a SchemaInfo, a Data, and a connection pool to a database with the same schema,
+    # modify the database such that the data_inspector will reconstruct the same data.
+    'setup_data'
+))
+
+
+gremlin_backend = Backend(
+    language='Gremlin'
+    schemaInfoClass=schema_info.CommonSchemaInfo,
+    lower_func=ir_lowering_gremlin.lower_ir,
+    emit_func=emit_gremlin.emit_code_from_ir,
+    test_schema_info=NotImplementedError(),
+    setup_schema=NotImplementedError(),
+    setup_data=NotImplementedError(),
+)
+
+match_backend = Backend(
+    language='MATCH'
+    schemaInfoClass=schema_info.CommonSchemaInfo,
+    lower_func=ir_lowering_match.lower_ir,
+    emit_func=emit_match.emit_code_from_ir,
+    test_schema_info=NotImplementedError(),
+    setup_schema=NotImplementedError(),
+    setup_data=NotImplementedError(),
+)
+
+cypher_backend = Backend(
+    language='Cypher'
+    schemaInfoClass=schema_info.CommonSchemaInfo,
+    lower_func=ir_lowering_cypher.lower_ir,
+    emit_func=emit_cypher.emit_code_from_ir,
+    test_schema_info=NotImplementedError(),
+    setup_schema=NotImplementedError(),
+    setup_data=NotImplementedError(),
+)
+
+sql_backend = Backend(
+    language='SQL',
+    schemaInfoClass=schema_info.SqlAlchemySchemaInfo,
+    lower_func=ir_lowering_sql.lower_ir,
+    emit_func=emit_sql.emit_sql,
+    test_schema_info=get_sqlalchemy_schema_info(),
+    setup_schema=NotImplementedError(),
+    setup_data=NotImplementedError(),
+)

--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -3,6 +3,7 @@ from compiler import (
     ir_lowering_match, ir_lowering_sql
 )
 from compiler.compiler_frontend import graphql_to_ir
+from tests import test_helpers  # TODO Move these helpers out of test helpers
 
 from schema import schema_info
 
@@ -30,8 +31,8 @@ Backend = namedtuple('Backend', (
     # and return the results.
     'run_func',
 
-    # An instance of SchemaInfoClass whose schema is the test_schema.
-    'test_schema_info',
+    # Returns whether two emitted queries are the same, up to differences in syntax/whitespace
+    'compare_queries',
 ))
 
 
@@ -40,7 +41,7 @@ gremlin_backend = Backend(
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_gremlin.lower_ir,
     emit_func=emit_gremlin.emit_code_from_ir,
-    test_schema_info=NotImplementedError(),
+    compare_queries=test_helpers.compare_gremlin,
 )
 
 match_backend = Backend(
@@ -48,7 +49,7 @@ match_backend = Backend(
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_match.lower_ir,
     emit_func=emit_match.emit_code_from_ir,
-    test_schema_info=NotImplementedError(),
+    compare_queries=test_helpers.compare_match,
 )
 
 cypher_backend = Backend(
@@ -56,7 +57,7 @@ cypher_backend = Backend(
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_cypher.lower_ir,
     emit_func=emit_cypher.emit_code_from_ir,
-    test_schema_info=NotImplementedError(),
+    compare_queries=test_helpers.compare_cypher,
 )
 
 sql_backend = Backend(
@@ -64,5 +65,5 @@ sql_backend = Backend(
     schemaInfoClass=schema_info.SqlAlchemySchemaInfo,
     lower_func=ir_lowering_sql.lower_ir,
     emit_func=emit_sql.emit_sql,
-    test_schema_info=get_sqlalchemy_schema_info(),
+    compare_queries=test_helpers.compare_sql,
 )

--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -3,9 +3,9 @@ from compiler import (
     ir_lowering_match, ir_lowering_sql
 )
 from compiler.compiler_frontend import graphql_to_ir
-from tests import test_helpers  # TODO(bojanserafimov): Move these helpers out of test helpers
 
 from schema import schema_info
+from tests import test_helpers  # TODO(bojanserafimov): Move these helpers out of test helpers
 
 
 # A backend is a compilation target (a language we can compile to)

--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -37,8 +37,9 @@ Backend = namedtuple('Backend', (
     # that the schema_inspector will be able to reconstruct the same schema.
     'setup_schema'
 
-    # Given a SchemaInfo, a Data, and a connection pool to a database with the same schema,
-    # modify the database such that the data_inspector will reconstruct the same data.
+    # Given a SchemaInfo, a dict representation of some data, and a connection pool to a
+    # database with the same schema, modify the database such that the data_inspector will
+    # reconstruct the same data.
     'setup_data'
 ))
 

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -8,6 +8,30 @@ import sqlalchemy
 from . import is_vertex_field_name
 
 
+# Complete schema information sufficient to compile GraphQL queries for most backends
+CommonSchemaInfo = namedtuple('CommonSchemaInfo', (
+    # GraphQLSchema
+    'schema',
+
+    # optional dict of GraphQL interface or type -> GraphQL union.
+    # Used as a workaround for GraphQL's lack of support for
+    # inheritance across "types" (i.e. non-interfaces), as well as a
+    # workaround for Gremlin's total lack of inheritance-awareness.
+    # The key-value pairs in the dict specify that the "key" type
+    # is equivalent to the "value" type, i.e. that the GraphQL type or
+    # interface in the key is the most-derived common supertype
+    # of every GraphQL type in the "value" GraphQL union.
+    # Recursive expansion of type equivalence hints is not performed,
+    # and only type-level correctness of this argument is enforced.
+    # See README.md for more details on everything this parameter does.
+    # *****
+    # Be very careful with this option, as bad input here will
+    # lead to incorrect output queries being generated.
+    # *****
+    'type_equivalence_hints',
+))
+
+
 # Describes the intent to join two tables using the specified columns.
 #
 # The resulting join expression could be something like:

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -14,7 +14,7 @@ from .. import get_graphql_schema_from_orientdb_schema_data
 from ..compiler.subclass import compute_subclass_sets
 from ..debugging_utils import pretty_print_gremlin, pretty_print_match
 from ..schema import CUSTOM_SCALAR_TYPES, is_vertex_field_name
-from ..schema.sqlalchemy_schema import DirectJoinDescriptor, make_sqlalchemy_schema_info
+from ..schema.schema_info import DirectJoinDescriptor, make_sqlalchemy_schema_info
 from ..schema_generation.orientdb.schema_graph_builder import get_orientdb_schema_graph
 from ..schema_generation.orientdb.utils import (
     ORIENTDB_INDEX_RECORDS_QUERY, ORIENTDB_SCHEMA_RECORDS_QUERY


### PR DESCRIPTION
Standardize the backends so we can write good cross-backend integration tests. This structure has always been present but never explicitly stated. Instead we've gotten away with laborious plumbing, incomplete documentation, and redefinition of the same integration test setup in various query languages (see `_compile_graphql_generic` or `test_data_tools`).