### PR TITLE
Register "slow" pytest mark to avoid PytestUnknownMarkWarning.

### DIFF
--- a/graphql_compiler/tests/conftest.py
+++ b/graphql_compiler/tests/conftest.py
@@ -125,6 +125,15 @@ def pytest_addoption(parser):
     parser.addoption('--skip-slow', action='store_true', default=False, help='Skip slow tests.')
 
 
+def pytest_configure(config):
+    """Initialize the pytest configuration. Executed prior to any tests."""
+    config.addinivalue_line(
+        # Define the "slow" pytest mark, to avoid PytestUnknownMarkWarning being generated.
+        'markers',
+        'slow: marks tests as slow (deselect with \'-m "not slow"\' or --skip-slow)',
+    )
+
+
 def pytest_collection_modifyitems(config, items):
     """Modify py.test behavior based on command line options."""
     if not config.getoption('--skip-slow'):


### PR DESCRIPTION
Applied recommended solution from: https://docs.pytest.org/en/latest/mark.html

Since marks have the `-m` syntax already available as a built-in, do we still need the `--skip-slow` flag or can we remove it?