### PR TITLE
Move get_graphql_schema_from_orientdb_schema_data to a more suitable location

### DIFF
--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -14,8 +14,7 @@ from .schema import (  # noqa
     DIRECTIVES, EXTENDED_META_FIELD_DEFINITIONS, GraphQLDate, GraphQLDateTime, GraphQLDecimal,
     insert_meta_fields_into_existing_schema, is_meta_field
 )
-from .schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
-from .schema_generation.orientdb.schema_graph_builder import get_orientdb_schema_graph
+from .schema_generation.orientdb import get_graphql_schema_from_orientdb_schema_data  # noqa
 
 
 __package_name__ = 'graphql-compiler'
@@ -112,65 +111,6 @@ def graphql_to_gremlin(schema, graphql_query, parameters, type_equivalence_hints
         schema, graphql_query, type_equivalence_hints=type_equivalence_hints)
     return compilation_result._replace(
         query=insert_arguments_into_query(compilation_result, parameters))
-
-
-def get_graphql_schema_from_orientdb_schema_data(schema_data, class_to_field_type_overrides=None,
-                                                 hidden_classes=None):
-    """Construct a GraphQL schema from an OrientDB schema.
-
-    Args:
-        schema_data: list of dicts describing the classes in the OrientDB schema. The following
-                     format is the way the data is structured in OrientDB 2. See
-                     the README.md file for an example of how to query this data.
-                     Each dict has the following string fields:
-                        - name: string, the name of the class.
-                        - superClasses (optional): list of strings, the name of the class's
-                                                   superclasses.
-                        - superClass (optional): string, the name of the class's superclass. May be
-                                                 used instead of superClasses if there is only one
-                                                 superClass. Used for backwards compatibility with
-                                                 OrientDB.
-                        - customFields (optional): dict, string -> string, data defined on the class
-                                                   instead of instances of the class.
-                        - abstract: bool, true if the class is abstract.
-                        - properties: list of dicts, describing the class's properties.
-                                      Each property dictionary has the following string fields:
-                                         - name: string, the name of the property.
-                                         - type: int, builtin OrientDB type ID of the property.
-                                                 See schema_properties.py for the mapping.
-                                         - linkedType (optional): int, if the property is a
-                                                                  collection of builtin OrientDB
-                                                                  objects, then it indicates their
-                                                                  type ID.
-                                         - linkedClass (optional): string, if the property is a
-                                                                   collection of class instances,
-                                                                   then it indicates the name of
-                                                                   the class. If class is an edge
-                                                                   class, and the field name is
-                                                                   either 'in' or 'out', then it
-                                                                   describes the name of an
-                                                                   endpoint of the edge.
-                                         - defaultValue: string, the textual representation of the
-                                                         default value for the property, as
-                                                         returned by OrientDB's schema
-                                                         introspection code, e.g., '{}' for
-                                                         the embedded set type. Note that if the
-                                                         property is a collection type, it must
-                                                         have a default value.
-        class_to_field_type_overrides: optional dict, class name -> {field name -> field type},
-                                       (string -> {string -> GraphQLType}). Used to override the
-                                       type of a field in the class where it's first defined and all
-                                       the class's subclasses.
-        hidden_classes: optional set of strings, classes to not include in the GraphQL schema.
-
-    Returns:
-        tuple of (GraphQL schema object, GraphQL type equivalence hints dict).
-        The tuple is of type (GraphQLSchema, {GraphQLObjectType -> GraphQLUnionType}).
-    """
-    schema_graph = get_orientdb_schema_graph(schema_data, [])
-    return get_graphql_schema_from_schema_graph(
-        schema_graph, class_to_field_type_overrides=class_to_field_type_overrides,
-        hidden_classes=hidden_classes)
 
 
 def graphql_to_redisgraph_cypher(schema, graphql_query, parameters, type_equivalence_hints=None):

--- a/graphql_compiler/schema_generation/orientdb/__init__.py
+++ b/graphql_compiler/schema_generation/orientdb/__init__.py
@@ -1,1 +1,62 @@
 # Copyright 2019-present Kensho Technologies, LLC.
