### PR TITLE
Move "compare_*" functions from test_helpers to query_comparison.py

### DIFF
--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -6,7 +6,7 @@ from .compiler import (
     ir_lowering_match, ir_lowering_sql
 )
 from .schema import schema_info
-from .tests import test_helpers  # TODO(bojanserafimov): Move these helpers out of test helpers
+from . import query_comparison
 
 
 # A backend is a compilation target (a language we can compile to)
@@ -42,7 +42,7 @@ gremlin_backend = Backend(
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_gremlin.lower_ir,
     emit_func=emit_gremlin.emit_code_from_ir,
-    compare_queries=test_helpers.compare_gremlin,
+    compare_queries=query_comparison.compare_gremlin,
 )
 
 match_backend = Backend(
@@ -50,7 +50,7 @@ match_backend = Backend(
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_match.lower_ir,
     emit_func=emit_match.emit_code_from_ir,
-    compare_queries=test_helpers.compare_match,
+    compare_queries=query_comparison.compare_match,
 )
 
 cypher_backend = Backend(
@@ -58,7 +58,7 @@ cypher_backend = Backend(
     schemaInfoClass=schema_info.CommonSchemaInfo,
     lower_func=ir_lowering_cypher.lower_ir,
     emit_func=emit_cypher.emit_code_from_ir,
-    compare_queries=test_helpers.compare_cypher,
+    compare_queries=query_comparison.compare_cypher,
 )
 
 sql_backend = Backend(
@@ -66,5 +66,5 @@ sql_backend = Backend(
     schemaInfoClass=schema_info.SQLAlchemySchemaInfo,
     lower_func=ir_lowering_sql.lower_ir,
     emit_func=NotImplementedError(),
-    compare_queries=test_helpers.compare_sql,
+    compare_queries=query_comparison.compare_sql,
 )

--- a/graphql_compiler/backend.py
+++ b/graphql_compiler/backend.py
@@ -1,12 +1,12 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
+from . import query_comparison
 from .compiler import (
     emit_cypher, emit_gremlin, emit_match, ir_lowering_cypher, ir_lowering_gremlin,
     ir_lowering_match, ir_lowering_sql
 )
 from .schema import schema_info
-from . import query_comparison
 
 
 # A backend is a compilation target (a language we can compile to)

--- a/graphql_compiler/query_comparison.py
+++ b/graphql_compiler/query_comparison.py
@@ -1,0 +1,77 @@
+from pprint import pformat
+import re
+import six
+
+from .debugging_utils import pretty_print_gremlin, pretty_print_match
+from .query_formatting.graphql_formatting import pretty_print_graphql
+
+
+def _get_mismatch_message(expected_blocks, received_blocks):
+    """Create a well-formated error message indicating that two lists of blocks are mismatched."""
+    pretty_expected = pformat(expected_blocks)
+    pretty_received = pformat(received_blocks)
+    return u'{}\n\n!=\n\n{}'.format(pretty_expected, pretty_received)
+
+
+def strip_whitespace(emitted_output):
+    """Transform emitted_output into a unique representation, regardless of lines / indentation."""
+    # The strings which we will be comparing have newlines and spaces we'd like to get rid of,
+    # so we can compare expected and produced emitted code irrespective of whitespace.
+    WHITESPACE_PATTERN = re.compile(u'[\t\n ]*', flags=re.UNICODE)
+    return WHITESPACE_PATTERN.sub(u'', emitted_output)
+
+
+def compare_ignoring_whitespace(test_case, expected, received, msg):
+    """Compare expected and received code, ignoring whitespace, with the given failure message."""
+    test_case.assertEqual(strip_whitespace(expected), strip_whitespace(received), msg=msg)
+
+
+def compare_ir_blocks(test_case, expected_blocks, received_blocks):
+    """Compare the expected and received IR blocks."""
+    mismatch_message = _get_mismatch_message(expected_blocks, received_blocks)
+
+    if len(expected_blocks) != len(received_blocks):
+        test_case.fail(u'Not the same number of blocks:\n\n'
+                       u'{}'.format(mismatch_message))
+
+    for i in six.moves.xrange(len(expected_blocks)):
+        expected = expected_blocks[i]
+        received = received_blocks[i]
+        test_case.assertEqual(expected, received,
+                              msg=u'Blocks at position {} were different: {} vs {}\n\n'
+                                  u'{}'.format(i, expected, received, mismatch_message))
+
+def compare_graphql(test_case, expected, received):
+    """Compare the expected and received GraphQL code, ignoring whitespace."""
+    msg = '\n{}\n\n!=\n\n{}'.format(
+        pretty_print_graphql(expected),
+        pretty_print_graphql(received))
+    compare_ignoring_whitespace(test_case, expected, received, msg)
+
+
+def compare_match(test_case, expected, received, parameterized=True):
+    """Compare the expected and received MATCH code, ignoring whitespace."""
+    msg = '\n{}\n\n!=\n\n{}'.format(
+        pretty_print_match(expected, parameterized=parameterized),
+        pretty_print_match(received, parameterized=parameterized))
+    compare_ignoring_whitespace(test_case, expected, received, msg)
+
+
+def compare_sql(test_case, expected, received):
+    """Compare the expected and received SQL query, ignoring whitespace."""
+    msg = '\n{}\n\n!=\n\n{}'.format(expected, received)
+    compare_ignoring_whitespace(test_case, expected, received, msg)
+
+
+def compare_gremlin(test_case, expected, received):
+    """Compare the expected and received Gremlin code, ignoring whitespace."""
+    msg = '\n{}\n\n!=\n\n{}'.format(
+        pretty_print_gremlin(expected),
+        pretty_print_gremlin(received))
+    compare_ignoring_whitespace(test_case, expected, received, msg)
+
+
+def compare_cypher(test_case, expected, received):
+    """Compare the expected and received Cypher query, ignoring whitespace."""
+    msg = '\n{}\n\n!=\n\n{}'.format(expected, received)
+    compare_ignoring_whitespace(test_case, expected, received, msg)

--- a/graphql_compiler/query_comparison.py
+++ b/graphql_compiler/query_comparison.py
@@ -1,5 +1,6 @@
 from pprint import pformat
 import re
+
 import six
 
 from .debugging_utils import pretty_print_gremlin, pretty_print_match
@@ -40,6 +41,7 @@ def compare_ir_blocks(test_case, expected_blocks, received_blocks):
         test_case.assertEqual(expected, received,
                               msg=u'Blocks at position {} were different: {} vs {}\n\n'
                                   u'{}'.format(i, expected, received, mismatch_message))
+
 
 def compare_graphql(test_case, expected, received):
     """Compare the expected and received GraphQL code, ignoring whitespace."""

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -11,7 +11,8 @@ import pytest
 from ...schema_generation.orientdb.schema_properties import ORIENTDB_BASE_VERTEX_CLASS_NAME
 from ...tests import test_backend
 from ...tests.test_helpers import generate_schema, generate_schema_graph
-from ..test_helpers import SCHEMA_TEXT, compare_ignoring_whitespace, get_schema
+from ..test_helpers import SCHEMA_TEXT, get_schema
+from ...query_comparison import compare_ignoring_whitespace
 from .integration_backend_config import (
     MATCH_BACKENDS, NEO4J_BACKENDS, REDISGRAPH_BACKENDS, SQL_BACKENDS
 )

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -8,11 +8,11 @@ from graphql.utils.schema_printer import print_schema
 from parameterized import parameterized
 import pytest
 
+from ...query_comparison import compare_ignoring_whitespace
 from ...schema_generation.orientdb.schema_properties import ORIENTDB_BASE_VERTEX_CLASS_NAME
 from ...tests import test_backend
 from ...tests.test_helpers import generate_schema, generate_schema_graph
 from ..test_helpers import SCHEMA_TEXT, get_schema
-from ...query_comparison import compare_ignoring_whitespace
 from .integration_backend_config import (
     MATCH_BACKENDS, NEO4J_BACKENDS, REDISGRAPH_BACKENDS, SQL_BACKENDS
 )

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -13,9 +13,9 @@ from ..compiler import (
     compile_graphql_to_sql
 )
 from ..compiler.ir_lowering_sql.metadata import SqlMetadata
-from .test_data_tools.data_tool import get_animal_schema_sql_metadata
-from .test_helpers import (SKIP_TEST,  compare_input_metadata, get_schema)
 from ..query_comparison import compare_cypher, compare_gremlin, compare_match, compare_sql
+from .test_data_tools.data_tool import get_animal_schema_sql_metadata
+from .test_helpers import SKIP_TEST, compare_input_metadata, get_schema
 
 
 def check_test_data(

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -14,10 +14,8 @@ from ..compiler import (
 )
 from ..compiler.ir_lowering_sql.metadata import SqlMetadata
 from .test_data_tools.data_tool import get_animal_schema_sql_metadata
-from .test_helpers import (
-    SKIP_TEST, compare_cypher, compare_gremlin, compare_input_metadata, compare_match, compare_sql,
-    get_schema
-)
+from .test_helpers import (SKIP_TEST,  compare_input_metadata, get_schema)
+from ..query_comparison import compare_cypher, compare_gremlin, compare_match, compare_sql
 
 
 def check_test_data(

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -19,7 +19,8 @@ from ..compiler.ir_lowering_match.utils import CompoundMatchQuery
 from ..compiler.match_query import convert_to_match_query
 from ..compiler.metadata import LocationInfo, QueryMetadataTable
 from ..schema import GraphQLDateTime
-from .test_helpers import compare_cypher, compare_gremlin, compare_match, get_schema
+from .test_helpers import get_schema
+from ..query_comparison import compare_cypher, compare_gremlin, compare_match
 
 
 class EmitMatchTests(unittest.TestCase):

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -18,9 +18,9 @@ from ..compiler.ir_lowering_common.common import OutputContextVertex
 from ..compiler.ir_lowering_match.utils import CompoundMatchQuery
 from ..compiler.match_query import convert_to_match_query
 from ..compiler.metadata import LocationInfo, QueryMetadataTable
+from ..query_comparison import compare_cypher, compare_gremlin, compare_match
 from ..schema import GraphQLDateTime
 from .test_helpers import get_schema
-from ..query_comparison import compare_cypher, compare_gremlin, compare_match
 
 
 class EmitMatchTests(unittest.TestCase):

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -11,11 +11,11 @@ import pytz
 from .. import graphql_to_gremlin, graphql_to_match
 from ..compiler import compile_graphql_to_gremlin, compile_graphql_to_match
 from ..exceptions import GraphQLInvalidArgumentError
+from ..query_comparison import compare_gremlin, compare_match
 from ..query_formatting import insert_arguments_into_query
 from ..query_formatting.common import validate_argument_type
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .test_helpers import get_schema
-from ..query_comparison import compare_gremlin, compare_match
 
 
 EXAMPLE_GRAPHQL_QUERY = '''{

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -14,7 +14,8 @@ from ..exceptions import GraphQLInvalidArgumentError
 from ..query_formatting import insert_arguments_into_query
 from ..query_formatting.common import validate_argument_type
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
-from .test_helpers import compare_gremlin, compare_match, get_schema
+from .test_helpers import get_schema
+from ..query_comparison import compare_gremlin, compare_match
 
 
 EXAMPLE_GRAPHQL_QUERY = '''{

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -9,8 +9,6 @@ from sqlalchemy.dialects import mssql
 
 from .. import get_graphql_schema_from_orientdb_schema_data
 from ..compiler.subclass import compute_subclass_sets
-from ..debugging_utils import pretty_print_gremlin, pretty_print_match
-from ..query_formatting.graphql_formatting import pretty_print_graphql
 from ..schema import CUSTOM_SCALAR_TYPES, is_vertex_field_name
 from ..schema.schema_info import DirectJoinDescriptor, make_sqlalchemy_schema_info
 from ..schema_generation.orientdb.schema_graph_builder import get_orientdb_schema_graph
@@ -209,6 +207,7 @@ def compare_input_metadata(test_case, expected, received):
 
         test_case.assertTrue(expected_value.is_same_type(received_value),
                              msg=u'{} != {}'.format(str(expected_value), str(received_value)))
+
 
 def get_schema():
     """Get a schema object for testing."""

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -1,8 +1,5 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Common test data and helper functions."""
-from pprint import pformat
-import re
-
 from graphql import GraphQLList, parse
 from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType
 from graphql.utils.build_ast_schema import build_ast_schema
@@ -22,10 +19,6 @@ from ..schema_generation.orientdb.utils import (
 )
 from ..schema_generation.utils import amend_custom_scalar_types
 
-
-# The strings which we will be comparing have newlines and spaces we'd like to get rid of,
-# so we can compare expected and produced emitted code irrespective of whitespace.
-WHITESPACE_PATTERN = re.compile(u'[\t\n ]*', flags=re.UNICODE)
 
 # flag to indicate a test component should be skipped
 SKIP_TEST = 'SKIP'
@@ -204,70 +197,6 @@ SCHEMA_TEXT = '''
 '''
 
 
-def transform(emitted_output):
-    """Transform emitted_output into a unique representation, regardless of lines / indentation."""
-    return WHITESPACE_PATTERN.sub(u'', emitted_output)
-
-
-def _get_mismatch_message(expected_blocks, received_blocks):
-    """Create a well-formated error message indicating that two lists of blocks are mismatched."""
-    pretty_expected = pformat(expected_blocks)
-    pretty_received = pformat(received_blocks)
-    return u'{}\n\n!=\n\n{}'.format(pretty_expected, pretty_received)
-
-
-def compare_ir_blocks(test_case, expected_blocks, received_blocks):
-    """Compare the expected and received IR blocks."""
-    mismatch_message = _get_mismatch_message(expected_blocks, received_blocks)
-
-    if len(expected_blocks) != len(received_blocks):
-        test_case.fail(u'Not the same number of blocks:\n\n'
-                       u'{}'.format(mismatch_message))
-
-    for i in six.moves.xrange(len(expected_blocks)):
-        expected = expected_blocks[i]
-        received = received_blocks[i]
-        test_case.assertEqual(expected, received,
-                              msg=u'Blocks at position {} were different: {} vs {}\n\n'
-                                  u'{}'.format(i, expected, received, mismatch_message))
-
-
-def compare_graphql(test_case, expected, received):
-    """Compare the expected and received GraphQL code, ignoring whitespace."""
-    msg = '\n{}\n\n!=\n\n{}'.format(
-        pretty_print_graphql(expected),
-        pretty_print_graphql(received))
-    compare_ignoring_whitespace(test_case, expected, received, msg)
-
-
-def compare_match(test_case, expected, received, parameterized=True):
-    """Compare the expected and received MATCH code, ignoring whitespace."""
-    msg = '\n{}\n\n!=\n\n{}'.format(
-        pretty_print_match(expected, parameterized=parameterized),
-        pretty_print_match(received, parameterized=parameterized))
-    compare_ignoring_whitespace(test_case, expected, received, msg)
-
-
-def compare_sql(test_case, expected, received):
-    """Compare the expected and received SQL query, ignoring whitespace."""
-    msg = '\n{}\n\n!=\n\n{}'.format(expected, received)
-    compare_ignoring_whitespace(test_case, expected, received, msg)
-
-
-def compare_gremlin(test_case, expected, received):
-    """Compare the expected and received Gremlin code, ignoring whitespace."""
-    msg = '\n{}\n\n!=\n\n{}'.format(
-        pretty_print_gremlin(expected),
-        pretty_print_gremlin(received))
-    compare_ignoring_whitespace(test_case, expected, received, msg)
-
-
-def compare_cypher(test_case, expected, received):
-    """Compare the expected and received Cypher query, ignoring whitespace."""
-    msg = '\n{}\n\n!=\n\n{}'.format(expected, received)
-    compare_ignoring_whitespace(test_case, expected, received, msg)
-
-
 def compare_input_metadata(test_case, expected, received):
     """Compare two dicts of input metadata, using proper GraphQL type comparison operators."""
     # First, assert that the sets of keys in both dicts are equal.
@@ -280,12 +209,6 @@ def compare_input_metadata(test_case, expected, received):
 
         test_case.assertTrue(expected_value.is_same_type(received_value),
                              msg=u'{} != {}'.format(str(expected_value), str(received_value)))
-
-
-def compare_ignoring_whitespace(test_case, expected, received, msg):
-    """Compare expected and received code, ignoring whitespace, with the given failure message."""
-    test_case.assertEqual(transform(expected), transform(received), msg=msg)
-
 
 def get_schema():
     """Get a schema object for testing."""

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -8,7 +8,8 @@ from . import test_input_data
 from ..compiler import blocks, expressions, helpers
 from ..compiler.compiler_frontend import OutputMetadata, graphql_to_ir
 from ..schema import COUNT_META_FIELD_NAME, GraphQLDate, GraphQLDateTime, GraphQLDecimal
-from .test_helpers import compare_input_metadata, compare_ir_blocks, get_schema
+from .test_helpers import compare_input_metadata, get_schema
+from ..query_comparison import compare_ir_blocks
 
 
 def check_test_data(test_case, test_data, expected_blocks, expected_location_types):

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -7,9 +7,9 @@ import six
 from . import test_input_data
 from ..compiler import blocks, expressions, helpers
 from ..compiler.compiler_frontend import OutputMetadata, graphql_to_ir
+from ..query_comparison import compare_ir_blocks
 from ..schema import COUNT_META_FIELD_NAME, GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .test_helpers import compare_input_metadata, get_schema
-from ..query_comparison import compare_ir_blocks
 
 
 def check_test_data(test_case, test_data, expected_blocks, expected_location_types):

--- a/graphql_compiler/tests/test_ir_lowering.py
+++ b/graphql_compiler/tests/test_ir_lowering.py
@@ -20,9 +20,9 @@ from ..compiler.ir_lowering_common.common import (
 from ..compiler.ir_lowering_match.utils import BetweenClause, CompoundMatchQuery
 from ..compiler.match_query import MatchQuery, convert_to_match_query
 from ..compiler.metadata import LocationInfo, QueryMetadataTable
+from ..query_comparison import compare_ir_blocks
 from ..schema import GraphQLDate, GraphQLDateTime
 from .test_helpers import get_schema
-from ..query_comparison import compare_ir_blocks
 
 
 def check_test_data(test_case, expected_object, received_object):

--- a/graphql_compiler/tests/test_ir_lowering.py
+++ b/graphql_compiler/tests/test_ir_lowering.py
@@ -21,7 +21,8 @@ from ..compiler.ir_lowering_match.utils import BetweenClause, CompoundMatchQuery
 from ..compiler.match_query import MatchQuery, convert_to_match_query
 from ..compiler.metadata import LocationInfo, QueryMetadataTable
 from ..schema import GraphQLDate, GraphQLDateTime
-from .test_helpers import compare_ir_blocks, get_schema
+from .test_helpers import get_schema
+from ..query_comparison import compare_ir_blocks
 
 
 def check_test_data(test_case, expected_object, received_object):


### PR DESCRIPTION
Just organizing code into modules with meaningful names and making it easier to avoid circular imports (we shouldn't be importing `test_helpers` from outside tests).