### PR TITLE
Rewrote SQL fold tests from #595 to make clear they target PostgreSQL

### DIFF
--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -4149,13 +4149,13 @@ class CompilerTests(unittest.TestCase):
                 "Animal_1".name AS animal_name,
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list
             FROM
-                "db_1.schema_1"."Animal" AS "Animal_1"
+                schema_1."Animal" AS "Animal_1"
             LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
-                FROM "db_1.schema_1"."Animal" AS "Animal_2"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
+                FROM schema_1."Animal" AS "Animal_2"
+                JOIN schema_1."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
                     "Animal_2".uuid
             ) AS folded_subquery_1
@@ -4186,14 +4186,14 @@ class CompilerTests(unittest.TestCase):
                 ARRAY [] :: VARCHAR []
               ) AS child_names_list
             FROM
-                "db_1.schema_1"."Animal" AS "Animal_1"
+                schema_1."Animal" AS "Animal_1"
             LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
                     array_agg("Animal_3".color) AS fold_output_color
-                FROM "db_1.schema_1"."Animal" AS "Animal_2"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
+                FROM schema_1."Animal" AS "Animal_2"
+                JOIN schema_1."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
                     "Animal_2".uuid
             ) AS folded_subquery_1
@@ -4217,25 +4217,25 @@ class CompilerTests(unittest.TestCase):
               coalesce(folded_subquery_2.fold_output_name, ARRAY[]::VARCHAR[])
                 AS sibling_and_self_names_list
             FROM
-              "db_1.schema_1"."Animal" AS "Animal_1"
+              schema_1."Animal" AS "Animal_1"
             LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
                 FROM
-                  "db_1.schema_1"."Animal" AS "Animal_2"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
+                  schema_1."Animal" AS "Animal_2"
+                JOIN schema_1."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
                   "Animal_2".uuid
             ) AS folded_subquery_1 ON "Animal_1".uuid = folded_subquery_1.uuid
-            JOIN "db_1.schema_1"."Animal" AS "Animal_4" ON "Animal_1".parent = "Animal_4".uuid
+            JOIN schema_1."Animal" AS "Animal_4" ON "Animal_1".parent = "Animal_4".uuid
             LEFT OUTER JOIN (
                 SELECT
                     "Animal_5".uuid AS uuid,
                     array_agg("Animal_6".name) AS fold_output_name
                 FROM
-                  "db_1.schema_1"."Animal" AS "Animal_5"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_6" ON "Animal_5".uuid = "Animal_6".parent
+                  schema_1."Animal" AS "Animal_5"
+                JOIN schema_1."Animal" AS "Animal_6" ON "Animal_5".uuid = "Animal_6".parent
                 GROUP BY
                   "Animal_5".uuid
             ) AS folded_subquery_2 ON "Animal_4".uuid = folded_subquery_2.uuid
@@ -4292,15 +4292,15 @@ class CompilerTests(unittest.TestCase):
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
                 AS sibling_and_self_names_list
             FROM
-              "db_1.schema_1"."Animal" AS "Animal_1"
-            JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+              schema_1."Animal" AS "Animal_1"
+            JOIN schema_1."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
             LEFT OUTER JOIN(
                 SELECT
                     "Animal_3".uuid AS uuid,
                     array_agg("Animal_4".name) AS fold_output_name
-                FROM "db_1.schema_1"."Animal" AS "Animal_3"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_4"
+                FROM schema_1."Animal" AS "Animal_3"
+                JOIN schema_1."Animal" AS "Animal_4"
                 ON "Animal_3".uuid = "Animal_4".parent
                 GROUP BY "Animal_3".uuid
             ) AS folded_subquery_1
@@ -4334,15 +4334,15 @@ class CompilerTests(unittest.TestCase):
               "Animal_1".name AS animal_name,
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
                   AS neighbor_and_self_names_list
-            FROM "db_1.schema_1"."Animal" AS "Animal_1"
-            JOIN "db_1.schema_1"."Location" AS "Location_1"
+            FROM schema_1."Animal" AS "Animal_1"
+            JOIN schema_1."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
             LEFT OUTER JOIN (
                 SELECT
                   "Location_2".uuid AS uuid,
                   array_agg("Animal_2".name) AS fold_output_name
-                FROM "db_1.schema_1"."Location" AS "Location_2"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+                FROM schema_1."Location" AS "Location_2"
+                JOIN schema_1."Animal" AS "Animal_2"
                 ON "Location_2".uuid = "Animal_2".lives_in
                 GROUP BY "Location_2".uuid
             ) AS folded_subquery_1
@@ -4364,15 +4364,15 @@ class CompilerTests(unittest.TestCase):
                 "Location_1".name AS location_name,
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
                     AS neighbor_and_self_names_list
-            FROM "db_1.schema_1"."Animal" AS "Animal_1"
-            JOIN "db_1.schema_1"."Location" AS "Location_1"
+            FROM schema_1."Animal" AS "Animal_1"
+            JOIN schema_1."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
             LEFT OUTER JOIN (
                 SELECT
                     "Location_2".uuid AS uuid,
                     array_agg("Animal_2".name) AS fold_output_name
-                FROM "db_1.schema_1"."Location" AS "Location_2"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+                FROM schema_1."Location" AS "Location_2"
+                JOIN schema_1."Animal" AS "Animal_2"
                 ON "Location_2".uuid = "Animal_2".lives_in
                 GROUP BY "Location_2".uuid
             ) AS folded_subquery_1
@@ -7247,16 +7247,16 @@ class CompilerTests(unittest.TestCase):
               "Animal_1".name AS animal_name,
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
               "Animal_2".name AS parent_name
-            FROM "db_1.schema_1"."Animal" AS "Animal_1"
+            FROM schema_1."Animal" AS "Animal_1"
             LEFT OUTER JOIN
-                "db_1.schema_1"."Animal" AS "Animal_2"
+                schema_1."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
             LEFT OUTER JOIN (
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name
-                FROM "db_1.schema_1"."Animal" AS "Animal_3"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_4"
+                FROM schema_1."Animal" AS "Animal_3"
+                JOIN schema_1."Animal" AS "Animal_4"
                 ON "Animal_3".uuid = "Animal_4".parent
                 GROUP BY "Animal_3".uuid
             ) AS folded_subquery_1
