### PR TITLE
Move __typename -> @class conversion after IR generation

### DIFF
--- a/graphql_compiler/ast_manipulation.py
+++ b/graphql_compiler/ast_manipulation.py
@@ -6,18 +6,11 @@ from graphql.language.ast import (
 from graphql.language.parser import parse
 
 from .exceptions import GraphQLParsingError
-from .schema import TYPENAME_META_FIELD_NAME
 
 
 def get_ast_field_name(ast):
-    """Return the normalized field name for the given AST node."""
-    replacements = {
-        # We always rewrite the following field names into their proper underlying counterparts.
-        TYPENAME_META_FIELD_NAME: '@class'
-    }
-    base_field_name = ast.name.value
-    normalized_name = replacements.get(base_field_name, base_field_name)
-    return normalized_name
+    """Return the field name for the given AST node."""
+    return ast.name.value
 
 
 def get_ast_field_name_or_none(ast):

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -8,7 +8,10 @@ from sqlalchemy import bindparam, sql
 
 from . import cypher_helpers, sqlalchemy_extensions
 from ..exceptions import GraphQLCompilationError
-from ..schema import COUNT_META_FIELD_NAME, TYPENAME_META_FIELD_NAME, GraphQLDate, GraphQLDateTime
+from ..schema import (
+    ALL_SUPPORTED_META_FIELDS, COUNT_META_FIELD_NAME, TYPENAME_META_FIELD_NAME, GraphQLDate,
+    GraphQLDateTime
+)
 from .compiler_entities import Expression
 from .helpers import (
     STANDARD_DATE_FORMAT, STANDARD_DATETIME_FORMAT, FoldScopeLocation, Location,
@@ -336,9 +339,10 @@ class LocalField(Expression):
             raise NotImplementedError(u'The SQL backend does not support lists. Cannot '
                                       u'process field {}.'.format(self.field_name))
 
-        if self.field_name == TYPENAME_META_FIELD_NAME:
-            raise NotImplementedError(u'The SQL backend does not support {}.'.format(
-                TYPENAME_META_FIELD_NAME))
+        # Meta fields are special cases; assume all meta fields are not implemented.
+        if self.field_name in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                self.field_name))
 
         return current_alias.c[self.field_name]
 
@@ -505,9 +509,10 @@ class ContextField(Expression):
                                       u'process field {}.'.format(self.location.field))
 
         if self.location.field is not None:
-            if self.location.field == TYPENAME_META_FIELD_NAME:
-                raise NotImplementedError(u'The SQL backend does not support {}.'.format(
-                    TYPENAME_META_FIELD_NAME))
+            # Meta fields are special cases; assume all meta fields are not implemented.
+            if self.location.field in ALL_SUPPORTED_META_FIELDS:
+                raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                    self.location.field))
             return aliases[(self.location.at_vertex().query_path, None)].c[self.location.field]
         else:
             raise AssertionError(u'This is a bug. The SQL backend does not use '
@@ -624,9 +629,10 @@ class OutputContextField(Expression):
             raise NotImplementedError(u'The SQL backend does not support lists. Cannot '
                                       u'output field {}.'.format(self.location.field))
 
-        if self.location.field == TYPENAME_META_FIELD_NAME:
-            raise NotImplementedError(u'The sql backend does not support {}.'.format(
-                TYPENAME_META_FIELD_NAME))
+        # Meta fields are special cases; assume all meta fields are not implemented.
+        if self.location.field in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The sql backend does not support meta field {}.'.format(
+                self.location.field))
 
         return aliases[(self.location.at_vertex().query_path, None)].c[self.location.field]
 

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -311,6 +311,11 @@ class LocalField(Expression):
 
         if self.field_name == TYPENAME_META_FIELD_NAME:
             return six.text_type('@class')
+        # Meta fields are special cases; assume all meta fields are not implemented unless
+        # otherwise specified.
+        elif self.field_name in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                self.field_name))
 
         return six.text_type(self.field_name)
 
@@ -325,6 +330,11 @@ class LocalField(Expression):
 
         if self.field_name == TYPENAME_META_FIELD_NAME:
             return u'{}[\'{}\']'.format(local_object_name, '@class')
+        # Meta fields are special cases; assume all meta fields are not implemented unless
+        # otherwise specified.
+        elif self.field_name in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                self.field_name))
 
         if '@' in self.field_name:
             return u'{}[\'{}\']'.format(local_object_name, self.field_name)
@@ -391,6 +401,11 @@ class GlobalContextField(Expression):
         mark_name, field_name = self.location.get_location_name()
         if field_name == TYPENAME_META_FIELD_NAME:
             field_name = '@class'
