### PR TITLE
Remove costly schema generation from cost estimation

### DIFF
--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -84,8 +84,8 @@ def _get_base_class_names_of_parent_and_child_from_edge(schema_graph, current_lo
     return parent_base_class_name, child_base_class_name
 
 
-def _query_statistics_for_vertex_edge_vertex_count(
-    statistics, query_metadata, parent_location, child_location):
+def _query_statistics_for_vertex_edge_vertex_count(statistics, query_metadata,
+                                                   parent_location, child_location):
     """Query statistics for the count of edges connecting parent and child_location vertices.
 
     Given a parent location and a child location, there are three constraints on each edge directly
@@ -238,8 +238,8 @@ def _estimate_edges_to_children_per_parent(schema_info, query_metadata, paramete
     return child_counts_per_parent
 
 
-def _estimate_subexpansion_cardinality(
-    schema_info, query_metadata, parameters, parent_location, child_location):
+def _estimate_subexpansion_cardinality(schema_info, query_metadata, parameters,
+                                       parent_location, child_location):
     """Estimate the cardinality associated with the subexpansion of a child_location vertex.
 
     Args:

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -6,7 +6,6 @@ from ..compiler.helpers import (
     INBOUND_EDGE_DIRECTION, OUTBOUND_EDGE_DIRECTION, FoldScopeLocation, Location,
     get_edge_direction_and_name
 )
-from ..schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from .filter_selectivity_utils import adjust_counts_for_filters
 
 
@@ -86,8 +85,7 @@ def _get_base_class_names_of_parent_and_child_from_edge(schema_graph, current_lo
 
 
 def _query_statistics_for_vertex_edge_vertex_count(
-    statistics, query_metadata, parent_location, child_location
-):
+    statistics, query_metadata, parent_location, child_location):
     """Query statistics for the count of edges connecting parent and child_location vertices.
 
     Given a parent location and a child location, there are three constraints on each edge directly
@@ -128,14 +126,12 @@ def _query_statistics_for_vertex_edge_vertex_count(
                              u'Found: edge {} with direction {}'.format(edge_name, edge_direction))
 
     query_result = statistics.get_vertex_edge_vertex_count(
-        outbound_vertex_name, edge_name, inbound_vertex_name
-    )
+        outbound_vertex_name, edge_name, inbound_vertex_name)
     return query_result
 
 
 def _estimate_vertex_edge_vertex_count_using_class_count(
-    schema_graph, statistics, query_metadata, parent_location, child_location
-):
+        schema_info, query_metadata, parent_location, child_location):
     """Estimate the count of edges connecting parent_location and child_location vertices.
 
     Given a parent location of class A and a child location of class B, this function estimates the
@@ -148,8 +144,7 @@ def _estimate_vertex_edge_vertex_count_using_class_count(
                                                   (number of B vertices) / (number of D vertices).
 
     Args:
-        schema_graph: SchemaGraph object.
-        statistics: Statistics object.
+        schema_info: QueryPlanningSchemaInfo
         query_metadata: QueryMetadataTable object.
         parent_location: BaseLocation, corresponding to the location the edge traversal begins from.
         child_location: BaseLocation, child of parent_location corresponding to the location the
@@ -159,13 +154,13 @@ def _estimate_vertex_edge_vertex_count_using_class_count(
         float, estimate for number of edges connecting parent_location and child_location.
     """
     _, edge_name = _get_last_edge_direction_and_name_to_location(child_location)
-    edge_counts = statistics.get_class_count(edge_name)
+    edge_counts = schema_info.statistics.get_class_count(edge_name)
 
     parent_name_from_location = query_metadata.get_location_info(parent_location).type.name
     child_name_from_location = query_metadata.get_location_info(child_location).type.name
     parent_base_class_name, child_base_class_name = (
-        _get_base_class_names_of_parent_and_child_from_edge(schema_graph, child_location)
-    )
+        _get_base_class_names_of_parent_and_child_from_edge(
+            schema_info.schema_graph, child_location))
 
     # False-positive bug in pylint: https://github.com/PyCQA/pylint/issues/3039
     # pylint: disable=old-division
@@ -173,23 +168,22 @@ def _estimate_vertex_edge_vertex_count_using_class_count(
     # Scale edge_counts if child_location's type is a subclass of the edge's endpoint type.
     if child_name_from_location != child_base_class_name:
         edge_counts *= (
-            float(statistics.get_class_count(child_name_from_location)) /
-            statistics.get_class_count(child_base_class_name)
+            float(schema_info.statistics.get_class_count(child_name_from_location)) /
+            schema_info.statistics.get_class_count(child_base_class_name)
         )
     # Scale edge_counts if parent_location's type is a subclass of the edge's endpoint type.
     if parent_name_from_location != parent_base_class_name:
         edge_counts *= (
-            float(statistics.get_class_count(parent_name_from_location)) /
-            statistics.get_class_count(parent_base_class_name)
+            float(schema_info.statistics.get_class_count(parent_name_from_location)) /
+            schema_info.statistics.get_class_count(parent_base_class_name)
         )
     # pylint: enable=old-division
 
     return edge_counts
 
 
-def _estimate_edges_to_children_per_parent(
-    schema_graph, statistics, query_metadata, parameters, parent_location, child_location
-):
+def _estimate_edges_to_children_per_parent(schema_info, query_metadata, parameters,
+                                           parent_location, child_location):
     """Estimate the count of edges per parent_location that connect to child_location vertices.
 
     Given a parent location of type A and child location of type B, assume all AB edges are
@@ -197,8 +191,7 @@ def _estimate_edges_to_children_per_parent(
     (number of AB edges) / (number of A vertices).
 
     Args:
-        schema_graph: SchemaGraph object.
-        statistics: Statistics object.
+        schema_info: QueryPlanningSchemaInfo
         query_metadata: QueryMetadataTable object.
         parameters: dict, parameters with which query will be executed.
         parent_location: BaseLocation, corresponding to the location the edge traversal begins from.
@@ -210,17 +203,16 @@ def _estimate_edges_to_children_per_parent(
         vertices.
     """
     edge_counts = _query_statistics_for_vertex_edge_vertex_count(
-        statistics, query_metadata, parent_location, child_location
+        schema_info.statistics, query_metadata, parent_location, child_location
     )
 
     if edge_counts is None:
         edge_counts = _estimate_vertex_edge_vertex_count_using_class_count(
-            schema_graph, statistics, query_metadata, parent_location, child_location
-        )
+            schema_info, query_metadata, parent_location, child_location)
 
     parent_name_from_location = query_metadata.get_location_info(parent_location).type.name
     # Count the number of parents, over which we assume the edges are uniformly distributed.
-    parent_location_counts = statistics.get_class_count(parent_name_from_location)
+    parent_location_counts = schema_info.statistics.get_class_count(parent_name_from_location)
 
     # False-positive bug in pylint: https://github.com/PyCQA/pylint/issues/3039
     # pylint: disable=old-division
@@ -240,21 +232,18 @@ def _estimate_edges_to_children_per_parent(
     child_name_from_location = query_metadata.get_location_info(child_location).type.name
     child_filters = query_metadata.get_filter_infos(child_location)
     child_counts_per_parent = adjust_counts_for_filters(
-        schema_graph, statistics, child_filters, parameters, child_name_from_location,
-        child_counts_per_parent
-    )
+        schema_info, child_filters, parameters, child_name_from_location,
+        child_counts_per_parent)
 
     return child_counts_per_parent
 
 
 def _estimate_subexpansion_cardinality(
-    schema_graph, statistics, query_metadata, parameters, parent_location, child_location
-):
+    schema_info, query_metadata, parameters, parent_location, child_location):
     """Estimate the cardinality associated with the subexpansion of a child_location vertex.
 
     Args:
-        schema_graph: SchemaGraph object
-        statistics: Statistics object
+        schema_info: QueryPlanningSchemaInfo
         query_metadata: QueryMetadataTable object
         parameters: dict, parameters with which query will be executed
         parent_location: BaseLocation object, location corresponding to the vertex being expanded
@@ -270,12 +259,10 @@ def _estimate_subexpansion_cardinality(
         (expected number of B-vertices) * (expected number of result sets per B-vertex).
     """
     child_counts_per_parent = _estimate_edges_to_children_per_parent(
-        schema_graph, statistics, query_metadata, parameters, parent_location, child_location
-    )
+        schema_info, query_metadata, parameters, parent_location, child_location)
 
     results_per_child = _estimate_expansion_cardinality(
-        schema_graph, statistics, query_metadata, parameters, child_location
-    )
+        schema_info, query_metadata, parameters, child_location)
 
     subexpansion_cardinality = child_counts_per_parent * results_per_child
 
@@ -290,14 +277,11 @@ def _estimate_subexpansion_cardinality(
     return subexpansion_cardinality
 
 
-def _estimate_expansion_cardinality(
-    schema_graph, statistics, query_metadata, parameters, current_location
-):
+def _estimate_expansion_cardinality(schema_info, query_metadata, parameters, current_location):
     """Estimate the cardinality of fully expanding a vertex corresponding to current_location.
 
     Args:
-        schema_graph: SchemaGraph object
-        statistics: Statistics object
+        schema_info: QueryPlanningSchemaInfo
         query_metadata: QueryMetadataTable object
         parameters: dict, parameters with which query will be executed
         current_location: BaseLocation object, corresponding to the vertex we're expanding
@@ -312,18 +296,16 @@ def _estimate_expansion_cardinality(
         # each subexpansion (e.g. If we expect each current vertex to have 2 children of type A and
         # 3 children of type B, we'll return 6 distinct result sets per current vertex).
         subexpansion_cardinality = _estimate_subexpansion_cardinality(
-            schema_graph, statistics, query_metadata, parameters, current_location, child_location
-        )
+            schema_info, query_metadata, parameters, current_location, child_location)
         expansion_cardinality *= subexpansion_cardinality
     return expansion_cardinality
 
 
-def estimate_query_result_cardinality(schema_graph, statistics, graphql_query, parameters):
+def estimate_query_result_cardinality(schema_info, graphql_query, parameters):
     """Estimate the cardinality of a GraphQL query's result using database statistics.
 
     Args:
-        schema_graph: SchemaGraph object
-        statistics: Statistics object
+        schema_info: QueryPlanningSchemaInfo
         graphql_query: string, a valid GraphQL query
         parameters: dict, parameters with which query will be executed.
 
@@ -331,32 +313,29 @@ def estimate_query_result_cardinality(schema_graph, statistics, graphql_query, p
         float, expected query result cardinality. Equal to the number of root vertices multiplied by
         the expected number of result sets per full expansion of a root vertex.
     """
-    graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
     query_metadata = graphql_to_ir(
-        graphql_schema, graphql_query, type_equivalence_hints=type_equivalence_hints
+        schema_info.schema, graphql_query, type_equivalence_hints=schema_info.type_equivalence_hints
     ).query_metadata_table
 
     root_location = query_metadata.root_location
 
     # First, count the vertices corresponding to the root location that pass relevant filters
     root_name = query_metadata.get_location_info(root_location).type.name
-    root_counts = statistics.get_class_count(root_name)
+    root_counts = schema_info.statistics.get_class_count(root_name)
     root_counts = adjust_counts_for_filters(
-        schema_graph, statistics, query_metadata.get_filter_infos(root_location), parameters,
-        root_name, root_counts
-    )
+        schema_info, query_metadata.get_filter_infos(root_location), parameters,
+        root_name, root_counts)
 
     # Next, find the number of expected result sets per root vertex when fully expanded
     results_per_root = _estimate_expansion_cardinality(
-        schema_graph, statistics, query_metadata, parameters, root_location
-    )
+        schema_info, query_metadata, parameters, root_location)
 
     expected_query_result_cardinality = root_counts * results_per_root
 
     return expected_query_result_cardinality
 
 
-def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, page_size):
+def estimate_number_of_pages(schema_info, graphql_query, params, page_size):
     """Estimate how many pages of results will be generated for a given query.
 
     Using the cardinality estimator, we generate an estimate for the query result cardinality i.e.
@@ -367,8 +346,7 @@ def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, pa
     (or equal to) 5000 results.
 
     Args:
-        schema_graph: SchemaGraph instance.
-        statistics: Statistics object.
+        schema_info: QueryPlanningSchemaInfo
         graphql_query: str, valid GraphQL query to be estimated.
         params: dict, parameters for the given query.
         page_size: int, desired number of result rows per page.
@@ -384,9 +362,7 @@ def estimate_number_of_pages(schema_graph, statistics, graphql_query, params, pa
                          u' with page size lower than 1: {} {}'
                          .format(graphql_query, page_size, params))
 
-    result_size = estimate_query_result_cardinality(
-        schema_graph, statistics, graphql_query, params
-    )
+    result_size = estimate_query_result_cardinality(schema_info, graphql_query, params)
     if result_size < 0.0:
         raise AssertionError(u'Received negative estimate {} for cardinality of query {}: {}'
                              .format(result_size, graphql_query, params))

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -2,13 +2,12 @@
 
 
 def generate_parameters_for_parameterized_query(
-    schema_graph, statistics, parameterized_pagination_queries, num_pages
+    schema_info, parameterized_pagination_queries, num_pages
 ):
     """Generate parameters for the given parameterized pagination queries.
 
     Args:
-        schema_graph: SchemaGraph instance.
-        statistics: Statistics object.
+        schema_info: QueryPlanningSchemaInfo
         parameterized_pagination_queries: ParameterizedPaginationQueries namedtuple, parameterized
                                           queries for which parameters are being generated.
         num_pages: int, number of pages to split the query into.

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -42,7 +42,7 @@ PaginationFilter = namedtuple(
 )
 
 
-def generate_parameterized_queries(schema_graph, statistics, query_ast, parameters):
+def generate_parameterized_queries(schema_info, query_ast, parameters):
     """Generate two parameterized queries that can be used to paginate over a given query.
 
     In order to paginate arbitrary GraphQL queries, additional filters may need to be added to be
@@ -51,8 +51,7 @@ def generate_parameterized_queries(schema_graph, statistics, query_ast, paramete
     controlled.
 
     Args:
-        schema_graph: SchemaGraph instance.
-        statistics: Statistics object.
+        schema_info: QueryPlanningSchemaInfo
         query_ast: Document, query that is being paginated.
         parameters: dict, list of parameters for the given query.
 

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -16,9 +16,7 @@ ASTWithParameters = namedtuple(
 )
 
 
-def split_into_page_query_and_remainder_query(
-    schema_graph, statistics, query_ast, parameters, num_pages
-):
+def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters, num_pages):
     """Split a query into two equivalent queries, one of which will return roughly a page of data.
 
     First, two parameterized queries are generated that contain filters usable for pagination i.e.
@@ -28,8 +26,7 @@ def split_into_page_query_and_remainder_query(
     data is equivalent to the original query's result data.
 
     Args:
-        schema_graph: SchemaGraph instance.
-        statistics: Statistics object.
+        schema_info: QueryPlanningSchemaInfo
         query_ast: Document, AST of the GraphQL query that will be split.
         parameters: dict, parameters with which query will be estimated.
         num_pages: int, number of pages to split the query into.
@@ -46,17 +43,14 @@ def split_into_page_query_and_remainder_query(
                              u' of results, as the number of pages {} must be greater than 1: {}'
                              .format(query_ast, num_pages, parameters))
 
-    parameterized_queries = generate_parameterized_queries(
-        schema_graph, statistics, query_ast, parameters
-    )
+    parameterized_queries = generate_parameterized_queries(schema_info, query_ast, parameters)
 
     next_page_parameters, remainder_parameters = generate_parameters_for_parameterized_query(
-        schema_graph, statistics, parameterized_queries, num_pages
-    )
+        schema_info, parameterized_queries, num_pages)
 
     next_page_ast_with_parameters = ASTWithParameters(
         parameterized_queries.page_query,
-        next_page_parameters,
+        next_page_parameters
     )
     remainder_ast_with_parameters = ASTWithParameters(
         parameterized_queries.remainder_query,

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -167,3 +167,34 @@ def make_sqlalchemy_schema_info(schema, type_equivalence_hints, dialect, vertex_
 
     return SQLAlchemySchemaInfo(
         schema, type_equivalence_hints, dialect, vertex_name_to_table, join_descriptors)
+
+
+# All schema information sufficient for query cost estimation and auto pagination
+QueryPlanningSchemaInfo = namedtuple('QueryPlanningSchemaInfo', (
+    # GraphQLSchema
+    'schema',
+
+    # optional dict of GraphQL interface or type -> GraphQL union.
+    # Used as a workaround for GraphQL's lack of support for
+    # inheritance across "types" (i.e. non-interfaces), as well as a
+    # workaround for Gremlin's total lack of inheritance-awareness.
+    # The key-value pairs in the dict specify that the "key" type
+    # is equivalent to the "value" type, i.e. that the GraphQL type or
+    # interface in the key is the most-derived common supertype
+    # of every GraphQL type in the "value" GraphQL union.
+    # Recursive expansion of type equivalence hints is not performed,
+    # and only type-level correctness of this argument is enforced.
+    # See README.md for more details on everything this parameter does.
+    # *****
+    # Be very careful with this option, as bad input here will
+    # lead to incorrect output queries being generated.
+    # *****
+    'type_equivalence_hints',
+
+    # A SchemaGraph instance that corresponds to the GraphQLSchema, containing additional
+    # information on unique indexes, subclass sets, and edge base connection classes.
+    'schema_graph',
+
+    # A Statistics object giving statistical information about all objects in the schema.
+    'statistics',
+))

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -13,8 +13,8 @@ from ...cost_estimation.filter_selectivity_utils import (
     adjust_counts_for_filters
 )
 from ...cost_estimation.statistics import LocalStatistics
-from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ...schema.schema_info import QueryPlanningSchemaInfo
+from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import generate_schema_graph
 
 

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -13,7 +13,19 @@ from ...cost_estimation.filter_selectivity_utils import (
     adjust_counts_for_filters
 )
 from ...cost_estimation.statistics import LocalStatistics
+from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
+from ...schema.schema_info import QueryPlanningSchemaInfo
 from ..test_helpers import generate_schema_graph
+
+
+def _make_schema_info_and_estimate_cardinality(schema_graph, statistics, graphql_input, args):
+    graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+    schema_info = QueryPlanningSchemaInfo(
+        schema=graphql_schema,
+        type_equivalence_hints=type_equivalence_hints,
+        schema_graph=schema_graph,
+        statistics=statistics)
+    return estimate_query_result_cardinality(schema_info, graphql_input, args)
 
 
 # The following TestCase class uses the 'snapshot_orientdb_client' fixture
@@ -28,6 +40,7 @@ class CostEstimationTests(unittest.TestCase):
     def test_root_count(self):
         """Ensure we correctly estimate the cardinality of the query root."""
         schema_graph = generate_schema_graph(self.orientdb_client)
+
         test_data = test_input_data.immediate_output()
 
         count_data = {
@@ -35,7 +48,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, test_data.graphql_input, dict()
         )
         expected_cardinality_estimate = 3.0
@@ -54,7 +67,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, test_data.graphql_input, dict()
         )
         # For each Animal, there are on average 5.0 / 3.0 Animal_ParentOf edges, so we expect
@@ -77,7 +90,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, test_data.graphql_input, dict()
         )
         # For each Animal, we expect 5.0 / 3.0 out_Species_Eats edges. Out of those FoodOrSpecies,
@@ -119,7 +132,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -160,7 +173,7 @@ class CostEstimationTests(unittest.TestCase):
             count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data
         )
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -197,7 +210,7 @@ class CostEstimationTests(unittest.TestCase):
             count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data
         )
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -234,7 +247,7 @@ class CostEstimationTests(unittest.TestCase):
             count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data
         )
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -277,7 +290,7 @@ class CostEstimationTests(unittest.TestCase):
             count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data
         )
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -311,7 +324,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -351,7 +364,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -371,7 +384,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -403,7 +416,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -442,7 +455,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -462,7 +475,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -489,7 +502,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -521,7 +534,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, dict()
         )
 
