### PR TITLE
Change table parameter name to vertex_name_to_table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1877,8 +1877,7 @@ for configuring and running SQLAlchemy in a production system.
     engine = create_engine('<connection string>')
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object
-    sql_schema_info = make_sqlalchemy_schema_info(schema, {}, engine.dialect, vertex_name_to_table,
-     {})
+    sql_schema_info = make_sqlalchemy_schema_info(schema, {}, engine.dialect, vertex_name_to_table, {})
 
 
     # =================================================================================================

--- a/README.rst
+++ b/README.rst
@@ -1839,51 +1839,52 @@ for configuring and running SQLAlchemy in a production system.
     from graphql_compiler.compiler.ir_lowering_sql.metadata import SqlMetadata
     from graphql_compiler.schema.schema_info import make_sqlalchemy_schema_info
     from graphql_compiler import graphql_to_sql
-    
+
     # =================================================================================================
     # Step 1: Provide schema information. Note that we are working on making this step automatic.
     # =================================================================================================
-    
+
     schema_text = '''
     schema {
         query: RootSchemaQuery
     }
     # IMPORTANT NOTE: all compiler directives are expected here, but not shown to keep the example brief
-    
+
     directive @filter(op_name: String!, value: [String!]!) on FIELD | INLINE_FRAGMENT
-    
+
     # < more directives here, see the GraphQL schema section of this README for more details. >
-    
+
     directive @output(out_name: String!) on FIELD
-    
+
     type Animal {
         name: String
     }
     '''
     schema = build_ast_schema(parse(schema_text))
-    
+
     # Map all GraphQL types to sqlalchemy tables.
     # See https://docs.sqlalchemy.org/en/latest/core/metadata.html for more details on this step.
-    tables = {
+    vertex_name_to_table = {
         'Animal': Table(
             'Animal',
             MetaData(),
             Column('name', String(length=12)),  # The name is the same as the one in the GraphQL schema
         ),
     }
-    
+
     # Prepare a SQLAlchemy engine to query the target relational database.
     # See https://docs.sqlalchemy.org/en/latest/core/engines.html for more detail on this step.
     engine = create_engine('<connection string>')
-    
+
     # Wrap the schema information into a SQLAlchemySchemaInfo object
-    sql_schema_info = make_sqlalchemy_schema_info(schema, {}, engine.dialect, tables, {})
-    
-    
+    sql_schema_info = make_sqlalchemy_schema_info(schema, {}, engine.dialect, vertex_name_to_table,
+     {})
+
+
     # =================================================================================================
     # Step 2: Compile and execute a GraphQL query against the schema
     # =================================================================================================
-    
+
     graphql_query = '''
     {
         Animal {
@@ -1895,7 +1896,7 @@ for configuring and running SQLAlchemy in a production system.
     parameters = {
         'names': ['animal name 1', 'animal name 2'],
     }
-    
+
     compilation_result = graphql_to_sql(sql_schema_info, graphql_query, parameters)
     query_results = [dict(result_proxy) for result_proxy in engine.execute(compilation_result.query)]
 

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -113,7 +113,9 @@ class CompilationState(object):
         if self._current_location.query_path in self._aliases:
             self._current_alias = self._aliases[self._current_location.query_path]
         else:
-            self._current_alias = self._sql_schema_info.tables[self._current_classname].alias()
+            self._current_alias = (
+                self._sql_schema_info.vertex_name_to_table[self._current_classname].alias()
+            )
 
     def _join_to_parent_location(self, parent_alias, from_column, to_column, optional):
         """Join the current location to the parent location using the column names specified."""

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -83,7 +83,7 @@ SQLAlchemySchemaInfo = namedtuple('SQLAlchemySchemaInfo', (
     # dict mapping every graphql object type or interface type name in the schema to
     # a sqlalchemy table. Column types that do not exist for this dialect are not allowed.
     # All tables are expected to have primary keys.
-    'tables',
+    'vertex_name_to_table',
 
     # dict mapping every graphql object type or interface type name in the schema to:
     #    dict mapping every vertex field name at that type to a DirectJoinDescriptor. The
@@ -93,7 +93,7 @@ SQLAlchemySchemaInfo = namedtuple('SQLAlchemySchemaInfo', (
 ))
 
 
-def make_sqlalchemy_schema_info(schema, type_equivalence_hints, dialect, tables,
+def make_sqlalchemy_schema_info(schema, type_equivalence_hints, dialect, vertex_name_to_table,
                                 join_descriptors, validate=True):
     """Make a SQLAlchemySchemaInfo if the input provided is valid.
 
@@ -117,8 +117,8 @@ def make_sqlalchemy_schema_info(schema, type_equivalence_hints, dialect, tables,
                                 lead to incorrect output queries being generated.
                                 *****
         dialect: sqlalchemy.engine.interfaces.Dialect
-        tables: dict mapping every graphql object type or interface type name in the schema to
-                a sqlalchemy table
+        vertex_name_to_table: dict mapping every graphql object type or interface type name in the
+                              schema to a sqlalchemy table
         join_descriptors: dict mapping graphql object and interface type names in the schema to:
                              dict mapping every vertex field name at that type to a
                              DirectJoinDescriptor. The tables the join is to be performed on are not
@@ -144,9 +144,10 @@ def make_sqlalchemy_schema_info(schema, type_equivalence_hints, dialect, tables,
             if isinstance(graphql_type, types_to_map):
                 if type_name != 'RootSchemaQuery' and not type_name.startswith('__'):
                     # Check existence of sqlalchemy table for this type
-                    if type_name not in tables:
-                        raise AssertionError(u'Table for type {} not found'.format(type_name))
-                    table = tables[type_name]
+                    if type_name not in vertex_name_to_table:
+                        raise AssertionError(u'Table for type {} not found'.format
+                                             (type_name))
+                    table = vertex_name_to_table[type_name]
                     if not isinstance(table, sqlalchemy.Table):
                         raise AssertionError(u'Table for type {} has wrong type {}'
                                              .format(type_name, type(table)))
@@ -164,4 +165,5 @@ def make_sqlalchemy_schema_info(schema, type_equivalence_hints, dialect, tables,
                                                      u'for property field {}'
                                                      .format(type_name, field_name))
 
-    return SQLAlchemySchemaInfo(schema, type_equivalence_hints, dialect, tables, join_descriptors)
+    return SQLAlchemySchemaInfo(
+        schema, type_equivalence_hints, dialect, vertex_name_to_table, join_descriptors)

--- a/graphql_compiler/tests/test_data_tools/data_tool.py
+++ b/graphql_compiler/tests/test_data_tools/data_tool.py
@@ -170,7 +170,7 @@ def generate_sql_integration_data(sql_test_backends):
         },
     )
     table_values = [
-        (sql_schema_info.tables['Animal'], animal_rows),
+        (sql_schema_info.vertex_name_to_table['Animal'], animal_rows),
     ]
     for sql_test_backend in six.itervalues(sql_test_backends):
         for table, insert_values in table_values:


### PR DESCRIPTION
This PR changes the `tables` field in SQLAlchemySchemaInfo to `vertex_name_to_table`. The `tables` field is misleading since it seems to imply that all SQLAlchemyTable objects are going to mapped to vertices. However,  junction tables may just be represented as edges. This PR is another refactor that needs to happen before landing SQLAlchemySchemaInfo generation.