### PR TITLE
Remove unnecessary limiting of type_equivalence_hints

### DIFF
--- a/graphql_compiler/schema_generation/sqlalchemy/__init__.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/__init__.py
@@ -57,15 +57,10 @@ def get_sqlalchemy_schema_info_from_specified_metadata(
 
     # Since there will be no inheritance in the GraphQL schema, it is simpler to omit the class.
     hidden_classes = set()
-    graphql_schema, _ = get_graphql_schema_from_schema_graph(
+    graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(
         schema_graph, class_to_field_type_overrides, hidden_classes)
 
     join_descriptors = get_join_descriptors_from_edge_descriptors(direct_edges)
-
-    # type_equivalence_hints exists as field in SQLAlchemySchemaInfo to make testing easier for
-    # the SQL backend. However, there is no inheritance in SQLAlchemy and there will be no GraphQL
-    # union types in the schema, so we set the type_equivalence_hints to be an empty dict.
-    type_equivalence_hints = {}
 
     return SQLAlchemySchemaInfo(
         graphql_schema, type_equivalence_hints, dialect, vertex_name_to_table, join_descriptors)


### PR DESCRIPTION
Since we don't generate any union types, then we will generate an empty type_equivalence_hints anyways. 