@@ -552,7 +565,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -593,7 +606,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data, vertex_edge_vertex_counts=vertex_edge_vertex_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -623,7 +636,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -652,7 +665,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -691,7 +704,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -734,7 +747,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -776,7 +789,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -819,7 +832,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -856,7 +869,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -891,7 +904,7 @@ class CostEstimationTests(unittest.TestCase):
         }
         statistics = LocalStatistics(count_data)
 
-        cardinality_estimate = estimate_query_result_cardinality(
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
             schema_graph, statistics, graphql_input, params
         )
 
@@ -900,6 +913,17 @@ class CostEstimationTests(unittest.TestCase):
         # have 13.0 / 7.0 Animal_BornAt edges, giving a total of 7.0 * (13.0 / 7.0) results.
         expected_cardinality_estimate = 7.0 * (11.0 / 7.0 + 1.0) * 1.0
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
+
+
+def _make_schema_info_and_get_filter_selectivity(schema_graph, statistics, filter_info,
+                                                 parameters, location_name):
+    graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+    schema_info = QueryPlanningSchemaInfo(
+        schema=graphql_schema,
+        type_equivalence_hints=type_equivalence_hints,
+        schema_graph=schema_graph,
+        statistics=statistics)
+    return _get_filter_selectivity(schema_info, filter_info, parameters, location_name)
 
 
 class FilterSelectivityUtilsTests(unittest.TestCase):
