### PR TITLE
Fix dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,7 +32,7 @@ pytest = ">=4.1.0,<5"
 pytest-cov = ">=2.6.1,<3"
 snapshottest = ">=0.5.1,<1"
 
-[packages]
+[packages] # Make sure to keep in sync with setup.py requirements.
 arrow = ">=0.10.0,<1"
 funcy = ">=1.7.3,<2"
 graphql-core = ">=2.1,<3"

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     author_email='graphql-compiler-maintainer@kensho.com',
     license='Apache 2.0',
     packages=find_packages(exclude=['tests*']),
+    # Make sure to keep in sync with Pipfile requirements.
     install_requires=[
         'arrow>=0.10.0,<1',
         'funcy>=1.7.3,<2',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import re
 
 from setuptools import find_packages, setup
 
-
 #  https://packaging.python.org/guides/single-sourcing-package-version/
 #  #single-sourcing-the-version
 
@@ -57,10 +56,10 @@ setup(
     license='Apache 2.0',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'arrow>=0.7.0,<1',
-        'funcy>=1.6,<2',
+        'arrow>=0.10.0,<1',
+        'funcy>=1.7.3,<2',
         'graphql-core>=2.1,<3',
-        'pytz>=2016.10',
+        'pytz>=2017.2',
         'six>=1.10.0',
         'sqlalchemy>=1.3.0,<2',
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import re
 
 from setuptools import find_packages, setup
 
+
 #  https://packaging.python.org/guides/single-sourcing-package-version/
 #  #single-sourcing-the-version
 


### PR DESCRIPTION
I am updating the setup.py dependencies to match the Pipfile dependencies since the Pipfile dependencies seem to be more strict. 

Unfortunately,  there is no elegant way to make sure that pipenv and setup.py don't get out of sync. https://github.com/pypa/pipenv/issues/209

I could add a hacky test to make sure they are in sync, but it currently does not seem to be worth the effort. I added some comments as a reminder so that this does not happen again.