### PR TITLE
Implement basic pagination planning

### DIFF
--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -8,7 +8,7 @@ from ..exceptions import GraphQLError
 # The intent to split the query at a certain vertex into a certain number of pages.
 VertexPartition = namedtuple(
     'VertexPartition', (
-        'query_path',  # List[field name : str] leading to the field to be filtered
+        'query_path',  # List[field name : str] leading to the vertex to be split
         'number_of_splits',  # The number of subdivisions intended for this vertex
     )
 )
@@ -35,11 +35,6 @@ def get_pagination_plan(schema_info, query_ast, number_of_pages):
     pagination_node = get_only_selection_from_ast(definition_ast, GraphQLError)
     query_path = [pagination_node.name.value]
 
-    # Find the field to use on the pagination node, or return None if there are no viable ones
-    field_name = schema_info.pagination_keys.get(pagination_node.name.value, None)
-    if field_name is None:
+    if pagination_node.name.value not in schema_info.pagination_keys:
         return None
-    query_path.append(field_name)
-    return PaginationPlan([
-        VertexPartition(query_path, number_of_pages)
-    ])
+    return PaginationPlan([VertexPartition(query_path, number_of_pages)])

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -7,8 +7,8 @@ from ..exceptions import GraphQLError
 
 # The intent to split the query at a certain vertex into a certain number of pages.
 VertexPartition = namedtuple(
-    'ValueRangeSplit', (
-        'query_path',  # List[class name : str] leading to the field to be filtered
+    'VertexPartition', (
+        'query_path',  # List[field name : str] leading to the field to be filtered
         'number_of_splits',  # The number of subdivisions intended for this vertex
     )
 )
@@ -22,17 +22,8 @@ PaginationPlan = namedtuple(
 )
 
 
-def get_vertices_for_pagination(schema_info, query_ast, number_of_pages):
-    """Return a list of nodes usable for pagination belonging to the given AST node.
-
-    Args:
-        schema_info: QueryPlanningSchemaInfo
-        query_ast: Document, AST of the GraphQL query that is being paginated.
-
-    Returns:
-        List[Field], field instances of vertices belonging to the given query documenting where to
-        add pagination filters, or None if no viable pagination plan exists.
-    """
+def get_pagination_plan(schema_info, query_ast, number_of_pages):
+    """Make a PaginationPlan for the given query and number of desired pages."""
     definition_ast = get_only_query_definition(query_ast, GraphQLError)
 
     # Select the root node as the only vertex to paginate on.

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -1,0 +1,53 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+from collections import namedtuple
+
+from ..ast_manipulation import get_only_query_definition, get_only_selection_from_ast
+from ..exceptions import GraphQLError
+
+
+# The intent to split the query at a certain vertex into a certain number of pages.
+VertexPartition = namedtuple(
+    'ValueRangeSplit', (
+        'vertex',  # Field, the vertex in the query AST that should be partitioned
+        'field_name',  # str, the field on the vertex on which the filter should be applied
+        'number_of_splits',  # The number of subdivisions intended for this vertex
+    )
+)
+
+
+# The intent to split the query with a combination of VertexPartitions
+PaginationPlan = namedtuple(
+    'PaginationPlan', (
+        'vertex_partitions',  # List[VertexPartition]
+    )
+)
+
+
+def get_vertices_for_pagination(schema_info, query_ast, number_of_pages):
+    """Return a list of nodes usable for pagination belonging to the given AST node.
+
+    Args:
+        schema_info: QueryPlanningSchemaInfo
+        query_ast: Document, AST of the GraphQL query that is being paginated.
+
+    Returns:
+        List[Field], field instances of vertices belonging to the given query documenting where to
+        add pagination filters, or None if no viable pagination plan exists.
+    """
+    definition_ast = get_only_query_definition(query_ast, GraphQLError)
+
+    # Select the root node as the only vertex to paginate on.
+    # TODO(bojanserafimov): Make a better pagination plan. Selecting the root is not
+    #                       a good idea if:
+    #                       - The root node has no pagination_key
+    #                       - The root node has a unique index
+    #                       - There are only a few different vertices at the root
+    pagination_node = get_only_selection_from_ast(definition_ast, GraphQLError)
+
+    # Find the field to use on the pagination node, or return None if there are no viable ones
+    field_name = schema_info.pagination_keys.get(pagination_node.name.value, None)
+    if field_name is None:
+        return None
+    return PaginationPlan([
+        VertexPartition(pagination_node, field_name, number_of_pages)
+    ])

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -48,7 +48,7 @@ class QueryPaginationTests(unittest.TestCase):
         # NOTE(bojanserafimov): This is a white box test for the current pagination planner.
         #                       When it improves, this test will need to be generalized.
         expected_plan = PaginationPlan([
-            VertexPartition(['Animal', 'uuid'], number_of_pages)
+            VertexPartition(['Animal'], number_of_pages)
         ])
         self.assertEqual(expected_plan, pagination_plan)
 

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -7,7 +7,7 @@ from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.statistics import LocalStatistics
 from ...query_pagination import QueryStringWithParameters, paginate_query
 from ...query_pagination.pagination_planning import (
-    PaginationPlan, VertexPartition, get_vertices_for_pagination
+    PaginationPlan, VertexPartition, get_pagination_plan
 )
 from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
@@ -43,7 +43,7 @@ class QueryPaginationTests(unittest.TestCase):
         }'''
         number_of_pages = 100
         query_ast = safe_parse_graphql(query)
-        pagination_plan = get_vertices_for_pagination(schema_info, query_ast, number_of_pages)
+        pagination_plan = get_pagination_plan(schema_info, query_ast, number_of_pages)
 
         # NOTE(bojanserafimov): This is a white box test for the current pagination planner.
         #                       When it improves, this test will need to be generalized.

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -26,7 +26,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
         uuid4_fields = {vertex_name: {'uuid'} for vertex_name in schema_graph.vertex_class_names}
-        class_counts = {'Animal': 4}
+        class_counts = {'Animal': 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
@@ -41,12 +41,9 @@ class QueryPaginationTests(unittest.TestCase):
                 name @output(out_name: "animal_name")
             }
         }'''
-        number_of_pages = 100
+        number_of_pages = 10
         query_ast = safe_parse_graphql(query)
         pagination_plan = get_pagination_plan(schema_info, query_ast, number_of_pages)
-
-        # NOTE(bojanserafimov): This is a white box test for the current pagination planner.
-        #                       When it improves, this test will need to be generalized.
         expected_plan = PaginationPlan([
             VertexPartition(['Animal'], number_of_pages)
         ])


### PR DESCRIPTION
The planner decides which vertices to use for pagination. The reason it's separated as a standalone component is to allow the user to bypass it.