### PR TITLE
Shorten SQLAlchemy schema info generation function name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1837,7 +1837,7 @@ as in the example below:
 
 .. code:: python
 
-    from graphql_compiler import get_sqlalchemy_schema_info_from_specified_metadata, graphql_to_sql
+    from graphql_compiler import get_sqlalchemy_schema_info, graphql_to_sql
     from sqlalchemy import MetaData, create_engine
 
     engine = create_engine('<connection string>')
@@ -1848,7 +1848,7 @@ as in the example below:
     metadata.reflect()
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object.
-    sql_schema_info = get_sqlalchemy_schema_info_from_specified_metadata(
+    sql_schema_info = get_sqlalchemy_schema_info(
         metadata.tables, {}, engine.dialect)
 
     # Write GraphQL query.
@@ -1879,7 +1879,7 @@ backed by SQL `association tables <https://en.wikipedia.org/wiki/Associative_ent
 
 .. code:: python
 
-    from graphql_compiler import get_sqlalchemy_schema_info_from_specified_metadata, graphql_to_sql
+    from graphql_compiler import get_sqlalchemy_schema_info, graphql_to_sql
     from graphql_compiler.schema_generation.sqlalchemy.edge_descriptors import DirectEdgeDescriptor
     from sqlalchemy import MetaData, create_engine
 
@@ -1899,7 +1899,7 @@ backed by SQL `association tables <https://en.wikipedia.org/wiki/Associative_ent
     }
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object.
-    sql_schema_info = get_sqlalchemy_schema_info_from_specified_metadata(
+    sql_schema_info = get_sqlalchemy_schema_info(
         metadata.tables, direct_edges, engine.dialect)
 
     # Write GraphQL query with edge traversal.

--- a/README.rst
+++ b/README.rst
@@ -1848,8 +1848,7 @@ as in the example below:
     metadata.reflect()
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object.
-    sql_schema_info = get_sqlalchemy_schema_info(
-        metadata.tables, {}, engine.dialect)
+    sql_schema_info = get_sqlalchemy_schema_info(metadata.tables, {}, engine.dialect)
 
     # Write GraphQL query.
     graphql_query = '''
@@ -1899,8 +1898,7 @@ backed by SQL `association tables <https://en.wikipedia.org/wiki/Associative_ent
     }
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object.
-    sql_schema_info = get_sqlalchemy_schema_info(
-        metadata.tables, direct_edges, engine.dialect)
+    sql_schema_info = get_sqlalchemy_schema_info(metadata.tables, direct_edges, engine.dialect)
 
     # Write GraphQL query with edge traversal.
     graphql_query = '''

--- a/docs/source/supported_databases/sql.rst
+++ b/docs/source/supported_databases/sql.rst
@@ -36,8 +36,7 @@ as in the example below:
     metadata.reflect()
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object.
-    sql_schema_info = get_sqlalchemy_schema_info(
-        metadata.tables, {}, engine.dialect)
+    sql_schema_info = get_sqlalchemy_schema_info(metadata.tables, {}, engine.dialect)
 
     # Write GraphQL query.
     graphql_query = '''
@@ -88,8 +87,7 @@ backed by SQL `association tables <https://en.wikipedia.org/wiki/Associative_ent
     }
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object.
-    sql_schema_info = get_sqlalchemy_schema_info(
-        metadata.tables, direct_edges, engine.dialect)
+    sql_schema_info = get_sqlalchemy_schema_info(metadata.tables, direct_edges, engine.dialect)
 
     # Write GraphQL query with edge traversal.
     graphql_query = '''

--- a/docs/source/supported_databases/sql.rst
+++ b/docs/source/supported_databases/sql.rst
@@ -25,7 +25,7 @@ as in the example below:
 
 .. code:: python
 
-    from graphql_compiler import get_sqlalchemy_schema_info_from_specified_metadata, graphql_to_sql
+    from graphql_compiler import get_sqlalchemy_schema_info, graphql_to_sql
     from sqlalchemy import MetaData, create_engine
 
     engine = create_engine('<connection string>')
@@ -36,7 +36,7 @@ as in the example below:
     metadata.reflect()
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object.
-    sql_schema_info = get_sqlalchemy_schema_info_from_specified_metadata(
+    sql_schema_info = get_sqlalchemy_schema_info(
         metadata.tables, {}, engine.dialect)
 
     # Write GraphQL query.
@@ -68,7 +68,7 @@ backed by SQL `association tables <https://en.wikipedia.org/wiki/Associative_ent
 
 .. code:: python
 
-    from graphql_compiler import get_sqlalchemy_schema_info_from_specified_metadata, graphql_to_sql
+    from graphql_compiler import get_sqlalchemy_schema_info, graphql_to_sql
     from graphql_compiler.schema_generation.sqlalchemy.edge_descriptors import DirectEdgeDescriptor
     from sqlalchemy import MetaData, create_engine
 
@@ -88,7 +88,7 @@ backed by SQL `association tables <https://en.wikipedia.org/wiki/Associative_ent
     }
 
     # Wrap the schema information into a SQLAlchemySchemaInfo object.
-    sql_schema_info = get_sqlalchemy_schema_info_from_specified_metadata(
+    sql_schema_info = get_sqlalchemy_schema_info(
         metadata.tables, direct_edges, engine.dialect)
 
     # Write GraphQL query with edge traversal.

--- a/graphql_compiler/__init__.py
+++ b/graphql_compiler/__init__.py
@@ -15,7 +15,7 @@ from .schema import (  # noqa
     insert_meta_fields_into_existing_schema, is_meta_field
 )
 from .schema_generation.orientdb import get_graphql_schema_from_orientdb_schema_data  # noqa
-from .schema_generation.sqlalchemy import get_sqlalchemy_schema_info_from_specified_metadata  # noqa
+from .schema_generation.sqlalchemy import get_sqlalchemy_schema_info  # noqa
 
 
 __package_name__ = 'graphql-compiler'

--- a/graphql_compiler/schema_generation/sqlalchemy/__init__.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/__init__.py
@@ -5,7 +5,7 @@ from .edge_descriptors import get_join_descriptors_from_edge_descriptors
 from .schema_graph_builder import get_sqlalchemy_schema_graph
 
 
-def get_sqlalchemy_schema_info_from_specified_metadata(
+def get_sqlalchemy_schema_info(
     vertex_name_to_table, direct_edges, dialect, class_to_field_type_overrides=None
 ):
     """Return a SQLAlchemySchemaInfo from the metadata.

--- a/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
+++ b/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
@@ -274,8 +274,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             )
         }
         with self.assertRaises(InvalidSQLEdgeError):
-            get_sqlalchemy_schema_info(
-                self.vertex_name_to_table, direct_edges, dialect())
+            get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_destination_vertex(self):
         direct_edges = {
@@ -287,8 +286,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             )
         }
         with self.assertRaises(InvalidSQLEdgeError):
-            get_sqlalchemy_schema_info(
-                self.vertex_name_to_table, direct_edges, dialect())
+            get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_source_column(self):
         direct_edges = {
@@ -300,8 +298,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             )
         }
         with self.assertRaises(InvalidSQLEdgeError):
-            get_sqlalchemy_schema_info(
-                self.vertex_name_to_table, direct_edges, dialect())
+            get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_destination_column(self):
         direct_edges = {
@@ -313,8 +310,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             )
         }
         with self.assertRaises(InvalidSQLEdgeError):
-            get_sqlalchemy_schema_info(
-                self.vertex_name_to_table, direct_edges, dialect())
+            get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
     def test_missing_primary_key(self):
         table_without_primary_key = Table(
@@ -326,5 +322,4 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             table_without_primary_key.name: table_without_primary_key
         }
         with self.assertRaises(MissingPrimaryKeyError):
-            get_sqlalchemy_schema_info(
-                faulty_vertex_name_to_table, {}, dialect())
+            get_sqlalchemy_schema_info(faulty_vertex_name_to_table, {}, dialect())

--- a/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
+++ b/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
@@ -9,7 +9,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.mssql import TINYINT, dialect
 from sqlalchemy.types import Binary, Integer, LargeBinary, String
 
-from ... import get_sqlalchemy_schema_info_from_specified_metadata
+from ... import get_sqlalchemy_schema_info
 from ...schema_generation.exceptions import InvalidSQLEdgeError, MissingPrimaryKeyError
 from ...schema_generation.schema_graph import IndexDefinition
 from ...schema_generation.sqlalchemy import (
@@ -274,7 +274,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             )
         }
         with self.assertRaises(InvalidSQLEdgeError):
-            get_sqlalchemy_schema_info_from_specified_metadata(
+            get_sqlalchemy_schema_info(
                 self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_destination_vertex(self):
@@ -287,7 +287,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             )
         }
         with self.assertRaises(InvalidSQLEdgeError):
-            get_sqlalchemy_schema_info_from_specified_metadata(
+            get_sqlalchemy_schema_info(
                 self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_source_column(self):
@@ -300,7 +300,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             )
         }
         with self.assertRaises(InvalidSQLEdgeError):
-            get_sqlalchemy_schema_info_from_specified_metadata(
+            get_sqlalchemy_schema_info(
                 self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_destination_column(self):
@@ -313,7 +313,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             )
         }
         with self.assertRaises(InvalidSQLEdgeError):
-            get_sqlalchemy_schema_info_from_specified_metadata(
+            get_sqlalchemy_schema_info(
                 self.vertex_name_to_table, direct_edges, dialect())
 
     def test_missing_primary_key(self):
@@ -326,5 +326,5 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             table_without_primary_key.name: table_without_primary_key
         }
         with self.assertRaises(MissingPrimaryKeyError):
-            get_sqlalchemy_schema_info_from_specified_metadata(
+            get_sqlalchemy_schema_info(
                 faulty_vertex_name_to_table, {}, dialect())


### PR DESCRIPTION
It is way too long.