### PR TITLE
Make parameters optional in get_graphql_schema_from_schema_graph

### DIFF
--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -167,11 +167,6 @@ def get_graphql_schema_from_orientdb_schema_data(schema_data, class_to_field_typ
         tuple of (GraphQL schema object, GraphQL type equivalence hints dict).
         The tuple is of type (GraphQLSchema, {GraphQLObjectType -> GraphQLUnionType}).
     """
-    if class_to_field_type_overrides is None:
-        class_to_field_type_overrides = dict()
-    if hidden_classes is None:
-        hidden_classes = set()
-
     schema_graph = get_orientdb_schema_graph(schema_data, [])
     return get_graphql_schema_from_schema_graph(schema_graph, class_to_field_type_overrides,
                                                 hidden_classes)

--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -168,8 +168,9 @@ def get_graphql_schema_from_orientdb_schema_data(schema_data, class_to_field_typ
         The tuple is of type (GraphQLSchema, {GraphQLObjectType -> GraphQLUnionType}).
     """
     schema_graph = get_orientdb_schema_graph(schema_data, [])
-    return get_graphql_schema_from_schema_graph(schema_graph, class_to_field_type_overrides,
-                                                hidden_classes)
+    return get_graphql_schema_from_schema_graph(
+        schema_graph, class_to_field_type_overrides=class_to_field_type_overrides,
+        hidden_classes=hidden_classes)
 
 
 def graphql_to_redisgraph_cypher(schema, graphql_query, parameters, type_equivalence_hints=None):

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -339,15 +339,7 @@ def estimate_query_result_cardinality(
         float, expected query result cardinality. Equal to the number of root vertices multiplied by
         the expected number of result sets per full expansion of a root vertex.
     """
-    if class_to_field_type_overrides is None:
-        class_to_field_type_overrides = dict()
-    if hidden_classes is None:
-        hidden_classes = set()
-
-    graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(
-        schema_graph, class_to_field_type_overrides=class_to_field_type_overrides,
-        hidden_classes=hidden_classes
-    )
+    graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
     query_metadata = graphql_to_ir(
         graphql_schema, graphql_query, type_equivalence_hints=type_equivalence_hints
     ).query_metadata_table

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -345,7 +345,8 @@ def estimate_query_result_cardinality(
         hidden_classes = set()
 
     graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(
-        schema_graph, class_to_field_type_overrides, hidden_classes
+        schema_graph, class_to_field_type_overrides=class_to_field_type_overrides,
+        hidden_classes=hidden_classes
     )
     query_metadata = graphql_to_ir(
         graphql_schema, graphql_query, type_equivalence_hints=type_equivalence_hints

--- a/graphql_compiler/schema_generation/graphql_schema.py
+++ b/graphql_compiler/schema_generation/graphql_schema.py
@@ -226,16 +226,21 @@ def get_graphql_schema_from_schema_graph(schema_graph, class_to_field_type_overr
 
     Args:
         schema_graph: SchemaGraph
-        class_to_field_type_overrides: dict, class name -> {field name -> field type},
+        class_to_field_type_overrides: optional dict, class name -> {field name -> field type},
                                        (string -> {string -> GraphQLType}). Used to override the
                                        type of a field in the class where it's first defined and all
                                        the class's subclasses.
-        hidden_classes: set of strings, classes to not include in the GraphQL schema.
+        hidden_classes: optional set of strings, classes to not include in the GraphQL schema.
 
     Returns:
         tuple of (GraphQL schema object, GraphQL type equivalence hints dict).
         The tuple is of type (GraphQLSchema, {GraphQLObjectType -> GraphQLUnionType}).
     """
+    if class_to_field_type_overrides is None:
+        class_to_field_type_overrides = dict()
+    if hidden_classes is None:
+        hidden_classes = set()
+
     _validate_overriden_fields_are_not_defined_in_superclasses(class_to_field_type_overrides,
                                                                schema_graph)
 

--- a/graphql_compiler/schema_generation/graphql_schema.py
+++ b/graphql_compiler/schema_generation/graphql_schema.py
@@ -220,8 +220,8 @@ def _create_union_types_specification(schema_graph, graphql_types, hidden_classe
     return types_spec
 
 
-def get_graphql_schema_from_schema_graph(schema_graph, class_to_field_type_overrides,
-                                         hidden_classes):
+def get_graphql_schema_from_schema_graph(schema_graph, class_to_field_type_overrides=None,
+                                         hidden_classes=None):
     """Return a GraphQL schema object corresponding to the schema of the given schema graph.
 
     Args:


### PR DESCRIPTION
In this PR, I make `hidden_classes` and `class_to_field_type_override` optional in `get_graphql_schema_from_schema_graph`. This PR is among the first refactors that I need to land to land the `SQLAlchemySchemaInfo` generation. 

I looked at everywhere this function is called in the repo and changed those function calls to use keyword arguments.