@@ -7342,19 +7342,19 @@ class CompilerTests(unittest.TestCase):
               "Animal_1".name AS animal_name,
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
               "Animal_2".name AS parent_name
-            FROM "db_1.schema_1"."Animal" AS "Animal_1"
+            FROM schema_1."Animal" AS "Animal_1"
             LEFT OUTER JOIN (
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name
-                FROM "db_1.schema_1"."Animal" AS "Animal_3"
-                JOIN "db_1.schema_1"."Animal" AS "Animal_4"
+                FROM schema_1."Animal" AS "Animal_3"
+                JOIN schema_1."Animal" AS "Animal_4"
                 ON "Animal_3".uuid = "Animal_4".parent
                 GROUP BY "Animal_3".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
             LEFT OUTER JOIN
-                "db_1.schema_1"."Animal" AS "Animal_2"
+                schema_1."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
         '''
         expected_cypher = '''

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -4223,7 +4223,7 @@ class CompilerTests(unittest.TestCase):
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
                 FROM
-                    "db_1.schema_1"."Animal" AS "Animal_2"
+                  "db_1.schema_1"."Animal" AS "Animal_2"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
                   "Animal_2".uuid

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -7248,7 +7248,7 @@ class CompilerTests(unittest.TestCase):
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
               "Animal_2".name AS parent_name
             FROM "db_1.schema_1"."Animal" AS "Animal_1"
-            LEFT OUTER JOIN 
+            LEFT OUTER JOIN
                 "db_1.schema_1"."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
             LEFT OUTER JOIN (
@@ -7353,7 +7353,7 @@ class CompilerTests(unittest.TestCase):
                 GROUP BY "Animal_3".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
-            LEFT OUTER JOIN 
+            LEFT OUTER JOIN
                 "db_1.schema_1"."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
         '''

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -4146,20 +4146,18 @@ class CompilerTests(unittest.TestCase):
         expected_mssql = SKIP_TEST
         expected_postgresql = '''
             SELECT
-              "Animal_1".name AS animal_name,
-              coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list
+                "Animal_1".name AS animal_name,
+                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list
             FROM
-              "db_1.schema_1"."Animal" AS "Animal_1"
-            LEFT OUTER JOIN(
+                "db_1.schema_1"."Animal" AS "Animal_1"
+            LEFT OUTER JOIN (
                 SELECT
                   "Animal_2".uuid AS uuid,
                   array_agg("Animal_3".name) AS fold_output_name
-                FROM
-                  "db_1.schema_1"."Animal" AS "Animal_2"
-                  JOIN "db_1.schema_1"."Animal" AS "Animal_3"
-                  ON "Animal_2".uuid = "Animal_3".parent
+                FROM "db_1.schema_1"."Animal" AS "Animal_2"
+                JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
-                  "Animal_2".uuid
+                    "Animal_2".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
         '''
@@ -4188,18 +4186,18 @@ class CompilerTests(unittest.TestCase):
                 ARRAY [] :: VARCHAR []
               ) AS child_names_list
             FROM
-              "db_1.schema_1"."Animal" AS "Animal_1"
-            LEFT OUTER JOIN(
+                "db_1.schema_1"."Animal" AS "Animal_1"
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
                     array_agg("Animal_3".color) AS fold_output_color
-                FROM
-                    "db_1.schema_1"."Animal" AS "Animal_2"
+                FROM "db_1.schema_1"."Animal" AS "Animal_2"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
                     "Animal_2".uuid
-            ) AS folded_subquery_1 ON "Animal_1".uuid = folded_subquery_1.uuid
+            ) AS folded_subquery_1
+            ON "Animal_1".uuid = folded_subquery_1.uuid
         '''
         expected_match = SKIP_TEST
         expected_gremlin = SKIP_TEST
@@ -4214,20 +4212,21 @@ class CompilerTests(unittest.TestCase):
         expected_postgresql = '''
             SELECT
               "Animal_1".name AS animal_name,
-              coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
+              coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
+                AS child_names_list,
               coalesce(folded_subquery_2.fold_output_name, ARRAY[]::VARCHAR[])
                 AS sibling_and_self_names_list
             FROM
               "db_1.schema_1"."Animal" AS "Animal_1"
             LEFT OUTER JOIN (
                 SELECT
-                  "Animal_2".uuid AS uuid,
-                  array_agg("Animal_3".name) AS fold_output_name
+                    "Animal_2".uuid AS uuid,
+                    array_agg("Animal_3".name) AS fold_output_name
                 FROM
-                  "db_1.schema_1"."Animal" AS "Animal_2"
+                    "db_1.schema_1"."Animal" AS "Animal_2"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
-                  "Animal_2".uuid
+                    "Animal_2".uuid
             ) AS folded_subquery_1 ON "Animal_1".uuid = folded_subquery_1.uuid
             JOIN "db_1.schema_1"."Animal" AS "Animal_4" ON "Animal_1".parent = "Animal_4".uuid
             LEFT OUTER JOIN (
@@ -4235,7 +4234,7 @@ class CompilerTests(unittest.TestCase):
                     "Animal_5".uuid AS uuid,
                     array_agg("Animal_6".name) AS fold_output_name
                 FROM
-                    "db_1.schema_1"."Animal" AS "Animal_5"
+                  "db_1.schema_1"."Animal" AS "Animal_5"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_6" ON "Animal_5".uuid = "Animal_6".parent
                 GROUP BY
                     "Animal_5".uuid
@@ -4300,12 +4299,10 @@ class CompilerTests(unittest.TestCase):
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name
-                FROM
-                  "db_1.schema_1"."Animal" AS "Animal_3"
+                FROM "db_1.schema_1"."Animal" AS "Animal_3"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_4"
                 ON "Animal_3".uuid = "Animal_4".parent
-                GROUP BY
-                  "Animal_3".uuid
+                GROUP BY "Animal_3".uuid
             ) AS folded_subquery_1
             ON "Animal_2".uuid = folded_subquery_1.uuid
         '''
@@ -4337,20 +4334,17 @@ class CompilerTests(unittest.TestCase):
               "Animal_1".name AS animal_name,
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
                   AS neighbor_and_self_names_list
-            FROM
-              "db_1.schema_1"."Animal" AS "Animal_1"
+            FROM "db_1.schema_1"."Animal" AS "Animal_1"
             JOIN "db_1.schema_1"."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
-            LEFT OUTER JOIN(
+            LEFT OUTER JOIN (
                 SELECT
                   "Location_2".uuid AS uuid,
                   array_agg("Animal_2".name) AS fold_output_name
-                FROM
-                  "db_1.schema_1"."Location" AS "Location_2"
+                FROM "db_1.schema_1"."Location" AS "Location_2"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_2"
                 ON "Location_2".uuid = "Animal_2".lives_in
-                GROUP BY
-                  "Location_2".uuid
+                GROUP BY "Location_2".uuid
             ) AS folded_subquery_1 ON "Location_1".uuid = folded_subquery_1.uuid
         '''
 
@@ -4369,21 +4363,19 @@ class CompilerTests(unittest.TestCase):
               "Location_1".name AS location_name,
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
                   AS neighbor_and_self_names_list
-            FROM
-              "db_1.schema_1"."Animal" AS "Animal_1"
+            FROM "db_1.schema_1"."Animal" AS "Animal_1"
             JOIN "db_1.schema_1"."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
-            LEFT OUTER JOIN(
+            LEFT OUTER JOIN (
                 SELECT
                   "Location_2".uuid AS uuid,
                   array_agg("Animal_2".name) AS fold_output_name
-                FROM
-                  "db_1.schema_1"."Location" AS "Location_2"
+                FROM "db_1.schema_1"."Location" AS "Location_2"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_2"
                 ON "Location_2".uuid = "Animal_2".lives_in
-                GROUP BY
-                  "Location_2".uuid
-            ) AS folded_subquery_1 ON "Location_1".uuid = folded_subquery_1.uuid
+                GROUP BY "Location_2".uuid
+            ) AS folded_subquery_1
+            ON "Location_1".uuid = folded_subquery_1.uuid
         '''
 
         expected_match = SKIP_TEST
@@ -7254,20 +7246,18 @@ class CompilerTests(unittest.TestCase):
               "Animal_1".name AS animal_name,
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
               "Animal_2".name AS parent_name
-            FROM
-              "db_1.schema_1"."Animal" AS "Animal_1"
-            LEFT OUTER JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+            FROM "db_1.schema_1"."Animal" AS "Animal_1"
+            LEFT OUTER JOIN 
+                "db_1.schema_1"."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
-            LEFT OUTER JOIN(
+            LEFT OUTER JOIN (
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name
-                FROM
-                  "db_1.schema_1"."Animal" AS "Animal_3"
+                FROM "db_1.schema_1"."Animal" AS "Animal_3"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_4"
                 ON "Animal_3".uuid = "Animal_4".parent
-                GROUP BY
-                  "Animal_3".uuid
+                GROUP BY "Animal_3".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
         '''
@@ -7351,21 +7341,19 @@ class CompilerTests(unittest.TestCase):
               "Animal_1".name AS animal_name,
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
               "Animal_2".name AS parent_name
-            FROM
-              "db_1.schema_1"."Animal" AS "Animal_1"
-            LEFT OUTER JOIN(
+            FROM "db_1.schema_1"."Animal" AS "Animal_1"
+            LEFT OUTER JOIN (
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name
-                FROM
-                  "db_1.schema_1"."Animal" AS "Animal_3"
+                FROM "db_1.schema_1"."Animal" AS "Animal_3"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_4"
                 ON "Animal_3".uuid = "Animal_4".parent
-                GROUP BY
-                  "Animal_3".uuid
+                GROUP BY "Animal_3".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
-            LEFT OUTER JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+            LEFT OUTER JOIN 
+                "db_1.schema_1"."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
         '''
         expected_cypher = '''

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -20,7 +20,8 @@ from .test_helpers import (
 
 
 def check_test_data(
-        test_case, test_data, expected_match, expected_gremlin, expected_sql, expected_cypher):
+        test_case, test_data, expected_match, expected_gremlin, expected_mssql, expected_cypher,
+        expected_postgresql=SKIP_TEST):
     """Assert that the GraphQL input generates all expected output queries data."""
     if test_data.type_equivalence_hints:
         # For test convenience, we accept the type equivalence hints in string form.
@@ -32,15 +33,20 @@ def check_test_data(
     else:
         schema_based_type_equivalence_hints = None
 
-    result = compile_graphql_to_match(test_case.schema, test_data.graphql_input,
-                                      type_equivalence_hints=schema_based_type_equivalence_hints)
-
-    compare_match(test_case, expected_match, result.query)
-    test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
-    compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
+    if expected_match == SKIP_TEST:
+        pass
+    else:
+        result = compile_graphql_to_match(test_case.schema, test_data.graphql_input,
+                                          type_equivalence_hints=schema_based_type_equivalence_hints
+                                          )
+        compare_match(test_case, expected_match, result.query)
+        test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
+        compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
 
     # Allow features to not be implemented in Gremlin and SQL, and instead raise compilation errors.
-    if expected_gremlin == NotImplementedError:
+    if expected_gremlin == SKIP_TEST:
+        pass
+    elif expected_gremlin == NotImplementedError:
         with test_case.assertRaises(NotImplementedError):
             compile_graphql_to_gremlin(
                 test_case.schema, test_data.graphql_input,
@@ -53,17 +59,32 @@ def check_test_data(
         test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
         compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
 
-    if expected_sql == SKIP_TEST:
+    if expected_mssql == SKIP_TEST:
         pass
-    elif expected_sql == NotImplementedError:
+    elif expected_mssql == NotImplementedError:
         not_supported = (NotImplementedError, GraphQLValidationError, GraphQLCompilationError)
         with test_case.assertRaises(not_supported):
-            compile_graphql_to_sql(test_case.sql_schema_info, test_data.graphql_input)
+            compile_graphql_to_sql(test_case.mssql_schema_info, test_data.graphql_input)
     else:
-        result = compile_graphql_to_sql(test_case.sql_schema_info, test_data.graphql_input)
+        result = compile_graphql_to_sql(test_case.mssql_schema_info, test_data.graphql_input)
         string_result = print_sqlalchemy_query_string(
-            result.query, test_case.sql_schema_info.dialect)
-        compare_sql(test_case, expected_sql, string_result)
+            result.query, test_case.mssql_schema_info.dialect)
+        compare_sql(test_case, expected_mssql, string_result)
+        test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
+        compare_input_metadata(test_case, test_data.expected_input_metadata,
+                               result.input_metadata)
+
+    if expected_postgresql == SKIP_TEST:
+        pass
+    elif expected_postgresql == NotImplementedError:
+        not_supported = (NotImplementedError, GraphQLValidationError, GraphQLCompilationError)
+        with test_case.assertRaises(not_supported):
+            compile_graphql_to_sql(test_case.postgresql_schema_info, test_data.graphql_input)
+    else:
+        result = compile_graphql_to_sql(test_case.postgresql_schema_info, test_data.graphql_input)
+        string_result = print_sqlalchemy_query_string(
+            result.query, test_case.postgresql_schema_info.dialect)
+        compare_sql(test_case, expected_postgresql, string_result)
         test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
         compare_input_metadata(test_case, test_data.expected_input_metadata,
                                result.input_metadata)
@@ -89,7 +110,8 @@ class CompilerTests(unittest.TestCase):
         """Disable max diff limits for all tests."""
         self.maxDiff = None
         self.schema = get_schema()
-        self.sql_schema_info = get_sqlalchemy_schema_info()
+        self.mssql_schema_info = get_sqlalchemy_schema_info()
+        self.postgresql_schema_info = get_sqlalchemy_schema_info(dialect='postgresql')
 
     def test_immediate_output(self):
         test_data = test_input_data.immediate_output()
@@ -4120,22 +4142,28 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         '''
-        expected_sql = '''
+        expected_mssql = SKIP_TEST
+        expected_postgresql = '''
             SELECT
-                [Animal_1].name AS animal_name,
-                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list
+              "Animal_1".name AS animal_name,
+              coalesce(
+                folded_subquery_1.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS child_names_list
             FROM
-                db_1.schema_1.[Animal] AS [Animal_1]
-            LEFT OUTER JOIN (
+              "db_1.schema_1"."Animal" AS "Animal_1"
+              LEFT OUTER JOIN(
                 SELECT
-                    [Animal_2].uuid AS uuid,
-                    array_agg([Animal_3].name) AS fold_output_name
-                FROM db_1.schema_1.[Animal] AS [Animal_2]
-                JOIN db_1.schema_1.[Animal] AS [Animal_3] ON [Animal_2].uuid = [Animal_3].parent
+                  "Animal_2".uuid AS uuid,
+                  array_agg("Animal_3".name) AS fold_output_name
+                FROM
+                  "db_1.schema_1"."Animal" AS "Animal_2"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_3"
+                  ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
-                    [Animal_2].uuid
-            ) AS folded_subquery_1
-            ON [Animal_1].uuid = folded_subquery_1.uuid
+                  "Animal_2".uuid
+              ) AS folded_subquery_1
+              ON "Animal_1".uuid = folded_subquery_1.uuid
         '''
         expected_cypher = '''
             MATCH (Animal___1:Animal)
@@ -4147,79 +4175,89 @@ class CompilerTests(unittest.TestCase):
               Animal___1.name AS `animal_name`,
               [x IN collected_Animal__out_Animal_ParentOf___1 | x.name] AS `child_names_list`
         '''
-        check_test_data(self, test_data, expected_match, expected_gremlin, expected_sql,
-                        expected_cypher)
+        check_test_data(self, test_data, expected_match, expected_gremlin, expected_mssql,
+                        expected_cypher, expected_postgresql)
 
     def test_fold_on_two_output_variables(self):
         test_data = test_input_data.fold_on_two_output_variables()
 
-        expected_sql = '''
+        expected_postgresql = '''
             SELECT
-                [Animal_1].name AS animal_name,
-                coalesce(folded_subquery_1.fold_output_color, ARRAY[]::VARCHAR[])
-                    AS child_color_list,
-                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
-                    AS child_names_list
+              "Animal_1".nameASanimal_name,
+              coalesce(
+                folded_subquery_1.fold_output_color,
+                ARRAY [] :: VARCHAR []
+              ) AS child_color_list,
+              coalesce(
+                folded_subquery_1.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS child_names_list
             FROM
-                db_1.schema_1.[Animal] AS [Animal_1]
-            LEFT OUTER JOIN (
+              "db_1.schema_1"."Animal" AS "Animal_1"
+              LEFT OUTER JOIN(
                 SELECT
-                    [Animal_2].uuid AS uuid,
-                    array_agg([Animal_3].name) AS fold_output_name,
-                    array_agg([Animal_3].color) AS fold_output_color
-                FROM db_1.schema_1.[Animal] AS [Animal_2]
-                JOIN db_1.schema_1.[Animal] AS [Animal_3] ON [Animal_2].uuid = [Animal_3].parent
+                  "Animal_2".uuid AS uuid,
+                  array_agg("Animal_3".name) AS fold_output_name,
+                  array_agg("Animal_3".color) AS fold_output_color
+                FROM
+                  "db_1.schema_1"."Animal" AS "Animal_2"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_3"
+                  ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
-                    [Animal_2].uuid
-            ) AS folded_subquery_1
-            ON [Animal_1].uuid = folded_subquery_1.uuid
+                  "Animal_2".uuid
+              ) AS folded_subquery_1 ON "Animal_1".uuid = folded_subquery_1.uuid
         '''
-        result = compile_graphql_to_sql(self.sql_schema_info, test_data.graphql_input)
-        string_result = str(result.query.compile(dialect=self.sql_schema_info.dialect))
-        compare_sql(self, expected_sql, string_result)
-        self.assertEqual(test_data.expected_output_metadata, result.output_metadata)
-        compare_input_metadata(self, test_data.expected_input_metadata,
-                               result.input_metadata)
+        expected_match = SKIP_TEST
+        expected_gremlin = SKIP_TEST
+        expected_mssql = SKIP_TEST
+        expected_cypher = SKIP_TEST
+        check_test_data(self, test_data, expected_match, expected_gremlin, expected_mssql,
+                        expected_cypher, expected_postgresql)
 
     def test_fold_same_edge_type_in_different_locations(self):
         test_data = test_input_data.fold_same_edge_type_in_different_locations()
 
-        expected_sql = '''
+        expected_postgresql = '''
             SELECT
-              [Animal_1].name AS animal_name,
-              coalesce(folded_subquery_1.fold_output_name, ARRAY [] :: VARCHAR [])
-                AS child_names_list,
-              coalesce(folded_subquery_2.fold_output_name, ARRAY [] :: VARCHAR [])
-                AS sibling_and_self_names_list
-            FROM db_1.schema_1.[Animal] AS [Animal_1]
-            LEFT OUTER JOIN (
+              "Animal_1".name AS animal_name,
+              coalesce(
+                folded_subquery_1.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS child_names_list,
+              coalesce(
+                folded_subquery_2.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS sibling_and_self_names_list
+            FROM
+              "db_1.schema_1"."Animal" AS "Animal_1"
+              LEFT OUTER JOIN (
                 SELECT
-                    [Animal_2].uuid AS uuid,
-                    array_agg([Animal_3].name) AS fold_output_name
+                  "Animal_2".uuid AS uuid,
+                  array_agg("Animal_3".name) AS fold_output_name
                 FROM
-                  db_1.schema_1.[Animal] AS [Animal_2]
-                  JOIN db_1.schema_1.[Animal] AS [Animal_3] ON [Animal_2].uuid = [Animal_3].parent
+                  "db_1.schema_1"."Animal" AS "Animal_2"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
-                  [Animal_2].uuid
-            ) AS folded_subquery_1 ON [Animal_1].uuid = folded_subquery_1.uuid
-            JOIN db_1.schema_1.[Animal] AS [Animal_4] ON [Animal_1].parent = [Animal_4].uuid
-            LEFT OUTER JOIN (
+                  "Animal_2".uuid
+              ) AS folded_subquery_1 ON "Animal_1".uuid = folded_subquery_1.uuid
+              JOIN "db_1.schema_1"."Animal" AS "Animal_4" ON "Animal_1".parent = "Animal_4".uuid
+              LEFT OUTER JOIN (
                 SELECT
-                    [Animal_5].uuid AS uuid,
-                    array_agg([Animal_6].name) AS fold_output_name
+                  "Animal_5".uuid AS uuid,
+                  array_agg("Animal_6".name) AS fold_output_name
                 FROM
-                  db_1.schema_1.[Animal] AS [Animal_5]
-                  JOIN db_1.schema_1.[Animal] AS [Animal_6] ON [Animal_5].uuid = [Animal_6].parent
+                  "db_1.schema_1"."Animal" AS "Animal_5"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_6" ON "Animal_5".uuid = "Animal_6".parent
                 GROUP BY
-                  [Animal_5].uuid
-            ) AS folded_subquery_2 ON [Animal_4].uuid = folded_subquery_2.uuid
+                  "Animal_5".uuid
+              ) AS folded_subquery_2 ON "Animal_4".uuid = folded_subquery_2.uuid
         '''
-        result = compile_graphql_to_sql(self.sql_schema_info, test_data.graphql_input)
-        string_result = str(result.query.compile(dialect=self.sql_schema_info.dialect))
-        compare_sql(self, expected_sql, string_result)
-        self.assertEqual(test_data.expected_output_metadata, result.output_metadata)
-        compare_input_metadata(self, test_data.expected_input_metadata,
-                               result.input_metadata)
+        expected_match = SKIP_TEST
+        expected_gremlin = SKIP_TEST
+        expected_mssql = SKIP_TEST
+        expected_cypher = SKIP_TEST
+        check_test_data(self, test_data, expected_match, expected_gremlin, expected_mssql,
+                        expected_cypher, expected_postgresql)
 
     def test_fold_after_traverse(self):
         test_data = test_input_data.fold_after_traverse()
@@ -4259,24 +4297,31 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         '''
-        expected_sql = '''
+        expected_mssql = SKIP_TEST
+        expected_postgresql = '''
             SELECT
-                [Animal_1].name AS animal_name,
-                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
-                    AS sibling_and_self_names_list
-            FROM db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN db_1.schema_1.[Animal] AS [Animal_2]
-            ON [Animal_1].parent = [Animal_2].uuid
-            LEFT OUTER JOIN (
+              "Animal_1".name AS animal_name,
+              coalesce(
+                folded_subquery_1.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS sibling_and_self_names_list
+            FROM
+              "db_1.schema_1"."Animal" AS "Animal_1"
+              JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+              ON "Animal_1".parent = "Animal_2".uuid
+              LEFT OUTER JOIN(
                 SELECT
-                    [Animal_3].uuid AS uuid,
-                    array_agg([Animal_4].name) AS fold_output_name
-                FROM db_1.schema_1.[Animal] AS [Animal_3]
-                JOIN db_1.schema_1.[Animal] AS [Animal_4]
-                ON [Animal_3].uuid = [Animal_4].parent
-                GROUP BY [Animal_3].uuid
-            ) AS folded_subquery_1
-            ON [Animal_2].uuid = folded_subquery_1.uuid'''
+                  "Animal_3".uuid AS uuid,
+                  array_agg("Animal_4".name) AS fold_output_name
+                FROM
+                  "db_1.schema_1"."Animal" AS "Animal_3"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_4"
+                ON "Animal_3".uuid = "Animal_4".parent
+                GROUP BY
+                  "Animal_3".uuid
+              ) AS folded_subquery_1
+              ON "Animal_2".uuid = folded_subquery_1.uuid
+        '''
         expected_cypher = '''
             MATCH (Animal___1:Animal)
             MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -4294,66 +4339,76 @@ class CompilerTests(unittest.TestCase):
                 `sibling_and_self_names_list`
         '''
 
-        check_test_data(self, test_data, expected_match, expected_gremlin, expected_sql,
-                        expected_cypher)
+        check_test_data(self, test_data, expected_match, expected_gremlin, expected_mssql,
+                        expected_cypher, expected_postgresql)
 
     def test_fold_after_traverse_different_types(self):
         test_data = test_input_data.fold_after_traverse_different_types()
 
-        expected_sql = '''
-                    SELECT
-                        [Animal_1].name AS animal_name,
-                        coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
-                            AS neighbor_and_self_names_list
-                    FROM db_1.schema_1.[Animal] AS [Animal_1]
-                    JOIN db_1.schema_1.[Location] AS [Location_1]
-                    ON [Animal_1].lives_in = [Location_1].uuid
-                    LEFT OUTER JOIN (
-                        SELECT
-                            [Location_2].uuid AS uuid,
-                            array_agg([Animal_2].name) AS fold_output_name
-                        FROM db_1.schema_1.[Location] AS [Location_2]
-                        JOIN db_1.schema_1.[Animal] AS [Animal_2]
-                        ON [Location_2].uuid = [Animal_2].lives_in
-                        GROUP BY [Location_2].uuid
-                    ) AS folded_subquery_1
-                    ON [Location_1].uuid = folded_subquery_1.uuid'''
+        expected_postgresql = '''
+            SELECT
+              "Animal_1".name AS animal_name,
+              coalesce(
+                folded_subquery_1.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS neighbor_and_self_names_list
+            FROM
+              "db_1.schema_1"."Animal" AS "Animal_1"
+              JOIN "db_1.schema_1"."Location" AS "Location_1"
+              ON "Animal_1".lives_in = "Location_1".uuid
+              LEFT OUTER JOIN(
+                SELECT
+                  "Location_2".uuid AS uuid,
+                  array_agg("Animal_2".name) AS fold_output_name
+                FROM
+                  "db_1.schema_1"."Location" AS "Location_2"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+                  ON "Location_2".uuid = "Animal_2".lives_in
+                GROUP BY
+                  "Location_2".uuid
+              ) AS folded_subquery_1 ON "Location_1".uuid = folded_subquery_1.uuid
+        '''
 
-        result = compile_graphql_to_sql(self.sql_schema_info, test_data.graphql_input)
-        string_result = str(result.query.compile(dialect=self.sql_schema_info.dialect))
-        compare_sql(self, expected_sql, string_result)
-        self.assertEqual(test_data.expected_output_metadata, result.output_metadata)
-        compare_input_metadata(self, test_data.expected_input_metadata,
-                               result.input_metadata)
+        expected_match = SKIP_TEST
+        expected_gremlin = SKIP_TEST
+        expected_mssql = SKIP_TEST
+        expected_cypher = SKIP_TEST
+        check_test_data(self, test_data, expected_match, expected_gremlin, expected_mssql,
+                        expected_cypher, expected_postgresql)
 
     def test_fold_after_traverse_no_output_on_root(self):
         test_data = test_input_data.fold_after_traverse_no_output_on_root()
 
-        expected_sql = '''
+        expected_postgresql = '''
             SELECT
-                [Location_1].name AS location_name,
-                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
-                    AS neighbor_and_self_names_list
-            FROM db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN db_1.schema_1.[Location] AS [Location_1]
-            ON [Animal_1].lives_in = [Location_1].uuid
-            LEFT OUTER JOIN (
+              "Location_1".name AS location_name,
+              coalesce(
+                folded_subquery_1.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS neighbor_and_self_names_list
+            FROM
+              "db_1.schema_1"."Animal" AS "Animal_1"
+              JOIN "db_1.schema_1"."Location" AS "Location_1"
+              ON "Animal_1".lives_in = "Location_1".uuid
+              LEFT OUTER JOIN(
                 SELECT
-                    [Location_2].uuid AS uuid,
-                    array_agg([Animal_2].name) AS fold_output_name
-                FROM db_1.schema_1.[Location] AS [Location_2]
-                JOIN db_1.schema_1.[Animal] AS [Animal_2]
-                ON [Location_2].uuid = [Animal_2].lives_in
-                GROUP BY [Location_2].uuid
-            ) AS folded_subquery_1
-            ON [Location_1].uuid = folded_subquery_1.uuid'''
+                  "Location_2".uuid AS uuid,
+                  array_agg("Animal_2".name) AS fold_output_name
+                FROM
+                  "db_1.schema_1"."Location" AS "Location_2"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+                  ON "Location_2".uuid = "Animal_2".lives_in
+                GROUP BY
+                  "Location_2".uuid
+              ) AS folded_subquery_1 ON "Location_1".uuid = folded_subquery_1.uuid
+        '''
 
-        result = compile_graphql_to_sql(self.sql_schema_info, test_data.graphql_input)
-        string_result = str(result.query.compile(dialect=self.sql_schema_info.dialect))
-        compare_sql(self, expected_sql, string_result)
-        self.assertEqual(test_data.expected_output_metadata, result.output_metadata)
-        compare_input_metadata(self, test_data.expected_input_metadata,
-                               result.input_metadata)
+        expected_match = SKIP_TEST
+        expected_gremlin = SKIP_TEST
+        expected_mssql = SKIP_TEST
+        expected_cypher = SKIP_TEST
+        check_test_data(self, test_data, expected_match, expected_gremlin, expected_mssql,
+                        expected_cypher, expected_postgresql)
 
     def test_fold_and_traverse(self):
         test_data = test_input_data.fold_and_traverse()
@@ -7210,25 +7265,32 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         '''
-        expected_sql = '''
-        SELECT
-            [Animal_1].name AS animal_name,
-            coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
-            [Animal_2].name AS parent_name
-        FROM db_1.schema_1.[Animal] AS [Animal_1]
-        LEFT OUTER JOIN
-            db_1.schema_1.[Animal] AS [Animal_2]
-        ON [Animal_1].parent = [Animal_2].uuid
-        LEFT OUTER JOIN (
+        expected_mssql = SKIP_TEST
+        expected_postgresql = '''
             SELECT
-                [Animal_3].uuid AS uuid,
-                array_agg([Animal_4].name) AS fold_output_name
-            FROM db_1.schema_1.[Animal] AS [Animal_3]
-            JOIN db_1.schema_1.[Animal] AS [Animal_4]
-            ON [Animal_3].uuid = [Animal_4].parent
-            GROUP BY [Animal_3].uuid
-        ) AS folded_subquery_1
-        ON [Animal_1].uuid = folded_subquery_1.uuid'''
+              "Animal_1".name AS animal_name,
+              coalesce(
+                folded_subquery_1.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS child_names_list,
+              "Animal_2".name AS parent_name
+            FROM
+              "db_1.schema_1"."Animal" AS "Animal_1"
+              LEFT OUTER JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+              ON "Animal_1".parent = "Animal_2".uuid
+              LEFT OUTER JOIN(
+                SELECT
+                  "Animal_3".uuid AS uuid,
+                  array_agg("Animal_4".name) AS fold_output_name
+                FROM
+                  "db_1.schema_1"."Animal" AS "Animal_3"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_4"
+                ON "Animal_3".uuid = "Animal_4".parent
+                GROUP BY
+                  "Animal_3".uuid
+              ) AS folded_subquery_1
+              ON "Animal_1".uuid = folded_subquery_1.uuid
+        '''
         expected_cypher = '''
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -7247,8 +7309,8 @@ class CompilerTests(unittest.TestCase):
                 END) AS `parent_name`
         '''
 
-        check_test_data(self, test_data, expected_match, expected_gremlin, expected_sql,
-                        expected_cypher)
+        check_test_data(self, test_data, expected_match, expected_gremlin, expected_mssql,
+                        expected_cypher, expected_postgresql)
 
     def test_fold_and_optional(self):
         test_data = test_input_data.fold_and_optional()
@@ -7303,25 +7365,32 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         '''
-        expected_sql = '''
-        SELECT
-            [Animal_1].name AS animal_name,
-            coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
-            [Animal_2].name AS parent_name
-        FROM db_1.schema_1.[Animal] AS [Animal_1]
-        LEFT OUTER JOIN (
+        expected_mssql = SKIP_TEST
+        expected_postgresql = '''
             SELECT
-                [Animal_3].uuid AS uuid,
-                array_agg([Animal_4].name) AS fold_output_name
-            FROM db_1.schema_1.[Animal] AS [Animal_3]
-            JOIN db_1.schema_1.[Animal] AS [Animal_4]
-            ON [Animal_3].uuid = [Animal_4].parent
-            GROUP BY [Animal_3].uuid
-        ) AS folded_subquery_1
-        ON [Animal_1].uuid = folded_subquery_1.uuid
-        LEFT OUTER JOIN
-            db_1.schema_1.[Animal] AS [Animal_2]
-        ON [Animal_1].parent = [Animal_2].uuid'''
+              "Animal_1".name AS animal_name,
+              coalesce(
+                folded_subquery_1.fold_output_name,
+                ARRAY [] :: VARCHAR []
+              ) AS child_names_list,
+              "Animal_2".name AS parent_name
+            FROM
+              "db_1.schema_1"."Animal" AS "Animal_1"
+              LEFT OUTER JOIN(
+                SELECT
+                  "Animal_3".uuid AS uuid,
+                  array_agg("Animal_4".name) AS fold_output_name
+                FROM
+                  "db_1.schema_1"."Animal" AS "Animal_3"
+                  JOIN "db_1.schema_1"."Animal" AS "Animal_4"
+                  ON "Animal_3".uuid = "Animal_4".parent
+                GROUP BY
+                  "Animal_3".uuid
+              ) AS folded_subquery_1
+              ON "Animal_1".uuid = folded_subquery_1.uuid
+              LEFT OUTER JOIN "db_1.schema_1"."Animal" AS "Animal_2"
+              ON "Animal_1".parent = "Animal_2".uuid
+        '''
         expected_cypher = '''
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -7340,8 +7409,8 @@ class CompilerTests(unittest.TestCase):
                 END) AS `parent_name`
         '''
 
-        check_test_data(self, test_data, expected_match, expected_gremlin, expected_sql,
-                        expected_cypher)
+        check_test_data(self, test_data, expected_match, expected_gremlin, expected_mssql,
+                        expected_cypher, expected_postgresql)
 
     def test_optional_traversal_and_fold_traversal(self):
         test_data = test_input_data.optional_traversal_and_fold_traversal()

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -4152,8 +4152,8 @@ class CompilerTests(unittest.TestCase):
                 "db_1.schema_1"."Animal" AS "Animal_1"
             LEFT OUTER JOIN (
                 SELECT
-                  "Animal_2".uuid AS uuid,
-                  array_agg("Animal_3".name) AS fold_output_name
+                    "Animal_2".uuid AS uuid,
+                    array_agg("Animal_3".name) AS fold_output_name
                 FROM "db_1.schema_1"."Animal" AS "Animal_2"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
@@ -4226,7 +4226,7 @@ class CompilerTests(unittest.TestCase):
                     "db_1.schema_1"."Animal" AS "Animal_2"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_3" ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY
-                    "Animal_2".uuid
+                  "Animal_2".uuid
             ) AS folded_subquery_1 ON "Animal_1".uuid = folded_subquery_1.uuid
             JOIN "db_1.schema_1"."Animal" AS "Animal_4" ON "Animal_1".parent = "Animal_4".uuid
             LEFT OUTER JOIN (
@@ -4237,7 +4237,7 @@ class CompilerTests(unittest.TestCase):
                   "db_1.schema_1"."Animal" AS "Animal_5"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_6" ON "Animal_5".uuid = "Animal_6".parent
                 GROUP BY
-                    "Animal_5".uuid
+                  "Animal_5".uuid
             ) AS folded_subquery_2 ON "Animal_4".uuid = folded_subquery_2.uuid
         '''
         expected_match = SKIP_TEST
@@ -4297,8 +4297,8 @@ class CompilerTests(unittest.TestCase):
             ON "Animal_1".parent = "Animal_2".uuid
             LEFT OUTER JOIN(
                 SELECT
-                  "Animal_3".uuid AS uuid,
-                  array_agg("Animal_4".name) AS fold_output_name
+                    "Animal_3".uuid AS uuid,
+                    array_agg("Animal_4".name) AS fold_output_name
                 FROM "db_1.schema_1"."Animal" AS "Animal_3"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_4"
                 ON "Animal_3".uuid = "Animal_4".parent
@@ -4345,7 +4345,8 @@ class CompilerTests(unittest.TestCase):
                 JOIN "db_1.schema_1"."Animal" AS "Animal_2"
                 ON "Location_2".uuid = "Animal_2".lives_in
                 GROUP BY "Location_2".uuid
-            ) AS folded_subquery_1 ON "Location_1".uuid = folded_subquery_1.uuid
+            ) AS folded_subquery_1
+            ON "Location_1".uuid = folded_subquery_1.uuid
         '''
 
         expected_match = SKIP_TEST
@@ -4360,16 +4361,16 @@ class CompilerTests(unittest.TestCase):
 
         expected_postgresql = '''
             SELECT
-              "Location_1".name AS location_name,
-              coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
-                  AS neighbor_and_self_names_list
+                "Location_1".name AS location_name,
+                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
+                    AS neighbor_and_self_names_list
             FROM "db_1.schema_1"."Animal" AS "Animal_1"
             JOIN "db_1.schema_1"."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
             LEFT OUTER JOIN (
                 SELECT
-                  "Location_2".uuid AS uuid,
-                  array_agg("Animal_2".name) AS fold_output_name
+                    "Location_2".uuid AS uuid,
+                    array_agg("Animal_2".name) AS fold_output_name
                 FROM "db_1.schema_1"."Location" AS "Location_2"
                 JOIN "db_1.schema_1"."Animal" AS "Animal_2"
                 ON "Location_2".uuid = "Animal_2".lives_in

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -692,8 +692,10 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
                 join_descriptors.setdefault(subclass, {})[edge_name] = join_info
     if dialect == 'postgresql':
         sqlalchemy_compiler_dialect = postgresql.dialect()
-    else:
+    elif dialect == 'mssql':
         sqlalchemy_compiler_dialect = mssql.dialect()
+    else:
+        raise AssertionError(u'Unrecognized dialect {}'.format(dialect))
     return make_sqlalchemy_schema_info(
         schema, type_equivalence_hints, sqlalchemy_compiler_dialect, tables, join_descriptors)
 

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -9,7 +9,7 @@ from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType
 from graphql.utils.build_ast_schema import build_ast_schema
 import six
 import sqlalchemy
-from sqlalchemy.dialects import mssql
+from sqlalchemy.dialects import mssql, postgresql
 
 from graphql_compiler.schema_generation.orientdb import get_graphql_schema_from_orientdb_schema_data
 
@@ -488,7 +488,7 @@ def _get_schema_without_list_valued_property_fields():
     return schema
 
 
-def get_sqlalchemy_schema_info():
+def get_sqlalchemy_schema_info(dialect='mssql'):
     """Get a SQLAlchemySchemaInfo for testing."""
     # We don't support list-valued property fields in SQL for now.
     schema = _get_schema_without_list_valued_property_fields()
@@ -690,9 +690,12 @@ def get_sqlalchemy_schema_info():
         for subclass in subclass_set:
             for edge_name, join_info in six.iteritems(join_descriptors.get(class_name, {})):
                 join_descriptors.setdefault(subclass, {})[edge_name] = join_info
-
+    if dialect == 'postgresql':
+        sqlalchemy_compiler_dialect = postgresql.dialect()
+    else:
+        sqlalchemy_compiler_dialect = mssql.dialect()
     return make_sqlalchemy_schema_info(
-        schema, type_equivalence_hints, mssql.dialect(), tables, join_descriptors)
+        schema, type_equivalence_hints, sqlalchemy_compiler_dialect, tables, join_descriptors)
 
 
 def generate_schema_graph(orientdb_client):

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -519,7 +519,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('important_event', sqlalchemy.String(40), nullable=True),
             sqlalchemy.Column('species', sqlalchemy.String(40), nullable=True),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
-            schema='db_1.schema_1'
+            schema=('db_1.' if dialect == 'mssql' else '') + 'schema_1'
         ),
         'BirthEvent': sqlalchemy.Table(
             'BirthEvent',
@@ -529,7 +529,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('event_date', sqlalchemy.DateTime, nullable=False),
             sqlalchemy.Column('related_event', uuid_type, primary_key=False),
-            schema='db_1.schema_1'
+            schema=('db_1.' if dialect == 'mssql' else '') + 'schema_1'
         ),
         'Entity': sqlalchemy.Table(
             'Entity',
@@ -538,7 +538,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('related_entity', uuid_type, nullable=True),
-            schema='db_1.schema_1'
+            schema=('db_1.' if dialect == 'mssql' else '') + 'schema_1'
         ),
         'Event': sqlalchemy.Table(
             'Event',
@@ -548,7 +548,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('event_date', sqlalchemy.DateTime, nullable=False),
             sqlalchemy.Column('related_event', uuid_type, primary_key=False),
-            schema='db_2.schema_1'
+            schema=('db_2.' if dialect == 'mssql' else '') + 'schema_1'
         ),
         'FeedingEvent': sqlalchemy.Table(
             'FeedingEvent',
@@ -558,7 +558,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('event_date', sqlalchemy.DateTime, nullable=False),
             sqlalchemy.Column('related_event', uuid_type, primary_key=False),
-            schema='db_2.schema_1'
+            schema=('db_2.' if dialect == 'mssql' else '') + 'schema_1'
         ),
         'Food': sqlalchemy.Table(
             'Food',
@@ -566,7 +566,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
-            schema='db_2.schema_2'
+            schema=('db_2.' if dialect == 'mssql' else '') + 'schema_2'
         ),
         'FoodOrSpecies': sqlalchemy.Table(
             'FoodOrSpecies',
@@ -574,7 +574,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
-            schema='db_2.schema_2'
+            schema=('db_2.' if dialect == 'mssql' else '') + 'schema_2'
         ),
         'Location': sqlalchemy.Table(
             'Location',
@@ -582,7 +582,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
-            schema='db_1.schema_1'
+            schema=('db_1.' if dialect == 'mssql' else '') + 'schema_1'
         ),
         'Species': sqlalchemy.Table(
             'Species',
@@ -593,13 +593,13 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
             sqlalchemy.Column('eats', uuid_type, nullable=True),
             sqlalchemy.Column('limbs', sqlalchemy.Integer, nullable=True),
             sqlalchemy.Column('related_entity', uuid_type, nullable=True),
-            schema='db_1.schema_1'
+            schema=('db_1.' if dialect == 'mssql' else '') + 'schema_1'
         ),
         'UniquelyIdentifiable': sqlalchemy.Table(
             'UniquelyIdentifiable',
             sqlalchemy_metadata_1,
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
-            schema='db_1.schema_1'
+            schema=('db_1.' if dialect == 'mssql' else '') + 'schema_1'
         ),
     }
 


### PR DESCRIPTION
This PR clarifies that default SQL behavior is MSSQL and that the recent update to fold functionality (#595) was designed to target Postgres. This PR changes interfacing with SQL so that the `dialect` field of SQLAlchemySchemaInfo is used to distinguish between Postgres and MSSQL. This will simplify PR #613 because now MSSQL will be assumed the default  compilation target. This will make it unnecessary to use flags to distinguish between different targets, enabling us to rely solely on the `dialect` field.