### PR TITLE
Move validation to the get_sqlalchemy_schema_graph

### DIFF
--- a/graphql_compiler/schema_generation/sqlalchemy/__init__.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/__init__.py
@@ -1,9 +1,8 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from ...schema.schema_info import SQLAlchemySchemaInfo
 from ..graphql_schema import get_graphql_schema_from_schema_graph
-from .edge_descriptors import get_join_descriptors_from_edge_descriptors, validate_edge_descriptors
+from .edge_descriptors import get_join_descriptors_from_edge_descriptors
 from .schema_graph_builder import get_sqlalchemy_schema_graph
-from .utils import validate_that_tables_have_primary_keys
 
 
 def get_sqlalchemy_schema_info_from_specified_metadata(
@@ -50,9 +49,6 @@ def get_sqlalchemy_schema_info_from_specified_metadata(
     Return:
         SQLAlchemySchemaInfo containing the full information needed to compile SQL queries.
     """
-    validate_edge_descriptors(vertex_name_to_table, direct_edges)
-    validate_that_tables_have_primary_keys(vertex_name_to_table.values())
-
     schema_graph = get_sqlalchemy_schema_graph(vertex_name_to_table, direct_edges)
 
     graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(

--- a/graphql_compiler/schema_generation/sqlalchemy/schema_graph_builder.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/schema_graph_builder.py
@@ -4,7 +4,9 @@ from ..schema_graph import (
     EdgeType, InheritanceStructure, PropertyDescriptor, SchemaGraph, VertexType,
     link_schema_elements
 )
+from .edge_descriptors import validate_edge_descriptors
 from .scalar_type_mapper import try_get_graphql_scalar_type
+from .utils import validate_that_tables_have_primary_keys
 
 
 def get_sqlalchemy_schema_graph(vertex_name_to_table, direct_edges):
@@ -26,6 +28,9 @@ def get_sqlalchemy_schema_graph(vertex_name_to_table, direct_edges):
     Returns:
         SchemaGraph reflecting the specified metadata.
     """
+    validate_edge_descriptors(vertex_name_to_table, direct_edges)
+    validate_that_tables_have_primary_keys(vertex_name_to_table.values())
+
     vertex_types = {
         vertex_name: _get_vertex_type_from_sqlalchemy_table(vertex_name, table)
         for vertex_name, table in vertex_name_to_table.items()


### PR DESCRIPTION
We should minimize the amount of code in get_sqlalchemy_schema_info_from_specified_metadata