### PR TITLE
Fix bug preventing tags from being used on the same vertex if the tag name differs from the column name

### DIFF
--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -151,7 +151,8 @@ def _represent_argument(directive_location, context, argument, inferred_type):
                     expressions.FalseLiteral)
 
         if field_is_local:
-            representation = expressions.LocalField(argument_name, inferred_type)
+            underlying_column_name = tag_info.location.field
+            representation = expressions.LocalField(underlying_column_name, inferred_type)
         else:
             representation = expressions.ContextField(location, inferred_type)
 
@@ -904,6 +905,12 @@ def process_filter_directive(filter_operation_info, location, context):
         a Filter basic block that performs the requested filtering operation
     """
     op_name, operator_params = _get_filter_op_name_and_values(filter_operation_info.directive)
+
+    # for idx, param in enumerate(operator_params):
+    #     if param[0] == '%':
+    #         tag_name = param[1:]
+    #         tagged_column = context['metadata']._tags[tag_name].location.field
+    #         operator_params[idx] = tagged_column
 
     non_comparison_filters = {
         u'name_or_alias': _process_name_or_alias_filter_directive,

--- a/graphql_compiler/compiler/filters.py
+++ b/graphql_compiler/compiler/filters.py
@@ -906,12 +906,6 @@ def process_filter_directive(filter_operation_info, location, context):
     """
     op_name, operator_params = _get_filter_op_name_and_values(filter_operation_info.directive)
 
