### PR TITLE
Make macro expansion faster

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2161,7 +2161,7 @@ We can now observe the process of macro expansion in action:
 
 .. code:: python
 
-    from graphql_compiler.macros import perform_macro_expansion
+    from graphql_compiler.macros import get_schema_with_macros, perform_macro_expansion
 
     query = '''{
         Animal {
@@ -2175,7 +2175,8 @@ We can now observe the process of macro expansion in action:
         'animal_name': 'Hedwig',
     }
 
-    new_query, new_args = perform_macro_expansion(your_macro_registry_object, query, args)
+    schema_with_macros = get_schema_with_macros(macro_registry)
+    new_query, new_args = perform_macro_expansion(macro_registry, schema_with_macros, query, args)
 
     print(new_query)
     # Prints out the following query:
@@ -2266,7 +2267,9 @@ automatically ensure that the macro edge's arguments become part of the expanded
         }
     }'''
     args = {}
-    expanded_query, new_args = perform_macro_expansion(your_macro_registry_object, query, args)
+    schema_with_macros = get_schema_with_macros(macro_registry)
+    expanded_query, new_args = perform_macro_expansion(
+          macro_registry, schema_with_macros, query, args)
 
     print(expanded_query)
     # Prints out the following query:

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -226,11 +226,12 @@ def get_schema_for_macro_definition(schema):
     return macro_definition_schema
 
 
-def perform_macro_expansion(macro_registry, graphql_with_macro, graphql_args):
+def perform_macro_expansion(macro_registry, schema_with_macros, graphql_with_macro, graphql_args):
     """Return a new GraphQL query string and args, after expanding any encountered macros.
 
     Args:
         macro_registry: MacroRegistry, the registry of macro descriptors used for expansion
+        schema_with_macros: A schema obtained by running get_schema_with_macros(macro_registry)
         graphql_with_macro: string, GraphQL query that potentially requires macro expansion
         graphql_args: dict mapping strings to any type, containing the arguments for the query
 
@@ -240,7 +241,6 @@ def perform_macro_expansion(macro_registry, graphql_with_macro, graphql_args):
         the returned values are guaranteed to be identical to the input query and args.
     """
     query_ast = safe_parse_graphql(graphql_with_macro)
-    schema_with_macros = get_schema_with_macros(macro_registry)
     validation_errors = validate_schema_and_query_ast(schema_with_macros, query_ast)
     if validation_errors:
         raise GraphQLValidationError(u'The provided GraphQL input does not validate: {} {}'

--- a/graphql_compiler/tests/test_macro_expansion.py
+++ b/graphql_compiler/tests/test_macro_expansion.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 
 from ..exceptions import GraphQLCompilationError
-from ..macros import perform_macro_expansion
+from ..macros import get_schema_with_macros, perform_macro_expansion
 from .test_helpers import compare_graphql, get_test_macro_registry
 
 
@@ -13,6 +13,7 @@ class MacroExpansionTests(unittest.TestCase):
         """Disable max diff limits for all tests."""
         self.maxDiff = None
         self.macro_registry = get_test_macro_registry()
+        self.schema_with_macros = get_schema_with_macros(self.macro_registry)
 
     def test_macro_edge_basic(self):
         query = '''{
@@ -35,7 +36,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self. schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -65,7 +67,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -95,7 +98,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -120,7 +124,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -159,7 +164,8 @@ class MacroExpansionTests(unittest.TestCase):
             'net_worth_upper_bound': 5,
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -199,7 +205,8 @@ class MacroExpansionTests(unittest.TestCase):
             'net_worth_upper_bound': 5,
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -236,7 +243,8 @@ class MacroExpansionTests(unittest.TestCase):
             'net_worth_upper_bound': 5,
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -265,7 +273,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -292,7 +301,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -319,7 +329,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -346,7 +357,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -379,7 +391,8 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'croissant'
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -410,7 +423,8 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'croissant'
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -437,7 +451,8 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'Nate',
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -469,7 +484,8 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'Nate',
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -503,7 +519,8 @@ class MacroExpansionTests(unittest.TestCase):
             'num_parents': 0,
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -534,7 +551,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -573,7 +591,7 @@ class MacroExpansionTests(unittest.TestCase):
         expected_args = {}
 
         expanded_query, new_args = perform_macro_expansion(
-            self.macro_registry, query, args)
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -611,7 +629,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -642,7 +661,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -679,7 +699,8 @@ class MacroExpansionTests(unittest.TestCase):
         }'''
         expected_args = {}
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -708,7 +729,8 @@ class MacroExpansionTests(unittest.TestCase):
             'wanted': 'Larry'
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)
 
@@ -747,6 +769,7 @@ class MacroExpansionTests(unittest.TestCase):
             'name': 'Nate',
         }
 
-        expanded_query, new_args = perform_macro_expansion(self.macro_registry, query, args)
+        expanded_query, new_args = perform_macro_expansion(
+            self.macro_registry, self.schema_with_macros, query, args)
         compare_graphql(self, expected_query, expanded_query)
         self.assertEqual(expected_args, new_args)

--- a/graphql_compiler/tests/test_macro_expansion_errors.py
+++ b/graphql_compiler/tests/test_macro_expansion_errors.py
@@ -2,7 +2,7 @@
 import unittest
 
 from ..exceptions import GraphQLCompilationError, GraphQLValidationError
-from ..macros import perform_macro_expansion
+from ..macros import get_schema_with_macros, perform_macro_expansion
 from .test_helpers import get_test_macro_registry
 
 
@@ -11,6 +11,7 @@ class MacroExpansionTests(unittest.TestCase):
         """Disable max diff limits for all tests."""
         self.maxDiff = None
         self.macro_registry = get_test_macro_registry()
+        self.schema_with_macros = get_schema_with_macros(self.macro_registry)
 
     def test_macro_edge_duplicate_edge_traversal(self):
         query = '''{
@@ -26,7 +27,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_macro_edge_duplicate_macro_traversal(self):
         query = '''{
@@ -42,7 +43,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_macro_edge_target_coercion_invalid_1(self):
         query = '''{
@@ -57,7 +58,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLValidationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_macro_edge_invalid_coercion_2(self):
         query = '''{
@@ -72,7 +73,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLValidationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_macro_edge_nonexistent(self):
         query = '''{
@@ -85,7 +86,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLValidationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_incorrect_schema_usage(self):
         # Test with fields that don't exist in the schema
@@ -99,7 +100,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLValidationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_recurse_at_expansion_is_not_supported(self):
         query = '''{
@@ -112,7 +113,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_optional_at_expansion_is_not_supported(self):
         query = '''{
@@ -125,7 +126,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_fold_at_expansion_is_not_supported(self):
         query = '''{
@@ -139,7 +140,7 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)
 
     def test_output_source_at_expansion_is_not_supported(self):
         query = '''{
@@ -153,4 +154,4 @@ class MacroExpansionTests(unittest.TestCase):
         args = {}
 
         with self.assertRaises(GraphQLCompilationError):
-            perform_macro_expansion(self.macro_registry, query, args)
+            perform_macro_expansion(self.macro_registry, self.schema_with_macros, query, args)


### PR DESCRIPTION
We currently generate the schema with macros every time we run macro expansion, which is very slow. In this PR I make the schema with macros an argument of macro expansion.

An alternative solution is to include the schema with macros into the macro registry, but that will make macro registry creation very slow (unless we make a `batch_register_macro_edge` method).