@@ -965,7 +989,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         filter_on_nonindex = FilterInfo(
             fields=('description',), op_name='=', args=('$description',)
         )
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, empty_statistics, filter_on_nonindex, params, classname
         )
         expected_selectivity = Selectivity(kind=FRACTIONAL_SELECTIVITY, value=1.0)
@@ -974,7 +998,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         # If we '='-filter on a property that's non-uniquely indexed, with no
         # distinct-field-values-count statistics, return a fractional selectivity of 1.
         nonunique_filter = FilterInfo(fields=('birthday',), op_name='=', args=('$birthday',))
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, empty_statistics, nonunique_filter, params, classname
         )
         expected_selectivity = Selectivity(kind=FRACTIONAL_SELECTIVITY, value=1.0)
@@ -989,7 +1013,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         # If we '='-filter on a property that's non-uniquely indexed, but has only 3 distinct field
         # values, return a fractional selectivity of 1.0 / 3.0.
         nonunique_filter = FilterInfo(fields=('birthday',), op_name='=', args=('$birthday',))
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, statistics_with_distinct_birthday_values_data,
             nonunique_filter, params, classname
         )
@@ -998,7 +1022,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
 
         # If we '='-filter on a property that is uniquely indexed, expect exactly 1 result.
         unique_filter = FilterInfo(fields=('uuid',), op_name='=', args=('$uuid',))
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, empty_statistics, unique_filter, params, classname
         )
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=1.0)
@@ -1013,7 +1037,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         # If we '='-filter on a property that is both uniquely indexed, and has 3 distinct field
         # values, expect exactly 1 result, since the index overrides the statistic.
         unique_filter = FilterInfo(fields=('uuid',), op_name='=', args=('$uuid',))
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, statistics_with_distinct_uuid_values_data,
             unique_filter, params, classname
         )
