### PR TITLE
Add compare_graphql to test_helpers

### DIFF
--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -9,6 +9,7 @@ import six
 
 from .. import get_graphql_schema_from_orientdb_schema_data
 from ..debugging_utils import pretty_print_gremlin, pretty_print_match
+from ..query_formatting.graphql_formatting import pretty_print_graphql
 from ..schema import CUSTOM_SCALAR_TYPES
 from ..schema_generation.orientdb.schema_graph_builder import get_orientdb_schema_graph
 from ..schema_generation.orientdb.utils import (
@@ -224,6 +225,14 @@ def compare_ir_blocks(test_case, expected_blocks, received_blocks):
         test_case.assertEqual(expected, received,
                               msg=u'Blocks at position {} were different: {} vs {}\n\n'
                                   u'{}'.format(i, expected, received, mismatch_message))
+
+
+def compare_graphql(test_case, expected, received):
+    """Compare the expected and received GraphQL code, ignoring whitespace."""
+    msg = '\n{}\n\n!=\n\n{}'.format(
+        pretty_print_graphql(expected),
+        pretty_print_graphql(received))
+    compare_ignoring_whitespace(test_case, expected, received, msg)
 
 
 def compare_match(test_case, expected, received, parameterized=True):


### PR DESCRIPTION
I've noticed macro_system has a `compare_graphql` function in the `test_helpers` module. This is a really sweet function, that would make testing pagination much easier. 

I basically just cargo-culted it. 