### PR TITLE
Fix fold implementation so that join to subquery uses INNER JOIN

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -291,7 +291,7 @@ class SQLFoldObject(object):
             from_clause,
             fold_subquery,
             onclause=(outer_from_table.c[edge.from_column] == fold_subquery.c[edge.from_column]),
-            isouter=True
+            isouter=False
         )
 
         return fold_subquery, joined_from_clause, outer_from_table

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -4300,7 +4300,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list
             FROM
                 schema_1."Animal" AS "Animal_1"
-            LEFT OUTER JOIN (
+            JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
@@ -4337,7 +4337,7 @@ class CompilerTests(unittest.TestCase):
               ) AS child_names_list
             FROM
                 schema_1."Animal" AS "Animal_1"
-            LEFT OUTER JOIN (
+            JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
@@ -4368,7 +4368,7 @@ class CompilerTests(unittest.TestCase):
                 AS sibling_and_self_names_list
             FROM
               schema_1."Animal" AS "Animal_1"
-            LEFT OUTER JOIN (
+            JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
@@ -4379,7 +4379,7 @@ class CompilerTests(unittest.TestCase):
                   "Animal_2".uuid
             ) AS folded_subquery_1 ON "Animal_1".uuid = folded_subquery_1.uuid
             JOIN schema_1."Animal" AS "Animal_4" ON "Animal_1".parent = "Animal_4".uuid
-            LEFT OUTER JOIN (
+            JOIN (
                 SELECT
                     "Animal_5".uuid AS uuid,
                     array_agg("Animal_6".name) AS fold_output_name
@@ -4445,7 +4445,7 @@ class CompilerTests(unittest.TestCase):
               schema_1."Animal" AS "Animal_1"
             JOIN schema_1."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
-            LEFT OUTER JOIN(
+            JOIN(
                 SELECT
                     "Animal_3".uuid AS uuid,
                     array_agg("Animal_4".name) AS fold_output_name
@@ -4487,7 +4487,7 @@ class CompilerTests(unittest.TestCase):
             FROM schema_1."Animal" AS "Animal_1"
             JOIN schema_1."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
-            LEFT OUTER JOIN (
+            JOIN (
                 SELECT
                   "Location_2".uuid AS uuid,
                   array_agg("Animal_2".name) AS fold_output_name
@@ -4517,7 +4517,7 @@ class CompilerTests(unittest.TestCase):
             FROM schema_1."Animal" AS "Animal_1"
             JOIN schema_1."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
-            LEFT OUTER JOIN (
+            JOIN (
                 SELECT
                     "Location_2".uuid AS uuid,
                     array_agg("Animal_2".name) AS fold_output_name
@@ -7401,7 +7401,7 @@ class CompilerTests(unittest.TestCase):
             LEFT OUTER JOIN
                 schema_1."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
-            LEFT OUTER JOIN (
+            JOIN (
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name
@@ -7493,7 +7493,7 @@ class CompilerTests(unittest.TestCase):
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
               "Animal_2".name AS parent_name
             FROM schema_1."Animal" AS "Animal_1"
-            LEFT OUTER JOIN (
+            JOIN (
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name


### PR DESCRIPTION
Predrag pointed out that since folds shouldn't be null and since the folded subquery is joined to the rest of the query on equality over primary keys, the join should be an `inner join`, not a `left join`

e.g. 

```
SELECT
    OuterVertex.property AS alias_1,
    folded_subquery_1.fold_output_column AS alias_2
FROM OuterVertex AS tbl_outer_0
LEFT OUTER JOIN (
    SELECT
       OuterVertex.primary_key AS primary_key,
       COALESCE(
           (SELECT
               '|' + COALESCE(
                 REPLACE(
                   REPLACE(
                     REPLACE(inner_table.agg_column, '^', '^e'), 
                   '~', '^n'),     
                 '|', '^d'),
            '~')
            FROM Table inner_table
            WHERE (inner_table.primary_key = outer_copy.primary_key) 
            FOR XML PATH ('')),
       '') AS aggregation,
    FROM OuterVertex AS tbl_outer_1
) AS folded_subquery_1
ON tbl_outer_0.primary_key = folded_subquery_1.primary_key
```

should instead use `INNER JOIN` because every row of tbl_outer_0 should find precisely one row in fold_subquery_1 that matches the predicate, and there should never be nulls.