@@ -1035,7 +1059,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         }
         # If we use an in_collection-filter on a property that is not uniquely indexed, with no
         # distinct_field_values_count statistic, return a fractional selectivity of 1.
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, empty_statistics, nonunique_filter, nonunique_params, classname
         )
         expected_selectivity = Selectivity(kind=FRACTIONAL_SELECTIVITY, value=1.0)
@@ -1050,7 +1074,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         # If we use an in_collection-filter using a collection with 2 elements on a property that is
         # not uniquely indexed, but has 3 distinct values, return a fractional
         # selectivity of 2.0 / 3.0.
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, statistics_with_distinct_birthday_values_data, nonunique_filter,
             nonunique_params, classname
         )
@@ -1062,7 +1086,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         )
         # If we use an in_collection-filter with 4 elements on a property that is not uniquely
         # indexed, but has 3 distinct values, return a fractional selectivity of 1.0.
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, statistics_with_distinct_birthday_values_data, nonunique_filter,
             nonunique_params, classname
         )
@@ -1080,14 +1104,16 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         }
         # If we use an in_collection-filter on a property that is uniquely indexed, expect as many
         # results as there are elements in the collection.
-        selectivity = _get_filter_selectivity(
+        selectivity = _make_schema_info_and_get_filter_selectivity(
             schema_graph, empty_statistics, in_collection_filter, unique_params, classname
         )
         expected_selectivity = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=3.0)
         self.assertEqual(expected_selectivity, selectivity)
 
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_inequality_filters_on_uuid(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         classname = 'Animal'
         between_filter = FilterInfo(fields=('uuid',), op_name='between',
                                     args=('$uuid_lower', '$uuid_upper',))
@@ -1099,10 +1125,14 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
             'uuid_upper': '7fffffff-ffff-ffff-ffff-ffffffffffff',
         }
         empty_statistics = LocalStatistics(dict())
