### PR TITLE
Remove Cypher query parameters documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,6 @@ Table of contents
    -  `Optional type_equivalence_hints compilation
       parameter <#optional-type_equivalence_hints-parameter>`__
    -  `SchemaGraph <#schemagraph>`__
-   -  `Cypher query parameters <#cypher-query-parameters>`__
 
 -  `FAQ <#faq>`__
 -  `License <#license>`__
@@ -2603,31 +2602,6 @@ See below for a mock example of how to build and use the
 In the future, we plan to add :code:`SchemaGraph` generation from SQLAlchemy
 metadata. We also plan to add a mechanism where one can query a
 :code:`SchemaGraph` using GraphQL queries.
-
-Cypher query parameters
-~~~~~~~~~~~~~~~~~~~~~~~
-
-RedisGraph `doesn't support query
-parameters <https://github.com/RedisGraph/RedisGraph/issues/544#issuecomment-507963576>`__,
-so we perform manual parameter interpolation in the
-:code:`graphql_to_redisgraph_cypher` function. However, for Neo4j, we can
-use Neo4j's client to do parameter interpolation on its own so that we
-don't reinvent the wheel.
-
-The function :code:`insert_arguments_into_query` does so based on the query
-language, which isn't fine-grained enough here-- for Cypher backends, we
-only want to insert parameters if the backend is RedisGraph, but not if
-it's Neo4j.
-
-Instead, the correct approach for Neo4j Cypher is as follows, given a
-Neo4j Python client called :code:`neo4j_client`:
-
-.. code:: python
-
-    compilation_result = compile_graphql_to_cypher(
-        schema, graphql_query, type_equivalence_hints=type_equivalence_hints)
-    with neo4j_client.driver.session() as session:
-        result = session.run(compilation_result.query, parameters)
 
 Amending Parsed Custom Scalar Types
 -----------------------------------


### PR DESCRIPTION
We never introduce the cypher compilation target anywhere in the documentation, but this documentation block seems to jump "right in". It confuses the reader and leaves him looking for the rest of the cypher documentation, which does not exist.  

Once the cypher compilation target and its backends are well documented we can re-introduce this documentation. For now, it is a net negative.