+        # Meta fields are special cases; assume all meta fields are not implemented unless
+        # otherwise specified.
+        elif field_name in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                field_name))
         validate_safe_string(mark_name)
         validate_safe_or_special_string(field_name)
 
@@ -455,6 +470,11 @@ class ContextField(Expression):
 
         if field_name == TYPENAME_META_FIELD_NAME:
             field_name = '@class'
+        # Meta fields are special cases; assume all meta fields are not implemented unless
+        # otherwise specified.
+        elif field_name in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                field_name))
 
         if field_name is None:
             return u'$matched.%s' % (mark_name,)
@@ -470,6 +490,11 @@ class ContextField(Expression):
 
         if field_name == TYPENAME_META_FIELD_NAME:
             field_name = '@class'
+        # Meta fields are special cases; assume all meta fields are not implemented unless
+        # otherwise specified.
+        elif field_name in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                field_name))
 
         if field_name is not None:
             validate_safe_or_special_string(field_name)
@@ -572,6 +597,11 @@ class OutputContextField(Expression):
         mark_name, field_name = self.location.get_location_name()
         if field_name == TYPENAME_META_FIELD_NAME:
             field_name = '@class'
+        # Meta fields are special cases; assume all meta fields are not implemented unless
+        # otherwise specified.
+        elif field_name in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                field_name))
         validate_safe_string(mark_name)
         validate_safe_or_special_string(field_name)
 
@@ -593,6 +623,11 @@ class OutputContextField(Expression):
 
         if field_name == TYPENAME_META_FIELD_NAME:
             field_name = '@class'
+        # Meta fields are special cases; assume all meta fields are not implemented unless
+        # otherwise specified.
+        elif field_name in ALL_SUPPORTED_META_FIELDS:
+            raise NotImplementedError(u'The SQL backend does not support meta field {}.'.format(
+                field_name))
 
         if '@' in field_name:
             template = u'm.{mark_name}[\'{field_name}\']'

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -11,7 +11,10 @@ from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType, Gra
 import six
 
 from ..exceptions import GraphQLCompilationError
-from ..schema import INBOUND_EDGE_FIELD_PREFIX, OUTBOUND_EDGE_FIELD_PREFIX, is_vertex_field_name
+from ..schema import (
+    INBOUND_EDGE_FIELD_PREFIX, OUTBOUND_EDGE_FIELD_PREFIX, TYPENAME_META_FIELD_NAME,
+    is_vertex_field_name
+)
 
 
 # These are the Java (OrientDB) representations of the ISO-8601 standard date and datetime formats.
@@ -40,7 +43,7 @@ def get_only_element_from_collection(one_element_collection):
 
 def get_field_type_from_schema(schema_type, field_name):
     """Return the type of the field in the given type, accounting for field name normalization."""
-    if field_name == '@class':
+    if field_name == TYPENAME_META_FIELD_NAME:
         return GraphQLString
     else:
         if field_name not in schema_type.fields:

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -7,7 +7,9 @@ import six
 from . import test_input_data
 from ..compiler import blocks, expressions, helpers
 from ..compiler.compiler_frontend import OutputMetadata, graphql_to_ir
-from ..schema import COUNT_META_FIELD_NAME, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+from ..schema import (
+    COUNT_META_FIELD_NAME, TYPENAME_META_FIELD_NAME, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+)
 from .test_helpers import compare_input_metadata, compare_ir_blocks, get_schema
 
 
@@ -1543,9 +1545,9 @@ class IrGenerationTests(unittest.TestCase):
             blocks.GlobalOperationsStart(),
             blocks.ConstructResult({
                 'base_cls': expressions.OutputContextField(
-                    base_location.navigate_to_field('@class'), GraphQLString),
+                    base_location.navigate_to_field(TYPENAME_META_FIELD_NAME), GraphQLString),
                 'child_cls': expressions.OutputContextField(
-                    species_location.navigate_to_field('@class'), GraphQLString),
+                    species_location.navigate_to_field(TYPENAME_META_FIELD_NAME), GraphQLString),
             }),
         ]
         expected_location_types = {
@@ -1565,7 +1567,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.Filter(
                 expressions.BinaryComposition(
                     u'=',
-                    expressions.LocalField('@class', GraphQLString),
+                    expressions.LocalField(TYPENAME_META_FIELD_NAME, GraphQLString),
                     expressions.Variable('$base_cls', GraphQLString)
                 )
             ),


### PR DESCRIPTION
As @obi1kenobi pointed out in [PR #621](https://github.com/kensho-technologies/graphql-compiler/pull/621), `@class` is an orientDB-ism. Currently, `__typename` is converted to `@class` in the IR generation step. This PR moves the conversion later since the IR must also be used by SQL and any future languages that do not use `@class`. 