+        empty_statistics_schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=empty_statistics)
 
         result_counts = adjust_counts_for_filters(
-            schema_graph, empty_statistics, filter_info_list, params, classname, 32.0
-        )
+            empty_statistics_schema_info, filter_info_list, params, classname, 32.0)
 
         # There are 32 Animals, and an estimated (1.0 / 4.0) of them have a UUID between the
         # parameters given in the parameters dict, so we get a result size of 32.0 * (1.0 / 4.0) =
@@ -1127,8 +1157,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         }
 
         result_counts = adjust_counts_for_filters(
-            schema_graph, empty_statistics, filter_info_list, params, classname, 32.0
-        )
+            empty_statistics_schema_info, filter_info_list, params, classname, 32.0)
 
         # There are 32 Animals, and an estimated (3.0 / 4.0) have a UUID greater or equal to
         # uuid_lower, and an estimated (1.0 / 2.0) have a UUID less than or equal to uuid_upper. The
@@ -1148,8 +1177,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         }
 
         result_counts = adjust_counts_for_filters(
-            schema_graph, empty_statistics, filter_info_list, params, classname, 32.0
-        )
+            empty_statistics_schema_info, filter_info_list, params, classname, 32.0)
 
         # It's impossible for a UUID to simultaneously be below uuid_upper and above uuid_lower as
         # uuid_upper is smaller than uuid_lower, so the result set is empty.

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -4,9 +4,9 @@ import unittest
 import pytest
 
 from ...cost_estimation.statistics import LocalStatistics
