### PR TITLE
Find orientdb recurse inconsistency

### DIFF
--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -363,7 +363,7 @@ class IntegrationTests(TestCase):
         # TODO(bojanserafimov): Only tested in MSSQL. To test in other backends, they should read in
         #                       the standard integration test schema used by the SQL backend.
         for graphql_query, expected_results in queries:
-            self.assertResultsEqual(graphql_query, parameters, test_backend.MSSQL, expected_results)
+            self.assertResultsEqual(graphql_query, parameters, test_backend.ORIENTDB, expected_results)
 
     # RedisGraph doesn't support temporal types, so Date types aren't supported.
     @use_all_backends(except_backends=(test_backend.REDISGRAPH))


### PR DESCRIPTION
This test will fail, pointing out that our Match and MSSQL backends have different recurse semantics.

The semantic question is, if a node can be reached in multiple different ways, should it be included in the result multiple times? Match says no, MSSQL says yes.

The docs don't precisely specify the desired semantics, so please comment if you have opinions.