### PR TITLE
Add histogram stats

### DIFF
--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -83,21 +83,6 @@ class Statistics(object):
         """
         return None
 
-    def get_field_quantile(self, vertex_name, field_name, fraction):
-        """Return the field value that's larger than a given fraction of all values.
-
-        Args:
-            vertex_name: str, name of a vertex defined in the GraphQL schema.
-            field_name: str, name of a vertex field.
-            fraction: float from 0 to 1, the fraction of values smaller than the result
-
-        Returns:
-            None or a value of the given field with the appropriate type that is larger than
-            a given fraction of all current values for that field. None is returned when the
-            result is unknown.
-        """
-        return None
-
     def get_field_quantiles(self, vertex_name, field_name):
         """Return a list dividing the field values in equally-sized groups.
 

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -121,11 +121,9 @@ class LocalStatistics(Statistics):
                              and property field name to a list of N quantiles, a sorted list of
                              values separating the values of the field into N-1 groups of almost
                              equal size. The first element of the list is the smallest known value,
-                             and the last element is the largest known value. Generally, the i-th
-                             element is a value greater than around i/N of all present values.
-                             The number N can be different for each entry. When a table has very
-                             few values, or no data is available, it is better not to provide
-                             information than to provide interpolated information.
+                             and the last element is the largest known value. The i-th
+                             element is a value greater than or equal to aroune i/N of all present
+                             values. The number N can be different for each entry.
         """
         if vertex_edge_vertex_counts is None:
             vertex_edge_vertex_counts = dict()

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -122,7 +122,7 @@ class LocalStatistics(Statistics):
                              values separating the values of the field into N-1 groups of almost
                              equal size. The first element of the list is the smallest known value,
                              and the last element is the largest known value. The i-th
-                             element is a value greater than or equal to aroune i/N of all present
+                             element is a value greater than or equal to i/N of all present
                              values. The number N can be different for each entry.
         """
         if vertex_edge_vertex_counts is None:

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -92,7 +92,7 @@ class Statistics(object):
 
         Returns:
             None or a sorted list of N quantiles dividing the values of the field
-            into N-1 groups of equal size. The first element of the list is the smallest
+            into N-1 groups of almost equal size. The first element of the list is the smallest
             known value, and the last element is the largest known value.
         """
         return None
@@ -119,10 +119,13 @@ class LocalStatistics(Statistics):
                                           values of that vertex class's property field.
             field_quantiles: optional dict, (str, str) -> list, mapping vertex class name
                              and property field name to a list of N quantiles, a sorted list of
-                             values seperating the values of the field into N-1 groups of equal
-                             size. The first element of the list is the smallest known value,
-                             and the last element is the largest known value. The number N can be
-                             different for each entry.
+                             values separating the values of the field into N-1 groups of almost
+                             equal size. The first element of the list is the smallest known value,
+                             and the last element is the largest known value. Generally, the i-th
+                             element is a value greater than around i/N of all present values.
+                             The number N can be different for each entry. When a table has very
+                             few values, or no data is available, it is better not to provide
+                             information than to provide interpolated information.
         """
         if vertex_edge_vertex_counts is None:
             vertex_edge_vertex_counts = dict()

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -82,6 +82,35 @@ class Statistics(object):
         """
         return None
 
+    def get_field_quantile(self, vertex_name, field_name, fraction):
+        """Return the field value that's larger than a given fraction of all values.
+
+        Args:
+            vertex_name: str, name of a vertex defined in the GraphQL schema.
+            field_name: str, name of a vertex field.
+            fraction: float from 0 to 1, the fraction of values smaller than the result
+
+        Returns:
+            None or a value of the given field with the appropriate type that is larger than
+            a given fraction of all current values for that field. None is returned when the
+            result is unknown.
+        """
+        return None
+
+    def get_quantile_rank_of_value(self, vertex_name, field_name, field_value):
+        """Return a [0-1] float representing the fraction of values that are smaller.
+
+        Args:
+            vertex_name: str, name of a vertex defined in the GraphQL schema.
+            field_name: str, name of a vertex field.
+            field_value: An appropriate value for the given field
+
+        Returns:
+            None or the fraction of values for the given field that are smaller than the
+            given value. None is returned when the result is unknown.
+        """
+        return None
+
 
 class LocalStatistics(Statistics):
     """Statistics class that receives all statistics at initialization, storing them in-memory."""
@@ -130,3 +159,11 @@ class LocalStatistics(Statistics):
         """See base class."""
         statistic_key = (vertex_name, field_name)
         return self._distinct_field_values_counts.get(statistic_key)
+
+    def get_field_quantile(self, vertex_name, field_name, fraction):
+        """See base class."""
+        raise NotImplementedError()
+
+    def get_quantile_rank_of_value(self, vertex_name, field_name, field_value):
+        """See base class."""
+        raise NotImplementedError()

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -88,7 +88,8 @@ class Statistics(object):
 
         Args:
             vertex_name: str, name of a vertex defined in the GraphQL schema.
-            field_name: str, name of a vertex field.
+            field_name: str, name of a vertex field. This field has to have a type on which
+                        the < operator makes sense.
 
         Returns:
             None or a sorted list of N quantiles dividing the values of the field

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -1,6 +1,5 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from abc import ABCMeta, abstractmethod
-import math
 
 from frozendict import frozendict
 import six

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -131,15 +131,22 @@ class LocalStatistics(Statistics):
             distinct_field_values_counts: optional dict, (str, str) -> int, mapping vertex class
                                           name and property field name to the count of distinct
                                           values of that vertex class's property field.
+            field_quantiles: optional dict, (str, str) -> list[int], mapping vertex class name
+                             and property field name to a list of N quantiles, a sorted list of
+                             values seperating the values of the field into N+1 groups of equal
+                             size.
         """
         if vertex_edge_vertex_counts is None:
             vertex_edge_vertex_counts = dict()
         if distinct_field_values_counts is None:
             distinct_field_values_counts = dict()
+        if field_quantiles is None:
+            field_quantiles = dict()
 
         self._class_counts = frozendict(class_counts)
         self._vertex_edge_vertex_counts = frozendict(vertex_edge_vertex_counts)
         self._distinct_field_values_counts = frozendict(distinct_field_values_counts)
+        self._field_quantiles = frozendict(field_quantiles)
 
     def get_class_count(self, class_name):
         """See base class."""
@@ -162,6 +169,12 @@ class LocalStatistics(Statistics):
 
     def get_field_quantile(self, vertex_name, field_name, fraction):
         """See base class."""
+        statistic_key = (vertex_name, field_name)
+        if statistic_key not in self._field_quantiles:
+            return None
+        quantiles = self._field_quantiles[statistic_key]
+
+        section_lower_bound = quantiles # XXX
         raise NotImplementedError()
 
     def get_quantile_rank_of_value(self, vertex_name, field_name, field_value):


### PR DESCRIPTION
This information is necessary for auto-pagination on non-uuid fields, and collaterally could make cost estimation more accurate.

When naming these functions, i considered other names that didn't work out as well:
- histogram: This is not a statistical term, but a visualization method.
- percentile: More widely known than quantile, but implies we use percents.