### PR TITLE
Fix navigation depth setup

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,3 +55,10 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# This specifies how many header levels below the title should we include in the table of contents
+# navigation bar. With a navigation depth of 2 we only include the title and the top header of
+# each page.
+html_theme_options = {
+    'navigation_depth': 2,
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,6 @@ The GraphQL Compiler
             GraphQL Compiler Readthedocs contributors.
 
 .. toctree::
-   :maxdepth: 2
    :hidden:
 
    Home <self>
@@ -176,7 +175,6 @@ To learn more about the core specification of the GraphQL query language see:
   available directives and how to use them to create powerful queries.
 
 .. toctree::
-   :maxdepth: 2
    :caption: Core Specification
    :hidden:
 
@@ -196,7 +194,6 @@ types of database backends:
 - :doc:`SQL Databases <databases/sql>`, including SQL Server, Postgres and more.
 
 .. toctree::
-   :maxdepth: 2
    :caption: Databases
    :hidden:
 
@@ -219,7 +216,6 @@ To learn more about the advanced features in the GraphQL compiler see:
   easy to explore the schema of a database, including the databases indexes.
 
 .. toctree::
-   :maxdepth: 2
    :caption: Advanced Features
    :hidden:
 


### PR DESCRIPTION
The table of contents navigation bar was incorrectly set up and so it included it all header levels. This PR fixes that bug.