### PR TITLE
Add fold in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -551,9 +551,9 @@ whose names contain the substring :code:`substr`:
 .. code::
 
     {
-        Animal @fold {
+        Animal {
             name @output(out_name: "animal_name")
-            out_Animal_ParentOf {
+            out_Animal_ParentOf @fold {
                 _x_count @filter(op_name: ">=", value: ["$count"])
                 name @filter(op_name: "has_substring", value: ["$substr"])
             }

--- a/README.rst
+++ b/README.rst
@@ -551,7 +551,7 @@ whose names contain the substring :code:`substr`:
 .. code::
 
     {
-        Animal {
+        Animal @fold {
             name @output(out_name: "animal_name")
             out_Animal_ParentOf {
                 _x_count @filter(op_name: ">=", value: ["$count"])

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -460,6 +460,12 @@ def get_sqlalchemy_schema_info():
             sqlalchemy.Column('limbs', sqlalchemy.Integer, nullable=False),
             schema='db_1.schema_1'
         ),
+        'UniquelyIdentifiable': sqlalchemy.Table(
+            'UniquelyIdentifiable',
+            sqlalchemy_metadata_1,
+            sqlalchemy.Column('uuid', uuid_type, primary_key=True),
+            schema='db_1.schema_1'
+        ),
     }
 
     # Compute the subclass sets, including union types
@@ -551,7 +557,7 @@ def get_sqlalchemy_schema_info():
                 join_descriptors.setdefault(subclass, {})[edge_name] = join_info
 
     return make_sqlalchemy_schema_info(
-        schema, type_equivalence_hints, mssql.dialect(), tables, join_descriptors, validate=False)
+        schema, type_equivalence_hints, mssql.dialect(), tables, join_descriptors)
 
 
 def generate_schema_graph(orientdb_client):

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -460,12 +460,6 @@ def get_sqlalchemy_schema_info():
             sqlalchemy.Column('limbs', sqlalchemy.Integer, nullable=False),
             schema='db_1.schema_1'
         ),
-        'UniquelyIdentifiable': sqlalchemy.Table(
-            'UniquelyIdentifiable',
-            sqlalchemy_metadata_1,
-            sqlalchemy.Column('uuid', uuid_type, primary_key=True),
-            schema='db_1.schema_1'
-        ),
     }
 
     # Compute the subclass sets, including union types
@@ -557,7 +551,7 @@ def get_sqlalchemy_schema_info():
                 join_descriptors.setdefault(subclass, {})[edge_name] = join_info
 
     return make_sqlalchemy_schema_info(
-        schema, type_equivalence_hints, mssql.dialect(), tables, join_descriptors)
+        schema, type_equivalence_hints, mssql.dialect(), tables, join_descriptors, validate=False)
 
 
 def generate_schema_graph(orientdb_client):


### PR DESCRIPTION
The example is mentioning a `@fold` directive that's not in the query.

While we're talking about the `@fold` documentation, there's something else we should clarify: If I filter on `name` inside a fold scope, and there are no matches, do i get an empty list, or does the row get removed? The documentation leads me to believe the row is removed, but I'm not sure that makes sense.