### PR TITLE
WIP Pagination parameter generator

### DIFF
--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -68,9 +68,15 @@ def _are_filter_fields_uniquely_indexed(filter_fields, unique_indexes):
     return False
 
 
-def _convert_uuid_string_to_int(uuid_string):
+def convert_uuid_string_to_int(uuid_string):
     """Return the integer representation of a UUID string."""
     return UUID(uuid_string).int
+
+
+def convert_int_to_uuid_string(int_value):
+    """Return the integer representation of a UUID string."""
+    # XXX needs more care
+    return str(UUID(int=int(int_value)))
 
 
 def _create_integer_interval(lower_bound, upper_bound):
@@ -429,7 +435,7 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
                     # Map uuid4 values to their corresponding integer values
                     if is_uuid4_field:
                         parameter_values = [
-                            _convert_uuid_string_to_int(value) for value in parameter_values
+                            convert_uuid_string_to_int(value) for value in parameter_values
                         ]
 
                     filter_interval = _get_query_interval_of_integer_inequality_filter(

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -8,7 +8,7 @@ from ..exceptions import GraphQLError
 # The intent to split the query at a certain vertex into a certain number of pages.
 VertexPartition = namedtuple(
     'VertexPartition', (
-        'query_path',  # List[field name : str] leading to the vertex to be split
+        'query_path',  # Tuple[field name : str] leading to the vertex to be split
         'number_of_splits',  # The number of subdivisions intended for this vertex
     )
 )
@@ -33,8 +33,19 @@ def get_pagination_plan(schema_info, query_ast, number_of_pages):
     #                       - The root node has a unique index
     #                       - There are only a few different vertices at the root
     pagination_node = get_only_selection_from_ast(definition_ast, GraphQLError)
-    query_path = [pagination_node.name.value]
 
-    if pagination_node.name.value not in schema_info.pagination_keys:
+    pagination_field = schema_info.pagination_keys.get(pagination_node.name.value)
+    if pagination_field is None:
         return None
-    return PaginationPlan([VertexPartition(query_path, number_of_pages)])
+
+    if is_uuid_field:
+        pass
+    elif is_int_field:
+        quantiles = schema_info.pagination_keys.statistics.get_field_quantiles(
+            pagination_node, pagination_field)
+        if quantiles is None or len(quantiles) < 10 * number_of_pages:
+            return None
+    else:
+        return None
+
+    return PaginationPlan([VertexPartition([pagination_node], number_of_pages)])

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -1,24 +1,20 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 
 
-def generate_parameters_for_parameterized_query(
-    schema_info, parameterized_pagination_queries, num_pages
-):
-    """Generate parameters for the given parameterized pagination queries.
+def generate_parameters_for_vertex_partition(schema_info, query_ast, parameters, vertex_partition):
+    """ """
+    vertex_type = TODO_get_from_(vertex_partition.query_path)
+    pagination_field = schema_info.pagination_keys.get(vertex_type)
 
-    Args:
-        schema_info: QueryPlanningSchemaInfo
-        parameterized_pagination_queries: ParameterizedPaginationQueries namedtuple, parameterized
-                                          queries for which parameters are being generated.
-        num_pages: int, number of pages to split the query into.
+    # See what are the min and max values currently imposed by existing filters.
+    # TODO(bojanserafimov): Assuming no existing filters for now.
+    min_value = None
+    max_value = None
 
-    Returns:
-        two dicts:
-            - dict, parameters with which to execute the page query. The next page query's
-              parameters are generated such that only a page of the original query's result data is
-              produced when executed.
-            - dict, parameters with which to execute the remainder query. The remainder query
-              parameters are generated such that they produce the remainder of the original query's
-              result data when executed.
-    """
-    raise NotImplementedError()
+    if is_uuid_field:
+        pass  # XXX subdivide evenly
+    elif is_int_field:
+        quantiles = schema_info.pagination_keys.statistics.get_field_quantiles(
+        # XXX use quantiles
+    else:
+        raise AssertionError()

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -1,20 +1,53 @@
 # Copyright 2019-present Kensho Technologies, LLC.
+from ..cost_estimation.helpers import is_int_field_type, is_uuid4_type
+from ..cost_estimation.filter_selectivity_utils import convert_uuid_string_to_int, convert_int_to_uuid_string, MIN_UUID_INT, MAX_UUID_INT
+
+
+# XXX merge plan:
+# - copy _convert_int_to_field_value and _convert_field_value_to_int from query-pagination branch
+# - implement _get_query_path_endpoint_type properly
+# - land to this PR
+# - find existing filters on the pagination_key
+# - Implement int field paging
+
+
+def _get_query_path_endpoint_type(schema, query_path):
+    current_type = schema.get_type('RootSchemaQuery')
+    for selection in query_path:
+        current_type = current_type.fields[selection].type.of_type
+    return current_type
 
 
 def generate_parameters_for_vertex_partition(schema_info, query_ast, parameters, vertex_partition):
-    """ """
-    vertex_type = TODO_get_from_(vertex_partition.query_path)
-    pagination_field = schema_info.pagination_keys.get(vertex_type)
+    """Return a generator"""
+    vertex_type = _get_query_path_endpoint_type(schema_info.schema, vertex_partition.query_path)
+    pagination_field = schema_info.pagination_keys[vertex_type.name]
+    if vertex_partition.number_of_splits < 2:
+        raise AssertionError('Invalid number of splits {}'.format(vertex_partition))
 
     # See what are the min and max values currently imposed by existing filters.
     # TODO(bojanserafimov): Assuming no existing filters for now.
     min_value = None
     max_value = None
 
-    if is_uuid_field:
-        pass  # XXX subdivide evenly
-    elif is_int_field:
+    if is_uuid4_type(schema_info, vertex_type.name, pagination_field):
+        min_int = convert_uuid_string_to_int(min_value) if min_value else MIN_UUID_INT
+        max_int = convert_uuid_string_to_int(max_value) if max_value else MAX_UUID_INT
+        int_value_splits = (
+            min_int + int(float(max_int - min_int) * i / vertex_partition.number_of_splits)
+            for i in range(1, vertex_partition.number_of_splits)
+        )
+        return (convert_int_to_uuid_string(int_value) for int_value in int_value_splits)
+    elif is_int_field_type(schema_info, vertex_type.name, pagination_field):
         quantiles = schema_info.pagination_keys.statistics.get_field_quantiles(
-        # XXX use quantiles
+            vertex_type.name, pagination_field)
+        if quantiles is None or len(quantiles) < 10 * vertex_partition.number_of_splits:
+            raise AssertionError('Invalid vertex partition {}. Not enough quantile data.'
+                                 .format(vertex_partitions))
+        raise NotImplementedError('Parameter generation for int fields is not implemeneted.')
     else:
         raise AssertionError()
+
+
+def generate_parameters_for_parameterized_query(schema_info, query, parameters):
+    raise NotImplementedError()

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -49,6 +49,37 @@ class QueryPaginationTests(unittest.TestCase):
         ])
         self.assertEqual(expected_plan, pagination_plan)
 
