### PR TITLE
Refactor MacroEdgeDescriptor to capture all of its info. Add more helpers.

### DIFF
--- a/graphql_compiler/macros/macro_edge/__init__.py
+++ b/graphql_compiler/macros/macro_edge/__init__.py
@@ -4,12 +4,15 @@ from ...exceptions import GraphQLInvalidMacroError
 from .validation import get_and_validate_macro_edge_info
 
 
-def make_macro_edge_descriptor(schema, macro_edge_graphql, macro_edge_args,
+def make_macro_edge_descriptor(schema, subclass_sets, macro_edge_graphql, macro_edge_args,
                                type_equivalence_hints=None):
-    """Validate the GraphQL macro edge definition, and return it in a form suitable for storage.
+    """Validate the GraphQL macro edge definition, and return a MacroEdgeDescriptor describing it.
 
     Args:
         schema: GraphQL schema object, created using the GraphQL library
+        subclass_sets: Dict[str, Set[str]] mapping class names to the set of its subclass names.
+                       A class in this context means the name of a GraphQLObjectType,
+                       GraphQLUnionType or GraphQLInterface.
         macro_edge_graphql: string, GraphQL defining how the new macro edge should be expanded
         macro_edge_args: dict mapping strings to any type, containing any arguments the macro edge
                          requires in order to function.
@@ -30,15 +33,14 @@ def make_macro_edge_descriptor(schema, macro_edge_graphql, macro_edge_args,
                                 *****
 
     Returns:
-        tuple (class name, macro edge name, MacroEdgeDescriptor) suitable for inclusion into the
-        GraphQL macro registry
+        MacroEdgeDescriptor suitable for inclusion into the GraphQL macro registry
     """
     root_ast = safe_parse_graphql(macro_edge_graphql)
 
     definition_ast = get_only_query_definition(root_ast, GraphQLInvalidMacroError)
 
-    class_name, macro_edge_name, macro_edge_descriptor = get_and_validate_macro_edge_info(
-        schema, definition_ast, macro_edge_args,
+    macro_edge_descriptor = get_and_validate_macro_edge_info(
+        schema, subclass_sets, definition_ast, macro_edge_args,
         type_equivalence_hints=type_equivalence_hints)
 
-    return class_name, macro_edge_name, macro_edge_descriptor
+    return macro_edge_descriptor

--- a/graphql_compiler/macros/macro_edge/ast_rewriting.py
+++ b/graphql_compiler/macros/macro_edge/ast_rewriting.py
@@ -1,13 +1,18 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 """Helpers for rewriting GraphQL AST objects using structural sharing."""
 from copy import copy
+from itertools import chain
 
 from graphql.language.ast import (
     Argument, Field, InlineFragment, ListValue, Name, OperationDefinition, SelectionSet,
     StringValue
 )
+import six
 
-from ...compiler.helpers import get_parameter_name, is_tagged_parameter
+from ...compiler.helpers import (
+    get_parameter_name, get_uniquely_named_objects_by_name, is_tagged_parameter
+)
+from ...exceptions import GraphQLCompilationError
 from ...schema import FilterDirective, TagDirective
 from ..macro_edge.directives import MacroEdgeTargetDirective
 
@@ -325,3 +330,95 @@ def find_target_and_copy_path_to_it(ast):
         new_ast = copy(ast)
         new_ast.selection_set = SelectionSet(new_selections)
         return new_ast, target_ast
+
+
+def merge_selection_sets(selection_set_a, selection_set_b):
+    """Merge selection sets, merging directives on name conflict.
+
+    Create a selection set that contains the selections of both inputs. If there is a name
+    collision on a property field, we take the directives from both inputs on that field and
+    merge them. We disallow name collision on a vertex field.
+
+    The value None represents an empty SelectionSet.
+
+    The order of selections in the resulting SelectionSet has the following properties:
+    - property fields are before vertex fields.
+    - property fields in selection_set_b come later than other property fields.
+    - vertex fields in selection_set_b come later than other vertex fields.
+    - ties are resolved by respecting the ordering of fields in the input arguments.
+
+    Args:
+        selection_set_a: SelectionSet or None to be merged with the other
+        selection_set_b: SelectionSet or None to be merged with the other
+
+    Returns:
+        SelectionSet or None with contents from both input selection sets
+    """
+    if selection_set_a is None:
+        return selection_set_b
+    if selection_set_b is None:
+        return selection_set_a
+
+    # Convert to dict
+    selection_dict_a = get_uniquely_named_objects_by_name(selection_set_a.selections)
+    selection_dict_b = get_uniquely_named_objects_by_name(selection_set_b.selections)
+
+    # Compute intersection by name
+    common_selection_dict = dict()
+    common_fields = set(selection_dict_a.keys()) & set(selection_dict_b.keys())
+    for field_name in common_fields:
+        field_a = selection_dict_a[field_name]
+        field_b = selection_dict_b[field_name]
+        if field_a.selection_set is not None or field_b.selection_set is not None:
+            raise GraphQLCompilationError(u'Macro edge expansion results in a query traversing the '
+                                          u'same edge {} twice, which is disallowed.'
+                                          .format(field_name))
+
+        merged_field = copy(field_a)
+        merged_field.directives = list(chain(field_a.directives, field_b.directives))
+        common_selection_dict[field_name] = merged_field
+
+    # Merge dicts, using common_selection_dict for keys present in both selection sets.
+    merged_selection_dict = copy(selection_dict_a)
+    merged_selection_dict.update(selection_dict_b)
+    merged_selection_dict.update(common_selection_dict)  # Overwrite keys in the intersection.
+
+    # The macro or the user code could have an unused (pro-forma) field for the sake of not
+    # having an empty selection in a vertex field. We remove pro-forma fields if they are
+    # no longer necessary.
+    if len(merged_selection_dict) > 1:  # Otherwise we need a pro-forma field
+        non_pro_forma_fields = {
+            name: ast
+            for name, ast in six.iteritems(merged_selection_dict)
+            if ast.selection_set is not None or len(ast.directives) > 0
+            # If there's selections or directives under the field, it is not pro-forma.
+        }
+        if non_pro_forma_fields:
+            merged_selection_dict = non_pro_forma_fields
+        else:
+            # There's multiple pro-forma fields. Pick one of them (the one with smallest name).
+            lexicographically_first_name = min(merged_selection_dict.keys())
+            merged_selection_dict = {
+                lexicographically_first_name: merged_selection_dict[lexicographically_first_name]
+            }
+
+    # Get a deterministic ordering of the merged selections
+    selection_name_order = list(chain((
+        ast.name.value
+        for ast in selection_set_a.selections
+        if ast.name.value not in selection_dict_b
+    ), (
+        ast.name.value
+        for ast in selection_set_b.selections
+    )))
+
+    # Make sure that all property fields come before all vertex fields. Note that sort is stable.
+    merged_selections = [
+        merged_selection_dict[name]
+        for name in selection_name_order
+        if name in merged_selection_dict
+    ]
+    return SelectionSet(sorted(
+        merged_selections,
+        key=lambda ast: ast.selection_set is not None
+    ))

--- a/graphql_compiler/macros/macro_edge/descriptor.py
+++ b/graphql_compiler/macros/macro_edge/descriptor.py
@@ -1,23 +1,32 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
+from ...schema import is_vertex_field_name
 from .ast_rewriting import remove_directives_from_ast
 from .directives import MacroEdgeDefinitionDirective
 
 
 MacroEdgeDescriptor = namedtuple(
     'MacroEdgeDescriptor', (
-        'expansion_ast',  # GraphQL AST object defining how the macro edge
-                          # should be expanded starting from its base type. The
-                          # selections must be merged (on both endpoints of the
-                          # macro edge) with the user-supplied GraphQL input.
-        'macro_args',     # Dict[str, Any] containing any arguments required by the macro
+        'base_class_name',  # str, name of GraphQL type where the macro edge is defined.
+                            # The macro edge exists at this type and all of its subtypes.
+        'macro_edge_name',  # str, name of the vertex field corresponding to this macro edge.
+                            # Should start with "out_" or "in_", per GraphQL compiler convention.
+        'expansion_ast',    # GraphQL AST object defining how the macro edge
+                            # should be expanded starting from its base type. The
+                            # selections must be merged (on both endpoints of the
+                            # macro edge) with the user-supplied GraphQL input.
+        'macro_args',       # Dict[str, Any] containing any arguments required by the macro
     )
 )
 
 
-def create_descriptor_from_ast_and_args(macro_definition_ast, macro_edge_args):
+def create_descriptor_from_ast_and_args(class_name, macro_edge_name,
+                                        macro_definition_ast, macro_edge_args):
     """Remove macro edge definition directive, and return a MacroEdgeDescriptor."""
+    if not is_vertex_field_name(macro_edge_name):
+        raise AssertionError(u'Received illegal macro edge name: {}'.format(macro_edge_name))
+
     directives_to_remove = {MacroEdgeDefinitionDirective}
     new_ast = remove_directives_from_ast(macro_definition_ast, directives_to_remove)
-    return MacroEdgeDescriptor(new_ast, macro_edge_args)
+    return MacroEdgeDescriptor(class_name, macro_edge_name, new_ast, macro_edge_args)


### PR DESCRIPTION
Two changes to look out for:
- MacroEdgeDescriptor now carries the base class name and macro edge name of its definition. This is to avoid continuously recomputing them from the expansion AST, as we were doing during expansion and validation.
- subclass_sets is now a required argument for the functions that make use of it. We will allow users to pass it explicitly when building a macro registry, but if they do not do so then we will build it for them from the schema and type equivalence hints. This will eliminate the pervasive "if subclass_sets is not None" checks that were throughout the code, where if this argument wasn't defined we'd just pretend that all types are only subclasses of themselves anyway.