### PR TITLE
Run backend integration test for SQL fold

### DIFF
--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -375,7 +375,6 @@ class IntegrationTests(TestCase):
             self.assertResultsEqual(graphql_query, parameters, test_backend.MSSQL, expected_results)
 
     @use_all_backends(except_backends=(
-        test_backend.MSSQL,  # Not implemented yet
         test_backend.REDISGRAPH,  # Not implemented yet
     ))
     @integration_fixtures


### PR DESCRIPTION
Basic folds are implemented in [#595](https://github.com/kensho-technologies/graphql-compiler/pull/595) so we should run the `test_fold_basic` integration test.