### PR TITLE
Remove SQL time type to GraphQLDateTime mapping

### DIFF
--- a/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
@@ -45,8 +45,6 @@ GENERIC_SQL_CLASS_TO_GRAPHQL_TYPE = {
     sqltypes.String: GraphQLString,
     sqltypes.Text: GraphQLString,
     sqltypes.TEXT: GraphQLString,
-    sqltypes.Time: GraphQLDateTime,
-    sqltypes.TIME: GraphQLDateTime,
     sqltypes.TIMESTAMP: GraphQLDateTime,
     sqltypes.Unicode: GraphQLString,
     sqltypes.UnicodeText: GraphQLString,
@@ -63,6 +61,8 @@ UNSUPPORTED_GENERIC_SQL_TYPES = frozenset({
     sqltypes.JSON,
     sqltypes.LargeBinary,
     sqltypes.PickleType,
+    sqltypes.Time,
+    sqltypes.TIME,
     sqltypes.VARBINARY,
 })
 
@@ -72,7 +72,6 @@ MSSQL_CLASS_TO_GRAPHQL_TYPE = {
     mssqltypes.REAL: GraphQLFloat,
     mssqltypes.NTEXT: GraphQLString,
     mssqltypes.SMALLDATETIME: GraphQLDateTime,
-    mssqltypes.TIME: GraphQLDateTime,
     mssqltypes.TINYINT: GraphQLInt,
     mssqltypes.UNIQUEIDENTIFIER: GraphQLID,
 }
@@ -84,6 +83,7 @@ UNSUPPORTED_MSSQL_TYPES = frozenset({
     mssqltypes.ROWVERSION,
     mssqltypes.SQL_VARIANT,
     mssqltypes.SMALLMONEY,
+    mssqltypes.TIME,
     # The mssqltypes.TIMESTAMP class inherits from SQL._Binary class, which is not supported.
     # TIMESTAMP docstring:
     #     Note this is completely different than the SQL Standard


### PR DESCRIPTION
This mapping is incorrect. The correct GraphQL type to represent these SQL types would be a `GraphQLTime`  type, which we don't currently have. 

It might be worth adding such a GraphQL type in the future. That's why I keep track of the SQL unsupported types. In case we ever decide to a new GraphQL type, we can just look at the unsupported types to see if any of these matches the new GraphQL type. 