### PR TITLE
Accept only MetaData object for schema generation

### DIFF
--- a/graphql_compiler/schema_generation/sqlalchemy/schema_graph_builder.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/schema_graph_builder.py
@@ -8,7 +8,9 @@ from ..schema_graph import (
 )
 from .edge_descriptors import validate_edge_descriptors
 from .scalar_type_mapper import try_get_graphql_scalar_type
-from .utils import validate_that_tables_have_primary_keys
+from .utils import (
+    validate_that_tables_belong_to_the_same_metadata_object, validate_that_tables_have_primary_keys
+)
 
 
 def get_sqlalchemy_schema_graph(vertex_name_to_table, direct_edges):
@@ -30,6 +32,7 @@ def get_sqlalchemy_schema_graph(vertex_name_to_table, direct_edges):
     Returns:
         SchemaGraph reflecting the specified metadata.
     """
+    validate_that_tables_belong_to_the_same_metadata_object(vertex_name_to_table.values())
     validate_edge_descriptors(vertex_name_to_table, direct_edges)
     validate_that_tables_have_primary_keys(vertex_name_to_table.values())
 

--- a/graphql_compiler/schema_generation/sqlalchemy/utils.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/utils.py
@@ -12,3 +12,15 @@ def validate_that_tables_have_primary_keys(tables):
                                          'the underlying row. They must simple be unique and '
                                          'non-null identifiers of each row.'
                                          .format(table.name, table.schema))
+
+
+def validate_that_tables_belong_to_the_same_metadata_object(tables):
+    """Validate that all the SQLAlchemy Table objects belong to the same MetaData object."""
+    metadata = None
+    for table in tables:
+        if metadata is None:
+            metadata = table.metadata
+        else:
+            if table.metadata is not metadata:
+                raise AssertionError('Multiple SQLAlchemy MetaData objects used for schema '
+                                     'generation.')

--- a/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
+++ b/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
@@ -23,27 +23,25 @@ from ...schema_generation.sqlalchemy.schema_graph_builder import get_sqlalchemy_
 
 def _get_test_vertex_name_to_table():
     """Return a dict mapping the name of each VertexType to the underlying SQLAlchemy Table."""
-    metadata1 = MetaData()
+    metadata = MetaData()
     table1 = Table(
         'Table1',
-        metadata1,
+        metadata,
         Column('column_with_supported_type', String(), primary_key=True),
         Column('column_with_non_supported_type', LargeBinary()),
         Column('column_with_mssql_type', TINYINT()),
         Column('source_column', Integer()),
     )
 
-    # We use a different metadata object to test there is no dependency on the metadata object.
-    metadata2 = MetaData()
     table2 = Table(
         'Table2',
-        metadata2,
+        metadata,
         Column('destination_column', Integer(), primary_key=True),
     )
 
     table3 = Table(
         'Table3',
-        metadata2,
+        metadata,
         Column('primary_key_column1', Integer()),
         Column('primary_key_column2', Integer()),
 
@@ -52,7 +50,7 @@ def _get_test_vertex_name_to_table():
 
     table4 = Table(
         'Table4',
-        metadata2,
+        metadata,
         Column('primary_key_column_with_unsupported_type', Binary()),
 
         PrimaryKeyConstraint('primary_key_column_with_unsupported_type'),

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -494,18 +494,14 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
     schema = _get_schema_without_list_valued_property_fields()
     type_equivalence_hints = get_type_equivalence_hints()
 
-    # Every SQLAlchemy Table needs to be attached to a MetaData object. We don't actually use it.
-    # We use a mixture of two metadata objects to make sure our implementation does not rely
-    # on all the tables sharing a metadata object.
-    sqlalchemy_metadata_1 = sqlalchemy.MetaData()
-    sqlalchemy_metadata_2 = sqlalchemy.MetaData()
+    sqlalchemy_metadata = sqlalchemy.MetaData()
 
     uuid_type = sqlalchemy.String(36)
 
     tables = {
         'Animal': sqlalchemy.Table(
             'Animal',
-            sqlalchemy_metadata_1,
+            sqlalchemy_metadata,
             sqlalchemy.Column('birthday', sqlalchemy.DateTime, nullable=False),
             sqlalchemy.Column('color', sqlalchemy.String(40), nullable=True),
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=True),
@@ -523,7 +519,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'BirthEvent': sqlalchemy.Table(
             'BirthEvent',
-            sqlalchemy_metadata_2,
+            sqlalchemy_metadata,
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
@@ -533,7 +529,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'Entity': sqlalchemy.Table(
             'Entity',
-            sqlalchemy_metadata_2,
+            sqlalchemy_metadata,
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
@@ -542,7 +538,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'Event': sqlalchemy.Table(
             'Event',
-            sqlalchemy_metadata_2,
+            sqlalchemy_metadata,
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
@@ -552,7 +548,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'FeedingEvent': sqlalchemy.Table(
             'FeedingEvent',
-            sqlalchemy_metadata_1,
+            sqlalchemy_metadata,
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
@@ -562,7 +558,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'Food': sqlalchemy.Table(
             'Food',
-            sqlalchemy_metadata_1,
+            sqlalchemy_metadata,
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
@@ -570,7 +566,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'FoodOrSpecies': sqlalchemy.Table(
             'FoodOrSpecies',
-            sqlalchemy_metadata_1,
+            sqlalchemy_metadata,
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
@@ -578,7 +574,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'Location': sqlalchemy.Table(
             'Location',
-            sqlalchemy_metadata_1,
+            sqlalchemy_metadata,
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=False),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
@@ -586,7 +582,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'Species': sqlalchemy.Table(
             'Species',
-            sqlalchemy_metadata_2,
+            sqlalchemy_metadata,
             sqlalchemy.Column('description', sqlalchemy.String(40), nullable=True),
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             sqlalchemy.Column('name', sqlalchemy.String(40), nullable=False),
@@ -597,7 +593,7 @@ def get_sqlalchemy_schema_info(dialect='mssql'):
         ),
         'UniquelyIdentifiable': sqlalchemy.Table(
             'UniquelyIdentifiable',
-            sqlalchemy_metadata_1,
+            sqlalchemy_metadata,
             sqlalchemy.Column('uuid', uuid_type, primary_key=True),
             schema=('db_1.' if dialect == 'mssql' else '') + 'schema_1'
         ),


### PR DESCRIPTION
There is no reason why we would need to use multiple MetaData objects and using multiple MetaData objects makes it harder to infer DirectEdgeDescriptor objects from foreign keys.