### PR TITLE
Compare directives by name instead of python object references

### DIFF
--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -16,11 +16,10 @@ from ..ast_manipulation import safe_parse_graphql
 from ..compiler.subclass import compute_subclass_sets
 from ..compiler.validation import validate_schema_and_query_ast
 from ..exceptions import GraphQLValidationError
-from ..schema import check_for_nondefault_directive_names
 from .macro_edge import make_macro_edge_descriptor
 from .macro_edge.directives import (
     DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION, DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION,
-    MacroEdgeDirective
+    MacroEdgeDirective, get_schema_for_macro_edge_definitions
 )
 from .macro_expansion import expand_macros_in_query_ast
 from .validation import (
@@ -212,18 +211,7 @@ def get_schema_for_macro_definition(schema):
     Raises:
         AssertionError, if the schema contains directive names that are non-default.
     """
-    macro_definition_schema = copy(schema)
-    macro_definition_schema_directives = schema.get_directives()
-    check_for_nondefault_directive_names(macro_definition_schema_directives)
-    macro_definition_schema_directives += DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION
-    # Remove disallowed directives from directives list
-    macro_definition_schema_directives = list(set(macro_definition_schema_directives) &
-                                              set(DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION))
-
-    # pylint: disable=protected-access
-    macro_definition_schema._directives = macro_definition_schema_directives
-    # pylint: enable=protected-access
-    return macro_definition_schema
+    get_schema_for_macro_edge_definitions(schema)
 
 
 def perform_macro_expansion(macro_registry, schema_with_macros, graphql_with_macro, graphql_args):

--- a/graphql_compiler/macros/macro_edge/directives.py
+++ b/graphql_compiler/macros/macro_edge/directives.py
@@ -73,8 +73,7 @@ def get_schema_for_macro_edge_definitions(querying_schema):
     check_for_nondefault_directive_names(original_directives)
 
     names_of_allowed_directives = {
-        directive.name 
-        for directive in DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION
+        directive.name for directive in DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION
     }
 
     new_directives = [

--- a/graphql_compiler/macros/macro_edge/directives.py
+++ b/graphql_compiler/macros/macro_edge/directives.py
@@ -73,8 +73,8 @@ def get_schema_for_macro_edge_definitions(querying_schema):
     check_for_nondefault_directive_names(original_directives)
 
     names_of_allowed_directives = {
-        directive.name for directive in
-        DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION
+        directive.name 
+        for directive in DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION
     }
 
     new_directives = [

--- a/graphql_compiler/tests/test_macro_schema.py
+++ b/graphql_compiler/tests/test_macro_schema.py
@@ -42,15 +42,21 @@ class MacroSchemaTests(unittest.TestCase):
     def test_get_schema_for_macro_definition_addition(self):
         original_schema = self.macro_registry.schema_without_macros
         macro_definition_schema = get_schema_for_macro_definition(original_schema)
+        macro_schema_directive_names = {
+            directive.name for directive in macro_definition_schema.get_directives()
+        }
         for directive in DIRECTIVES_REQUIRED_IN_MACRO_EDGE_DEFINITION:
-            self.assertTrue(directive in macro_definition_schema.get_directives())
+            self.assertIn(directive.name, macro_schema_directive_names)
 
     def test_get_schema_for_macro_definition_retain(self):
         original_schema = self.macro_registry.schema_without_macros
         macro_definition_schema = get_schema_for_macro_definition(original_schema)
+        macro_schema_directive_names = {
+            directive.name for directive in macro_definition_schema.get_directives()
+        }
         for directive in original_schema.get_directives():
             if directive in DIRECTIVES_ALLOWED_IN_MACRO_EDGE_DEFINITION:
-                self.assertTrue(directive in macro_definition_schema.get_directives())
+                self.assertIn(directive.name, macro_schema_directive_names)
 
     def test_get_schema_for_macro_definition_removal(self):
         schema_with_macros = get_schema_with_macros(self.macro_registry)


### PR DESCRIPTION
`get_schema_for_macro_definition` currently does not work correctly. If you serialize and parse a schema and then run `get_schema_for_macro_definition`, you'll end up with a schema with only the required macro directives. The subtle reason this happens is that we currently compare directives by their python object references instead of their names.
 