### PR TITLE
Fix DateTime value parsing

### DIFF
--- a/graphql_compiler/schema/__init__.py
+++ b/graphql_compiler/schema/__init__.py
@@ -242,7 +242,6 @@ def _parse_datetime_value(value):
         # Strip the "Z" and add an explicit time zone instead.
         value = value[:-1] + '+00:00'
 
-
     return arrow.get(value, 'YYYY-MM-DDTHH:mm:ssZZ').datetime
 
 

--- a/graphql_compiler/schema/__init__.py
+++ b/graphql_compiler/schema/__init__.py
@@ -242,8 +242,7 @@ def _parse_datetime_value(value):
         # Strip the "Z" and add an explicit time zone instead.
         value = value[:-1] + '+00:00'
 
-    return arrow.get(value, 'YYYY-MM-DDTHH:mm:ssZ').datetime
-
+    return arrow.get(value, 'YYYY-MM-DDTHH:mm:ssZZ').datetime
 
 GraphQLDate = GraphQLScalarType(
     name='Date',

--- a/graphql_compiler/schema/__init__.py
+++ b/graphql_compiler/schema/__init__.py
@@ -244,6 +244,7 @@ def _parse_datetime_value(value):
 
     return arrow.get(value, 'YYYY-MM-DDTHH:mm:ssZZ').datetime
 
+
 GraphQLDate = GraphQLScalarType(
     name='Date',
     description='The `Date` scalar type represents day-accuracy date objects.'


### PR DESCRIPTION
This pull request is to fix the CI issues for 
https://github.com/kensho-technologies/graphql-compiler/pull/548

If you look at the logs, you'll notice that it is failing for a reason completely unrelated to the changes in the PR. It seems that during CI a later version of arrow gets installed in the pipenv enviroment and with it our test fails. My best guess is that the later version of arrow fixed a bug that we relied on for datetime parsing. Anyways, I found the correct way to correct timezone tokens in the Supported Tokens section of  https://arrow.readthedocs.io/en/latest/ and am submitting the fix in this PR. 