+from ..graphql_schema import get_graphql_schema_from_schema_graph
+from .schema_graph_builder import get_orientdb_schema_graph
+
+
+def get_graphql_schema_from_orientdb_schema_data(schema_data, class_to_field_type_overrides=None,
+                                                 hidden_classes=None):
+    """Construct a GraphQL schema from an OrientDB schema.
+
+    Args:
+        schema_data: list of dicts describing the classes in the OrientDB schema. The following
+                     format is the way the data is structured in OrientDB 2. See
+                     the README.md file for an example of how to query this data.
+                     Each dict has the following string fields:
+                        - name: string, the name of the class.
+                        - superClasses (optional): list of strings, the name of the class's
+                                                   superclasses.
+                        - superClass (optional): string, the name of the class's superclass. May be
+                                                 used instead of superClasses if there is only one
+                                                 superClass. Used for backwards compatibility with
+                                                 OrientDB.
+                        - customFields (optional): dict, string -> string, data defined on the class
+                                                   instead of instances of the class.
+                        - abstract: bool, true if the class is abstract.
+                        - properties: list of dicts, describing the class's properties.
+                                      Each property dictionary has the following string fields:
+                                         - name: string, the name of the property.
+                                         - type: int, builtin OrientDB type ID of the property.
+                                                 See schema_properties.py for the mapping.
+                                         - linkedType (optional): int, if the property is a
+                                                                  collection of builtin OrientDB
+                                                                  objects, then it indicates their
+                                                                  type ID.
+                                         - linkedClass (optional): string, if the property is a
+                                                                   collection of class instances,
+                                                                   then it indicates the name of
+                                                                   the class. If class is an edge
+                                                                   class, and the field name is
+                                                                   either 'in' or 'out', then it
+                                                                   describes the name of an
+                                                                   endpoint of the edge.
+                                         - defaultValue: string, the textual representation of the
+                                                         default value for the property, as
+                                                         returned by OrientDB's schema
+                                                         introspection code, e.g., '{}' for
+                                                         the embedded set type. Note that if the
+                                                         property is a collection type, it must
+                                                         have a default value.
+        class_to_field_type_overrides: optional dict, class name -> {field name -> field type},
+                                       (string -> {string -> GraphQLType}). Used to override the
+                                       type of a field in the class where it's first defined and all
+                                       the class's subclasses.
+        hidden_classes: optional set of strings, classes to not include in the GraphQL schema.
+
+    Returns:
+        tuple of (GraphQL schema object, GraphQL type equivalence hints dict).
+        The tuple is of type (GraphQLSchema, {GraphQLObjectType -> GraphQLUnionType}).
+    """
+    schema_graph = get_orientdb_schema_graph(schema_data, [])
+    return get_graphql_schema_from_schema_graph(
+        schema_graph, class_to_field_type_overrides=class_to_field_type_overrides,
+        hidden_classes=hidden_classes)

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -11,7 +11,8 @@ import six
 import sqlalchemy
 from sqlalchemy.dialects import mssql
 
-from .. import get_graphql_schema_from_orientdb_schema_data
+from graphql_compiler.schema_generation.orientdb import get_graphql_schema_from_orientdb_schema_data
+
 from ..compiler.subclass import compute_subclass_sets
 from ..debugging_utils import pretty_print_gremlin, pretty_print_match
 from ..query_formatting.graphql_formatting import pretty_print_graphql

--- a/graphql_compiler/tests/test_schema_generation.py
+++ b/graphql_compiler/tests/test_schema_generation.py
@@ -6,7 +6,8 @@ from graphql.type import GraphQLInterfaceType, GraphQLList, GraphQLObjectType, G
 import pytest
 import six
 
-from .. import get_graphql_schema_from_orientdb_schema_data
+from graphql_compiler.schema_generation.orientdb import get_graphql_schema_from_orientdb_schema_data
+
 from ..schema_generation.graphql_schema import _get_union_type_name
 from ..schema_generation.orientdb.schema_graph_builder import get_orientdb_schema_graph
 from ..schema_generation.orientdb.schema_properties import (


### PR DESCRIPTION
In this PR I move `get_graphql_schema_from_orientdb_schema_data` to a more suitable location. Since we currently have in the top level init file in the compiler, we are having to contaminate the namespace of this function with functions that we need not want in this namespace such as `get_graphql_schema_from_schema_graph`. If we leave this is at is, this problem is going to become worse when I add in the function that generates the `SQLAlchemySchemaInfo` object. For instance, I plan to use validation functions that I don't think we should have in this namespace. 

I verified that no function in any code block in the README.rst file, references either `get_graphql_schema_from_schema_graph` or `get_orientdb_schema_graph` in the top level init namespace.