-from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
-from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...query_pagination import QueryStringWithParameters, paginate_query
+from ...schema.schema_info import QueryPlanningSchemaInfo
+from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import generate_schema_graph
 
 

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -4,6 +4,8 @@ import unittest
 import pytest
 
 from ...cost_estimation.statistics import LocalStatistics
+from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
+from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...query_pagination import QueryStringWithParameters, paginate_query
 from ..test_helpers import generate_schema_graph
 
@@ -20,6 +22,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_basic_pagination(self):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         test_data = '''{
             Animal {
                 name @output(out_name: "animal")
@@ -32,6 +35,11 @@ class QueryPaginationTests(unittest.TestCase):
         }
 
         statistics = LocalStatistics(count_data)
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics)
 
         # Since query pagination is still a skeleton, we expect a NotImplementedError for this test.
         # Once query pagination is fully implemented, the result of this call should be equal to
@@ -39,7 +47,7 @@ class QueryPaginationTests(unittest.TestCase):
         # pylint: disable=unused-variable
         with self.assertRaises(NotImplementedError):
             paginated_queries = paginate_query(                     # noqa: unused-variable
-                schema_graph, statistics, test_data, parameters, 1
+                schema_info, test_data, parameters, 1
             )
 
         expected_query_list = (                                     # noqa: unused-variable


### PR DESCRIPTION
Currently, cost estimation takes among other things a `schema_graph` and `statistics`, and the first thing it does is generate a graphql schema using `graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)`.

It does not make sense to generate schema inside cost estimation because:
1. Cost estimation should not rely on schema generation
2. It can be costly to run

Cost estimation needs the `graphql_schema` in order to compile the query to IR, and use its `query_metadata_table`. So there's two ways to solve this problem: Either provide a `graphql_schema` as an argument, or provide the IR of the query as an argument. This PR takes the first approach because it is more flexible. It allows us to remove the schema graph as a dependency if we decide to do so (maybe to remove the `orientdb_client` as a test dependency), and access the query in all stages: text, AST and IR.

In this PR, I add the `schema_graph` and `type_equivalence_hints` as additional arguments to all cost estimation and auto pagination functions. To keep the number of arguments small, I also group all schema information arguments (everything that does not depend on the particular query) into a `QueryPlanningSchemaInfo`.