### PR TITLE
Use :ref: directive for hyperlinking

### DIFF
--- a/docs/source/advanced_features/macro_system.rst
+++ b/docs/source/advanced_features/macro_system.rst
@@ -17,7 +17,7 @@ users to define **macros** -- type-safe rules for programmatic query rewriting
 that transform user-provided queries on the *desired* data model into
 queries on the *actual* data model in the underlying data systems.
 
-When macros are defined, the compiler loads them into a `macro registry <Macro registry>`_ -- a
+When macros are defined, the compiler loads them into a :ref:`macro registry <macro_registry>` -- a
 data structure that tracks all currently available macros, the resulting GraphQL schema
 (accounting for macros), and any additional metadata needed by the compiler.
 The compiler then leverages this registry to expand queries that rely on macros,
@@ -39,9 +39,11 @@ though there are some key differences:
   seamlessly with all databases and even on schemas stitched together from multiple databases.
   In contrast, not all databases support SQL-like :code:`VIEW` functionality.
 
-Currently, the compiler supports one type of macro: `macro edges <Macro edges>`_, which allow
+Currently, the compiler supports one type of macro: :ref:`macro edges <macro_edges>`, which allow
 the creation of "virtual" edges computed from existing ones.
 More types of macros are coming in the future.
+
+.. _macro_registry:
 
 Macro registry
 --------------
@@ -81,6 +83,7 @@ The :code:`get_schema_for_macro_definition()` function is able to transform a qu
 into one that is suitable for defining macros. Getting such a schema may be useful, for example,
 when setting up a GraphQL editor (such as GraphiQL) to create and edit macros.
 
+.. _macro_edges:
 
 Macro edges
 -----------

--- a/docs/source/language_specification/query_directives.rst
+++ b/docs/source/language_specification/query_directives.rst
@@ -154,7 +154,7 @@ captured in a :code:`@fold`. The :code:`_x_count` meta field that is available
 within :code:`@fold` scopes represents the number of elements in the fold,
 and may be filtered or output as usual. As :code:`_x_count` represents a
 count of elements, marking it :code:`@output` will produce an integer value.
-See the `\_x\_count <#x-count>`__ section for more details.
+See the :ref:`\_x\_count <x_count>` section for more details.
 
 Example Use
 ~~~~~~~~~~~
@@ -332,7 +332,7 @@ used as part of a :code:`@filter` directive.
 
 To supply a tagged value to a :code:`@filter` directive, place the tag name
 (prefixed with a :code:`%` symbol) in the :code:`@filter`'s :code:`value` array. See
-`Passing parameters <#passing-parameters>`__ for more details.
+:ref:`Passing parameters <passing_parameters>` for more details.
 
 Example Use
 ~~~~~~~~~~~
@@ -373,7 +373,7 @@ Allows filtering of the data to be returned, based on any of a set of
 filtering operations. Conceptually, it is the GraphQL equivalent of the
 SQL :code:`WHERE` keyword.
 
-See `Supported filtering operations <#supported-filtering-operations>`__
+See `Supported filtering operations <supported_filtering_operations>`__
 for details on the various types of filtering that the compiler
 currently supports. These operations are currently hardcoded in the
 compiler; in the future, we may enable the addition of custom filtering
@@ -386,6 +386,8 @@ were joined by SQL :code:`AND` keywords.
 Using a :code:`@tag` and a :code:`@filter` that references the tag within the
 same vertex is allowed, so long as the two do not appear on the exact
 same property field.
+
+.. _passing_parameters:
 
 Passing Parameters
 ~~~~~~~~~~~~~~~~~~
@@ -751,6 +753,7 @@ Constraints and Rules
    used in the query.
 -  Cannot be used within a scope marked :code:`@optional` or :code:`@fold`.
 
+.. _supported_filtering_operations:
 
 Supported filtering operations
 ------------------------------

--- a/docs/source/language_specification/schema_types.rst
+++ b/docs/source/language_specification/schema_types.rst
@@ -127,7 +127,7 @@ Lets go over a toy example of a GraphQL object type:
 
 Here are some of the details:
 
-- :code:`_x_count`: is a `meta field <#meta-fields>`__. Meta fields are an advanced compiler
+- :code:`_x_count`: is a `meta field <meta_fields>`__. Meta fields are an advanced compiler
   feature.
 - :code:`name` is a **property field** that represents concrete data.
 - :code:`in_Animal_PlaysWith` is a **vertex field** representing an inbound edge.
@@ -222,7 +222,7 @@ implementation in the GraphQL schema to model the abstract inheritance in the un
         in_Species_Eats: [Species]
     }
 
-Querying an interface type without any `type coercion <#type-coercion>`__ returns all of the
+Querying an interface type without any `type coercion <type_coercion>`__ returns all of the
 the objects implemented by the interface. For instance, the following query returns the name of all
 :code:`Food`, :code:`Species` and :code:`Animal` objects.
 
@@ -263,6 +263,8 @@ as well an entry in :code:`type_equivalence_hints` mapping :code:`Food` to
 
 To query an union type, one must always type coerce to one of the encompassed object types as
 illustrated in the section below.
+
+.. _type_coercion:
 
 Type coercions
 ~~~~~~~~~~~~~~
@@ -314,6 +316,7 @@ In this query, the :code:`out_Entity_Related` is of :code:`Entity` type.
 However, the query only wants to return results where the related entity
 is a :code:`Species`, which :code:`... on Species` ensures is the case.
 
+.. _meta_fields:
 
 Meta fields
 -----------
@@ -356,6 +359,8 @@ others. Vertices of all subtypes of :code:`Entity` will therefore be
 returned, and the :code:`entity_type` column that outputs the :code:`__typename`
 field will show their runtime type: :code:`Animal`, :code:`Species`, :code:`Food`,
 etc.
+
+.. _x_count:
 
 \_x\_count
 ~~~~~~~~~~


### PR DESCRIPTION
In general, creating hyperlinks that reference other parts of a restructuredtext document is a bit of a pain. The way that hyperlink targets are generated is not very intuitive and documentation is not the best. On the other hand, Sphinx supports a directive called `:ref:` that achieves much of the same functionality but is way easier to use.   

Therefore, in this diff, I switch from using standard restructuredtext intra-doc hyperlinking features to using the sphinx `:ref:` directive. The readthedocs functionality and structure do not change with this diff. This diff is simply to encourage usage of the `:ref:` directive.

Here are some of the benefits of using `:ref:`:
1. The `:ref:` directive is way less magical. I am still not entirely sure how hyperlink targets are created in standard restructured text.  On the other hand with `:ref:`, you simply put a label somewhere in your set of readthedocs files and you reference that label when using the ref directive. If that label, is already taken then readthedocs will issue a warning when you run `make html`. 
2. Also, if you use `:ref:` incorrectly and have an invalid reference, then running `make html` will issue a warning that the hyperlink is invalid. 

Here is a link that explains more in detail how `:ref:` works.
https://www.sphinx-doc.org/en/1.5/markup/inline.html#role-ref