-    # for idx, param in enumerate(operator_params):
-    #     if param[0] == '%':
-    #         tag_name = param[1:]
-    #         tagged_column = context['metadata']._tags[tag_name].location.field
-    #         operator_params[idx] = tagged_column
-
     non_comparison_filters = {
         u'name_or_alias': _process_name_or_alias_filter_directive,
         u'between': _process_between_filter_directive,

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -255,6 +255,41 @@ class CompilerTests(unittest.TestCase):
         check_test_data(
             self, test_data, expected_match, expected_gremlin, expected_sql, expected_cypher)
 
+    def test_colocated_filter_with_differently_named_column_and_tag(self):
+        test_data = test_input_data.colocated_filter_with_differently_named_column_and_tag()
+
+        expected_match = '''
+            SELECT Animal__out_Entity_Related___1.name AS `related_name` FROM (MATCH {{
+                where: ((@this INSTANCEOF 'Animal')),
+                as: Animal___1
+            }}.out('Entity_Related') {{
+                class: Entity,
+                where: ((alias CONTAINS name)),
+                as: Animal__out_Entity_Related___1
+            }} RETURN $matches)
+        '''
+        expected_gremlin = '''
+            g.V('@class', 'Animal')
+            .as('Animal___1')
+                .out('Entity_Related')
+                .filter{it, m -> it.alias.contains(it.name)}
+                .as('Animal__out_Entity_Related___1')
+            .back('Animal___1')
+            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
+                related_name: m.Animal__out_Entity_Related___1.name
+            ])}
+        '''
+        expected_sql = NotImplementedError
+        expected_cypher = '''
+            MATCH (Animal___1:Animal)
+            MATCH (Animal___1)-[:Entity_Related]->(Animal__out_Entity_Related___1:Entity)
+                WHERE (Animal__out_Entity_Related___1.name IN Animal__out_Entity_Related___1.alias)
+            RETURN Animal__out_Entity_Related___1.name AS `related_name`
+        '''
+
+        check_test_data(
+            self, test_data, expected_match, expected_gremlin, expected_sql, expected_cypher)
+
     def test_colocated_out_of_order_filter_and_tag(self):
         test_data = test_input_data.colocated_out_of_order_filter_and_tag()
 

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -290,8 +290,8 @@ class CompilerTests(unittest.TestCase):
         check_test_data(
             self, test_data, expected_match, expected_gremlin, expected_sql, expected_cypher)
 
-    def test_colocated_filter_tag_sharing_name_with_other_column(self):
-        test_data = test_input_data.colocated_filter_tag_sharing_name_with_other_column()
+    def test_colocated_filter_and_tag_sharing_name_with_other_column(self):
+        test_data = test_input_data.colocated_filter_and_tag_sharing_name_with_other_column()
 
         expected_match = '''
             SELECT Animal__out_Entity_Related___1.name AS `related_name` FROM (MATCH {{

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -290,6 +290,41 @@ class CompilerTests(unittest.TestCase):
         check_test_data(
             self, test_data, expected_match, expected_gremlin, expected_sql, expected_cypher)
 
+    def test_colocated_filter_tag_sharing_name_with_other_column(self):
+        test_data = test_input_data.colocated_filter_tag_sharing_name_with_other_column()
+
+        expected_match = '''
+            SELECT Animal__out_Entity_Related___1.name AS `related_name` FROM (MATCH {{
+                where: ((@this INSTANCEOF 'Animal')),
+                as: Animal___1
+            }}.out('Entity_Related') {{
+                class: Entity,
+                where: ((alias CONTAINS name)),
+                as: Animal__out_Entity_Related___1
+            }} RETURN $matches)
+        '''
+        expected_gremlin = '''
+            g.V('@class', 'Animal')
+            .as('Animal___1')
+                .out('Entity_Related')
+                .filter{it, m -> it.alias.contains(it.name)}
+                .as('Animal__out_Entity_Related___1')
+            .back('Animal___1')
+            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
+                related_name: m.Animal__out_Entity_Related___1.name
+            ])}
+        '''
+        expected_sql = NotImplementedError
+        expected_cypher = '''
+            MATCH (Animal___1:Animal)
+            MATCH (Animal___1)-[:Entity_Related]->(Animal__out_Entity_Related___1:Entity)
+                WHERE (Animal__out_Entity_Related___1.name IN Animal__out_Entity_Related___1.alias)
+            RETURN Animal__out_Entity_Related___1.name AS `related_name`
+        '''
+
+        check_test_data(
+            self, test_data, expected_match, expected_gremlin, expected_sql, expected_cypher)
+
     def test_colocated_out_of_order_filter_and_tag(self):
         test_data = test_input_data.colocated_out_of_order_filter_and_tag()
 

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -122,6 +122,28 @@ def colocated_filter_with_differently_named_column_and_tag():  # noqa: D103
         type_equivalence_hints=None)
 
 
+def colocated_filter_and_tag_sharing_name_with_other_column():  # noqa: D103
+    graphql_input = '''{
+        Animal {
+            out_Entity_Related {
+                name @output(out_name: "related_name")
+                     @tag(tag_name: "parent")
+                alias @filter(op_name: "contains", value: ["%parent"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'related_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
 def colocated_out_of_order_filter_and_tag():  # noqa: D103
     graphql_input = '''{
         Animal {

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -100,6 +100,28 @@ def colocated_filter_and_tag():  # noqa: D103
         type_equivalence_hints=None)
 
 
+def colocated_filter_with_differently_named_column_and_tag():  # noqa: D103
+    graphql_input = '''{
+        Animal {
+            out_Entity_Related {
+                name @output(out_name: "related_name")
+                     @tag(tag_name: "tagged_name")
+                alias @filter(op_name: "contains", value: ["%tagged_name"])
+            }
+        }
+    }'''
+    expected_output_metadata = {
+        'related_name': OutputMetadata(type=GraphQLString, optional=False),
+    }
+    expected_input_metadata = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None)
+
+
 def colocated_out_of_order_filter_and_tag():  # noqa: D103
     graphql_input = '''{
         Animal {

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -343,6 +343,38 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
+    def test_colocated_filter_with_differently_named_column_and_tag(self):
+        test_data = test_input_data.colocated_filter_with_differently_named_column_and_tag()
+
+        base_location = helpers.Location(('Animal',))
+        child_location = base_location.navigate_to_subpath('out_Entity_Related')
+
+        expected_blocks = [
+            blocks.QueryRoot({'Animal'}),
+            blocks.MarkLocation(base_location),
+            blocks.Traverse('out', 'Entity_Related'),
+            blocks.Filter(
+                expressions.BinaryComposition(
+                    u'contains',
+                    expressions.LocalField('alias', GraphQLList(GraphQLString)),
+                    expressions.LocalField('name', GraphQLString)
+                )
+            ),
+            blocks.MarkLocation(child_location),
+            blocks.Backtrack(base_location),
+            blocks.GlobalOperationsStart(),
+            blocks.ConstructResult({
+                'related_name': expressions.OutputContextField(
+                    child_location.navigate_to_field('name'), GraphQLString)
+            }),
+        ]
+        expected_location_types = {
+            base_location: 'Animal',
+            child_location: 'Entity',
+        }
+
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
+
     def test_colocated_out_of_order_filter_and_tag(self):
         test_data = test_input_data.colocated_out_of_order_filter_and_tag()
 

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -375,6 +375,38 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
+    def test_colocated_filter_and_tag_sharing_name_with_other_column(self):
+        test_data = test_input_data.colocated_filter_and_tag_sharing_name_with_other_column()
+
+        base_location = helpers.Location(('Animal',))
+        child_location = base_location.navigate_to_subpath('out_Entity_Related')
+
+        expected_blocks = [
+            blocks.QueryRoot({'Animal'}),
+            blocks.MarkLocation(base_location),
+            blocks.Traverse('out', 'Entity_Related'),
+            blocks.Filter(
+                expressions.BinaryComposition(
+                    u'contains',
+                    expressions.LocalField('alias', GraphQLList(GraphQLString)),
+                    expressions.LocalField('name', GraphQLString)
+                )
+            ),
+            blocks.MarkLocation(child_location),
+            blocks.Backtrack(base_location),
+            blocks.GlobalOperationsStart(),
+            blocks.ConstructResult({
+                'related_name': expressions.OutputContextField(
+                    child_location.navigate_to_field('name'), GraphQLString)
+            }),
+        ]
+        expected_location_types = {
+            base_location: 'Animal',
+            child_location: 'Entity',
+        }
+
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
+
     def test_colocated_out_of_order_filter_and_tag(self):
         test_data = test_input_data.colocated_out_of_order_filter_and_tag()
 


### PR DESCRIPTION
Fixes issue #652. Issue was resolved in `compiler.filters._represent_argument` by ensuring that when the tagged field is local (i.e. that it is being use at the same vertex at which it was tagged), that the representation comes from the underlying column name not from the name used in the tag.

This issue didn't come up for tags that are used on a different vertex, because those tags are identified by the location block at which they were tagged.