+    def test_parameter_value_generation(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
+        uuid4_fields = {vertex_name: {'uuid'} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {'Animal': 1000}
+        statistics = LocalStatistics(class_counts)
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields)
+
+        query = '''{
+            Animal {
+                name @output(out_name: "animal_name")
+            }
+        }'''
+        args = {}
+        query_ast = safe_parse_graphql(query)
+        vertex_partition = VertexPartition(['Animal'], 4)
+        generated_parameters = generate_parameters_for_vertex_partition(
+            schema_info, query_ast, args, vertex_partition)
+
+        expected_parameters = [
+            # XXX 4 even uuids
+        ]
+        self.assertEqual(expected_parameters, generated_parameters)
+
     # TODO: These tests can be sped up by having an existing test SchemaGraph object.
     @pytest.mark.usefixtures('snapshot_orientdb_client')
     def test_basic_pagination(self):

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -9,6 +9,7 @@ from ...query_pagination import QueryStringWithParameters, paginate_query
 from ...query_pagination.pagination_planning import (
     PaginationPlan, VertexPartition, try_get_pagination_plan
 )
+from ...query_pagination.parameter_generator import generate_parameters_for_vertex_partition
 from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import generate_schema_graph
@@ -77,9 +78,11 @@ class QueryPaginationTests(unittest.TestCase):
             schema_info, query_ast, args, vertex_partition)
 
         expected_parameters = [
-            # XXX 4 even uuids
+            '40000000-0000-0000-0000-000000000000',
+            '80000000-0000-0000-0000-000000000000',
+            'c0000000-0000-0000-0000-000000000000',
         ]
-        self.assertEqual(expected_parameters, generated_parameters)
+        self.assertEqual(expected_parameters, list(generated_parameters))
 
     # TODO: These tests can be sped up by having an existing test SchemaGraph object.
     @pytest.mark.usefixtures('snapshot_orientdb_client')


### PR DESCRIPTION
Implement `generate_parameters_for_vertex_partition`, returning a generator of values that split the vertex into the desired number of splits. Usually only the first number in the generator is needed, but it's good to have all just in case. The function can be used and tested without access to a parameterized query.