### PR TITLE
Fix SQL integration data

### DIFF
--- a/graphql_compiler/tests/test_data_tools/data_tool.py
+++ b/graphql_compiler/tests/test_data_tools/data_tool.py
@@ -144,6 +144,8 @@ def tear_down_integration_test_backends(sql_test_backends):
 def generate_sql_integration_data(sql_test_backends):
     """Populate test data for SQL backends for integration testing."""
     sql_schema_info = get_sqlalchemy_schema_info()
+
+    # Map vertex classes tuples containing the properties of each vertex of that class
     vertex_values = {
         'Animal': (
             {
@@ -179,13 +181,7 @@ def generate_sql_integration_data(sql_test_backends):
         ),
     }
 
-    uuid_to_class_name = {}
-    for vertex_name, values in six.iteritems(vertex_values):
-        for value in values:
-            if value['uuid'] in uuid_to_class_name:
-                raise AssertionError(u'Duplicate uuid found {}'.format(value['uuid']))
-            uuid_to_class_name[value['uuid']] = vertex_name
-
+    # Map edges to tuples containing the source and destination vertex of each edge of that class
     edge_values = {
         'Entity_Related': (
             {
@@ -195,11 +191,17 @@ def generate_sql_integration_data(sql_test_backends):
         )
     }
 
+    uuid_to_class_name = {}
+    for vertex_name, values in six.iteritems(vertex_values):
+        for value in values:
+            if value['uuid'] in uuid_to_class_name:
+                raise AssertionError(u'Duplicate uuid found {}'.format(value['uuid']))
+            uuid_to_class_name[value['uuid']] = vertex_name
+
     uuid_to_foreign_key_values = {}
     for edge_name, edge_values in six.iteritems(edge_values):
         for edge_value in edge_values:
             from_classname = uuid_to_class_name[edge_value['from_uuid']]
-            to_classname = uuid_to_class_name[edge_value['to_uuid']]
             edge_field_name = 'out_{}'.format(edge_name)
             join_descriptor = sql_schema_info.join_descriptors[from_classname][edge_field_name]
             if join_descriptor.to_column != 'uuid':

--- a/graphql_compiler/tests/test_data_tools/data_tool.py
+++ b/graphql_compiler/tests/test_data_tools/data_tool.py
@@ -191,6 +191,7 @@ def generate_sql_integration_data(sql_test_backends):
         )
     }
 
+    # Find the class name of each vertex uuid
     uuid_to_class_name = {}
     for vertex_name, values in six.iteritems(vertex_values):
         for value in values:
@@ -198,6 +199,7 @@ def generate_sql_integration_data(sql_test_backends):
                 raise AssertionError(u'Duplicate uuid found {}'.format(value['uuid']))
             uuid_to_class_name[value['uuid']] = vertex_name
 
+    # Represent all edges as foreign keys
     uuid_to_foreign_key_values = {}
     for edge_name, edge_values in six.iteritems(edge_values):
         for edge_value in edge_values:
@@ -216,6 +218,7 @@ def generate_sql_integration_data(sql_test_backends):
                                           .format(edge_name, edge_value['from_uuid']))
             existing_foreign_key_values[join_descriptor.from_column] = edge_value['to_uuid']
 
+    # Insert all the prepared data into the test database
     for sql_test_backend in six.itervalues(sql_test_backends):
         for vertex_name, insert_values in six.iteritems(vertex_values):
             table = sql_schema_info.vertex_name_to_table[vertex_name]

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -571,11 +571,12 @@ def get_sqlalchemy_schema_info():
         'Species': sqlalchemy.Table(
             'Species',
             sqlalchemy_metadata_2,
-            sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
+            sqlalchemy.Column('description', sqlalchemy.String(40), nullable=True),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('eats', uuid_type, nullable=True),
-            sqlalchemy.Column('limbs', sqlalchemy.Integer, nullable=False),
+            sqlalchemy.Column('limbs', sqlalchemy.Integer, nullable=True),
+            sqlalchemy.Column('related_entity', uuid_type, nullable=True),
             schema='db_1.schema_1'
         ),
         'UniquelyIdentifiable': sqlalchemy.Table(


### PR DESCRIPTION
Match the SQL integration data with the one we use for all other databases, while at the same time moving towards a backend-agnostic integration data representation.