### PR TITLE
Add pagination keys to query planning info

### DIFF
--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -197,4 +197,9 @@ QueryPlanningSchemaInfo = namedtuple('QueryPlanningSchemaInfo', (
 
     # A Statistics object giving statistical information about all objects in the schema.
     'statistics',
+
+    # Dict mapping all vertex names in the schema to the Int or ID type property name
+    # to be used for pagination on that vertex. This property should be non-null and
+    # unique for all rows. An easy choice in most situations is the primary key.
+    'pagination_keys',
 ))

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -200,9 +200,13 @@ QueryPlanningSchemaInfo = namedtuple('QueryPlanningSchemaInfo', (
 
     # Dict mapping vertex names in the graphql schema to the Int or ID type property name
     # to be used for pagination on that vertex. This property should be non-null and
-    # unique for all rows. Note that the type of this property might be different in the
-    # schema graph, due to the process of type overrides that happens during schema generation.
-    # An easy choice for pagination key in most situations is the primary key. The pagination
-    # key for a vertex can be omitted making the vertex ineligible for pagination.
+    # unique for all rows.  An easy choice for pagination key in most situations is the
+    # primary key. The pagination key for a vertex can be omitted making the vertex
+    # ineligible for pagination.
+    #
+    # NOTE(bojanserafimov): The type of this property might be different in the
+    #                       schema graph, due to the process of type overrides that happens
+    #                       during schema generation.
+    # HACK(bojanserafimov): All ID types are assumed to be uniformly-distributed uuid4s.
     'pagination_keys',
 ))

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -198,8 +198,11 @@ QueryPlanningSchemaInfo = namedtuple('QueryPlanningSchemaInfo', (
     # A Statistics object giving statistical information about all objects in the schema.
     'statistics',
 
-    # Dict mapping all vertex names in the schema to the Int or ID type property name
+    # Dict mapping vertex names in the graphql schema to the Int or ID type property name
     # to be used for pagination on that vertex. This property should be non-null and
-    # unique for all rows. An easy choice in most situations is the primary key.
+    # unique for all rows. Note that the type of this property might be different in the
+    # schema graph, due to the process of type overrides that happens during schema generation.
+    # An easy choice for pagination key in most situations is the primary key. The pagination
+    # key for a vertex can be omitted making the vertex ineligible for pagination.
     'pagination_keys',
 ))

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -20,11 +20,13 @@ from ..test_helpers import generate_schema_graph
 
 def _make_schema_info_and_estimate_cardinality(schema_graph, statistics, graphql_input, args):
     graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+    pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
     schema_info = QueryPlanningSchemaInfo(
         schema=graphql_schema,
         type_equivalence_hints=type_equivalence_hints,
         schema_graph=schema_graph,
-        statistics=statistics)
+        statistics=statistics,
+        pagination_keys=pagination_keys)
     return estimate_query_result_cardinality(schema_info, graphql_input, args)
 
 
@@ -918,11 +920,13 @@ class CostEstimationTests(unittest.TestCase):
 def _make_schema_info_and_get_filter_selectivity(schema_graph, statistics, filter_info,
                                                  parameters, location_name):
     graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+    pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
     schema_info = QueryPlanningSchemaInfo(
         schema=graphql_schema,
         type_equivalence_hints=type_equivalence_hints,
         schema_graph=schema_graph,
-        statistics=statistics)
+        statistics=statistics,
+        pagination_keys=pagination_keys)
     return _get_filter_selectivity(schema_info, filter_info, parameters, location_name)
 
 
@@ -1114,6 +1118,7 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
     def test_inequality_filters_on_uuid(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
         classname = 'Animal'
         between_filter = FilterInfo(fields=('uuid',), op_name='between',
                                     args=('$uuid_lower', '$uuid_upper',))
@@ -1129,7 +1134,8 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
             schema=graphql_schema,
             type_equivalence_hints=type_equivalence_hints,
             schema_graph=schema_graph,
-            statistics=empty_statistics)
+            statistics=empty_statistics,
+            pagination_keys=pagination_keys)
 
         result_counts = adjust_counts_for_filters(
             empty_statistics_schema_info, filter_info_list, params, classname, 32.0)

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -23,6 +23,7 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
         test_data = '''{
             Animal {
                 name @output(out_name: "animal")
@@ -39,7 +40,8 @@ class QueryPaginationTests(unittest.TestCase):
             schema=graphql_schema,
             type_equivalence_hints=type_equivalence_hints,
             schema_graph=schema_graph,
-            statistics=statistics)
+            statistics=statistics,
+            pagination_keys=pagination_keys)
 
         # Since query pagination is still a skeleton, we expect a NotImplementedError for this test.
         # Once query pagination is fully implemented, the result of this call should be equal to


### PR DESCRIPTION
Adding the option to paginate on a field that's not `uuid`. This information could come from the schema graph if it was included, but including it is a whole ordeal that meddles with schema generation, and the test schema itself.