### PR TITLE
Move schema generation tests to its own directory

### DIFF
--- a/graphql_compiler/tests/schema_generation_tests/__init__.py
+++ b/graphql_compiler/tests/schema_generation_tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2019-present Kensho Technologies, LLC.

--- a/graphql_compiler/tests/schema_generation_tests/test_orientdb_schema_generation.py
+++ b/graphql_compiler/tests/schema_generation_tests/test_orientdb_schema_generation.py
@@ -6,11 +6,10 @@ from graphql.type import GraphQLInterfaceType, GraphQLList, GraphQLObjectType, G
 import pytest
 import six
 
-from graphql_compiler.schema_generation.orientdb import get_graphql_schema_from_orientdb_schema_data
-
-from ..schema_generation.graphql_schema import _get_union_type_name
-from ..schema_generation.orientdb.schema_graph_builder import get_orientdb_schema_graph
-from ..schema_generation.orientdb.schema_properties import (
+from ...schema_generation.graphql_schema import _get_union_type_name
+from ...schema_generation.orientdb import get_graphql_schema_from_orientdb_schema_data
+from ...schema_generation.orientdb.schema_graph_builder import get_orientdb_schema_graph
+from ...schema_generation.orientdb.schema_properties import (
     ORIENTDB_BASE_EDGE_CLASS_NAME, ORIENTDB_BASE_VERTEX_CLASS_NAME, PROPERTY_TYPE_EMBEDDED_LIST_ID,
     PROPERTY_TYPE_EMBEDDED_SET_ID, PROPERTY_TYPE_LINK_ID, PROPERTY_TYPE_STRING_ID
 )


### PR DESCRIPTION
I think it'd be a good idea to have all schema generation tests in its own directory. Just to keep the library more organized.