### PR TITLE
Add "About the Graphql Compiler" section to readthedocs

### DIFF
--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -182,7 +182,7 @@ This feature implements a workaround for a limitation of OrientDB, where
 subsequent traversals from them. To work around this issue, the compiler
 rewrites the query into several disjoint queries whose union produces
 the exact same results as a single query that allows optional
-traversals.
+traversals. See this :ref:`link <compound_optional_performance_penalty>` for more details.
 
 v1.4.1
 ------

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -1,0 +1,295 @@
+Changelog
+=========
+
+Current development version
+---------------------------
+
+v1.11.0
+-------
+
+-  Release automatic GraphQL schema generation from OrientDB schema
+   metadata.
+   `#204 <https://github.com/kensho-technologies/graphql-compiler/pull/204>`__
+-  Release the SchemaGraph, a utility class designed for easy schema
+   introspection.
+   `#292 <https://github.com/kensho-technologies/graphql-compiler/pull/292>`__
+-  Release :code:`not_contains` and :code:`not_in_collection` filter operations.
+   `#349 <https://github.com/kensho-technologies/graphql-compiler/pull/349>`__
+   `#350 <https://github.com/kensho-technologies/graphql-compiler/pull/350>`__
+-  Allow out-of-order :code:`@tag` and :code:`@filter` when in the same scope.
+   `#351 <https://github.com/kensho-technologies/graphql-compiler/pull/351>`__
+-  Fix a bug causing MATCH queries to have missing type coercions.
+   `#332 <https://github.com/kensho-technologies/graphql-compiler/pull/332>`__
+-  Release functionality that is able to amend parsing and serialization
+   of custom scalar types in schemas parsed from text form.
+   `#398 <https://github.com/kensho-technologies/graphql-compiler/pull/398>`__
+-  Improve validation error messages for output and parameter names.
+   `#414 <https://github.com/kensho-technologies/graphql-compiler/pull/414>`__
+   `#416 <https://github.com/kensho-technologies/graphql-compiler/pull/416>`__
+-  Alpha (unstable) release of query cost estimation functionality.
+   `#345 <https://github.com/kensho-technologies/graphql-compiler/pull/345>`__
+-  Clean up README.md and update troubleshooting documentation.
+-  Many maintainer quality-of-life improvements.
+
+Thanks to :code:`0xflotus`, :code:`bojanserafimov`, :code:`evantey`,
+:code:`LWProgramming`, :code:`pmantica1`, :code:`qqi0O0`, and :code:`Vlad` for their
+contributions.
+
+v1.10.1
+-------
+
+-  Fix :code:`_x_count` and optional filter creating duplicate
+   GlobalOperationsStart IR blocks.
+   `#253 <https://github.com/kensho-technologies/graphql-compiler/pull/253>`__.
+-  Raise error for unused :code:`@tag` directives
+   `#224 <https://github.com/kensho-technologies/graphql-compiler/pull/224>`__.
+-  Much documentation cleanup and many maintainer quality-of-life
+   improvements.
+
+Thanks to :code:`bojanserafimov`, :code:`evantey14`, :code:`jeremy.meulemans`, and
+:code:`pmantica1` for their contributions.
+
+v1.10.0
+-------
+
+-  **BREAKING**: Rename the :code:`__count` meta field to :code:`_x_count`, to
+   avoid GraphQL schema parsing issues with other GraphQL libraries.
+   `#176 <https://github.com/kensho-technologies/graphql-compiler/pull/176>`__
+
+v1.9.0
+------
+
+-  Add a :code:`__count` meta field that supports outputting and filtering
+   on the size of a :code:`@fold` scope.
+   `#158 <https://github.com/kensho-technologies/graphql-compiler/pull/158>`__
+-  Add scaffolding for development and testing of SQL compiler backend,
+   and a variety of development quality-of-life improvements.
+
+Thanks to :code:`jmeulemans` for his contributions.
+
+v1.8.3
+------
+
+-  Explicit support for Python 3.7. Earlier compiler versions also
+   worked on 3.7, but now we also run tests in 3.7 to confirm.
+   `#148 <https://github.com/kensho-technologies/graphql-compiler/pull/148>`__
+-  Bug fix for compilation error when using :code:`has_edge_degree` and
+   :code:`between` filtering in the same scope.
+   `#146 <https://github.com/kensho-technologies/graphql-compiler/pull/146>`__
+-  Exposed additional query metadata that describes :code:`@recurse` and
+   :code:`@filter` directives encountered in the query.
+   `#141 <https://github.com/kensho-technologies/graphql-compiler/pull/141/files>`__
+
+Thanks to :code:`gurer-kensho` for the contribution.
+
+v1.8.2
+------
+
+-  Fix overly strict type check on :code:`@recurse` directives involving a
+   union type.
+   `#131 <https://github.com/kensho-technologies/graphql-compiler/pull/131>`__
+
+Thanks to :code:`cw6515` for the fix!
+
+v1.8.1
+------
+
+-  Fix a bug that arose when using certain type coercions that the
+   compiler optimizes away to a no-op.
+   `#127 <https://github.com/kensho-technologies/graphql-compiler/pull/127>`__
+
+Thanks to :code:`bojanserafimov` for the fix!
+
+v1.8.0
+------
+
+-  Allow :code:`@optional` vertex fields nested inside other :code:`@optional`
+   vertex fields.
+   `#120 <https://github.com/kensho-technologies/graphql-compiler/pull/120>`__
+-  Fix a bug that accidentally disallowed having two :code:`@recurse`
+   directives within the same vertex field.
+   `#115 <https://github.com/kensho-technologies/graphql-compiler/pull/115>`__
+-  Enforce that all required directives are present in the schema.
+   `#114 <https://github.com/kensho-technologies/graphql-compiler/pull/114>`__
+-  Under the hood, made fairly major changes to how query metadata is
+   tracked and processed.
+
+Thanks to :code:`amartyashankha`, :code:`cw6515`, and :code:`yangsong97` for their
+contributions!
+
+v1.7.2
+------
+
+-  Fix possible incorrect query execution due to dropped type coercions.
+   `#110 <https://github.com/kensho-technologies/graphql-compiler/pull/110>`__
+   `#113 <https://github.com/kensho-technologies/graphql-compiler/pull/113>`__
+
+v1.7.0
+------
+
+-  Add a new :code:`@filter` operator: :code:`intersects`.
+   `#100 <https://github.com/kensho-technologies/graphql-compiler/pull/100>`__
+-  Add an optimization that helps OrientDB choose a good starting point
+   for query evaluation.
+   `#102 <https://github.com/kensho-technologies/graphql-compiler/pull/102>`__
+
+The new optimization pass manages what type information is visible at
+different points in the generated query. By exposing additional type
+information, or hiding existing type information, the compiler maximizes
+the likelihood that OrientDB will start evaluating the query at the
+location of lowest cardinality. This produces a massive performance
+benefit -- up to 1000x on some queries!
+
+Thanks to :code:`yangsong97` for making his first contribution with the
+:code:`intersects` operator!
+
+v1.6.2
+------
+
+-  Fix incorrect filtering in :code:`@optional` locations.
+   `#95 <https://github.com/kensho-technologies/graphql-compiler/pull/95>`__
+
+Thanks to :code:`amartyashankha` for the fix!
+
+v1.6.1
+------
+
+-  Fix a bad compilation bug on :code:`@fold` and :code:`@optional` in the same
+   scope.
+   `#86 <https://github.com/kensho-technologies/graphql-compiler/pull/86>`__
+
+Thanks to :code:`amartyashankha` for the fix!
+
+v1.6.0
+------
+
+-  Add full support for :code:`Decimal` data, including both filtering and
+   output.
+   `#91 <https://github.com/kensho-technologies/graphql-compiler/pull/91>`__
+
+v1.5.0
+------
+
+-  Allow expanding vertex fields within :code:`@optional` scopes.
+   `#83 <https://github.com/kensho-technologies/graphql-compiler/pull/83>`__
+
+This is a massive feature, totaling over 4000 lines of changes and
+hundreds of hours of many engineers' time. Special thanks to
+:code:`amartyashankha` for taking point on the implementation!
+
+This feature implements a workaround for a limitation of OrientDB, where
+:code:`MATCH` treats optional vertices as terminal and does not allow
+subsequent traversals from them. To work around this issue, the compiler
+rewrites the query into several disjoint queries whose union produces
+the exact same results as a single query that allows optional
+traversals. See `the documentation in the
+README <https://github.com/kensho-technologies/graphql-compiler/blob/3c79cd97744b7f3f842c2d32ddc2a072c7fa7898/README.md#expanding-optional-vertex-fields>`__
+for more details.
+
+v1.4.1
+------
+
+-  Make MATCH use the :code:`BETWEEN` operator when possible, to avoid `an
+   OrientDB performance
+   issue <https://github.com/orientechnologies/orientdb/issues/8230>`__
+   `#70 <https://github.com/kensho-technologies/graphql-compiler/pull/70>`__
+
+Thanks to :code:`amartyashankha` for this contribution!
+
+v1.4.0
+------
+
+-  Enable expanding vertex fields inside :code:`@fold`
+   `#64 <https://github.com/kensho-technologies/graphql-compiler/pull/64>`__
+
+Thanks to :code:`amartyashankha` for this contribution!
+
+v1.3.1
+------
+
+-  Add a workaround for a bug in OrientDB related to :code:`@recurse` with
+   type coercions
+   `#55 <https://github.com/kensho-technologies/graphql-compiler/pull/55>`__
+-  Exposed the package name and version in the root :code:`__init__.py` file
+   `#57 <https://github.com/kensho-technologies/graphql-compiler/pull/57>`__
+
+v1.3.0
+------
+
+-  Add a new :code:`@filter` operator: :code:`has_edge_degree`.
+   `#52 <https://github.com/kensho-technologies/graphql-compiler/pull/52>`__
+-  Lots of under-the-hood cleanup and improvements.
+
+v1.2.1
+------
+
+-  Add workaround for `OrientDB type inconsistency when filtering
+   lists <https://github.com/orientechnologies/orientdb/issues/7811>`__
+   `#42 <https://github.com/kensho-technologies/graphql-compiler/pull/42>`__
+
+v1.2.0
+------
+
+-  **BREAKING**: Requires OrientDB 2.2.28+, since it depends on two
+   OrientDB bugs being fixed: `bug
+   1 <https://github.com/orientechnologies/orientdb/issues/7225>`__ `bug
+   2 <https://github.com/orientechnologies/orientdb/issues/7754>`__
+-  Allow type coercions and filtering within :code:`@fold` scopes.
+-  Fix bug where :code:`@filter` directives could end up ignored if more
+   than two were in the same scope
+-  Optimize type coercions in :code:`@optional` and :code:`@recurse` scopes.
+-  Optimize multiple outputs from the same :code:`@fold` scope.
+-  Allow having multiple :code:`@filter` directives on the same field
+   `#33 <https://github.com/kensho-technologies/graphql-compiler/pull/33>`__
+-  Allow using the :code:`name_or_alias` filtering operation on interface
+   types
+   `#37 <https://github.com/kensho-technologies/graphql-compiler/pull/37>`__
+
+v1.1.0
+------
+
+-  Add support for Python 3
+   `#31 <https://github.com/kensho-technologies/graphql-compiler/pull/31>`__
+-  Make it possible to use :code:`@fold` together with union-typed vertex
+   fields
+   `#32 <https://github.com/kensho-technologies/graphql-compiler/pull/32>`__
+
+Thanks to :code:`ColCarroll` for making the compiler support Python 3!
+
+v1.0.3
+------
+
+-  Fix a minor bug in the GraphQL pretty-printer
+   `#30 <https://github.com/kensho-technologies/graphql-compiler/pull/30>`__
+
+v1.0.2
+------
+
+-  Make the :code:`graphql_to_ir()` easier to use by making it automatically
+   add a new line to the end of the GraphQL query string. Works around
+   an issue in the :code:`graphql-core`\ dependency library:
+   `https://github.com/graphql-python/graphql-core/issues/98 <https://github.com/graphql-python/graphql-core/issues/98>`__
+-  Robustness improvements for the pretty-printer
+   `#27 <https://github.com/kensho-technologies/graphql-compiler/pull/27>`__
+
+Thanks to :code:`benlongo` for their contributions.
+
+v1.0.1
+------
+
+-  Add GraphQL pretty printer: :code:`python -m graphql_compiler.tool`
+   `#23 <https://github.com/kensho-technologies/graphql-compiler/pull/23>`__
+-  Raise errors if there are no :code:`@output` directives within a
+   :code:`@fold` scope
+   `#18 <https://github.com/kensho-technologies/graphql-compiler/pull/18>`__
+
+Thanks to :code:`benlongo`, :code:`ColCarroll`, and :code:`cw6515` for their
+contributions.
+
+v1.0.0
+------
+
+Initial release.
+
+Thanks to :code:`MichaelaShtilmanMinkin` for the help in putting the
+documentation together.

--- a/docs/source/about/changelog.rst
+++ b/docs/source/about/changelog.rst
@@ -182,9 +182,7 @@ This feature implements a workaround for a limitation of OrientDB, where
 subsequent traversals from them. To work around this issue, the compiler
 rewrites the query into several disjoint queries whose union produces
 the exact same results as a single query that allows optional
-traversals. See `the documentation in the
-README <https://github.com/kensho-technologies/graphql-compiler/blob/3c79cd97744b7f3f842c2d32ddc2a072c7fa7898/README.md#expanding-optional-vertex-fields>`__
-for more details.
+traversals.
 
 v1.4.1
 ------

--- a/docs/source/about/code_of_conduct.rst
+++ b/docs/source/about/code_of_conduct.rst
@@ -1,0 +1,83 @@
+Contributor Covenant Code of Conduct
+====================================
+
+Our Pledge
+----------
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our
+project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, gender identity and
+expression, level of experience, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+-  Using welcoming and inclusive language
+-  Being respectful of differing viewpoints and experiences
+-  Gracefully accepting constructive criticism
+-  Focusing on what is best for the community
+-  Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+-  The use of sexualized language or imagery and unwelcome sexual
+   attention or advances
+-  Trolling, insulting/derogatory comments, and personal or political
+   attacks
+-  Public or private harassment
+-  Publishing others' private information, such as a physical or
+   electronic address, without explicit permission
+-  Other conduct which could reasonably be considered inappropriate in a
+   professional setting
+
+Our Responsibilities
+--------------------
+
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful.
+
+Scope
+-----
+
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an
+official project e-mail address, posting via an official social media
+account, or acting as an appointed representative at an online or
+offline event. Representation of a project may be further defined and
+clarified by project maintainers.
+
+Enforcement
+-----------
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported by contacting the project team at
+graphql-compiler-maintainer@kensho.com. All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary
+and appropriate to the circumstances. The project team is obligated to
+maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted
+separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in
+good faith may face temporary or permanent repercussions as determined
+by other members of the project's leadership.
+
+Attribution
+-----------
+
+This Code of Conduct is adapted from the `Contributor
+Covenant <http://contributor-covenant.org>`__, version 1.4, available at
+`http://contributor-covenant.org/version/1/4 <http://contributor-covenant.org/version/1/4/>`__

--- a/docs/source/about/contributing.rst
+++ b/docs/source/about/contributing.rst
@@ -1,0 +1,167 @@
+Contributing
+============
+
+Thank you for taking the time to contribute to this project!
+
+To get started, make sure that you have :code:`pipenv`, :code:`docker` and
+:code:`docker-compose` installed on your computer. Additionally, since this
+is a package that supports both Python 2 and Python 3, please make sure
+you have Python 2.7.15+ and Python 3.6+ installed locally. This project
+assumes that they are available on the system as :code:`python2` and
+:code:`python3`, respectively. If you do not already have them installed,
+consider doing so using `pyenv <https://github.com/pyenv/pyenv>`__.
+
+Integration tests are run against multiple SQL databases, some of which
+require dialect specific installations to be available in the
+development environment. Currently this affects MySQL. A compatible
+driver can be installed on OSX with:
+
+.. code:: bash
+
+   brew install mysql
+
+or on Ubuntu with:
+
+.. code:: bash
+
+   apt-get install python-mysqldb
+
+For more details on other systems please refer to `MySQL dialect
+information <https://docs.sqlalchemy.org/en/latest/dialects/mysql.html>`__.
+
+Once the dev environment is prepared, from the root of the repository,
+run:
+
+::
+
+   docker-compose up -d
+   pipenv sync --dev
+   pipenv shell
+
+   py.test graphql_compiler/tests
+
+Some snapshot and integration tests take longer to setup, run, and
+teardown. These can be optionally skipped during development by running
+the tests with the :code:`--skip-slow` flag:
+
+.. code:: bash
+
+   py.test graphql_compiler/tests --skip-slow
+
+If you run into any issues, please consult the TROUBLESHOOTING.md file.
+If you encounter and resolve an issue that is not already part of the
+troubleshooting guide, we'd appreciate it if you open a pull request and
+update the guide to make future development easier.
+
+A test method or class can be marked as slow to be skipped in this
+fashion by decorating with the :code:`@pytest.mark.slow` flag.
+
+Code of Conduct
+---------------
+
+This project adheres to the Contributor Covenant `code of
+conduct <CODE_OF_CONDUCT.md>`__. By participating, you are expected to
+uphold this code. Please report unacceptable behavior at
+graphql-compiler-maintainer@kensho.com.
+
+Contributor License Agreement
+-----------------------------
+
+Each contributor is required to agree to our `Contributor License
+Agreement <https://www.clahub.com/agreements/kensho-technologies/graphql-compiler>`__,
+to ensure that their contribution may be safely merged into the project
+codebase and released under the existing code license. This agreement
+does not change contributors' rights to use the contributions for any
+other purpose -- it is simply used for the protection of both the
+contributors and the project.
+
+Style Guide
+-----------
+
+This project primarily follows the `PEP 8 style guide
+<https://www.python.org/dev/peps/pep-0008/>`__, and secondarily the
+`Google Python style guide <https://google.github.io/styleguide/pyguide.html>`__.
+If the style guides differ on a convention, the PEP 8 style guide is preferred.
+
+Additionally, any contributions must pass the linter :code:`scripts/lint.sh`
+when executed from a pipenv shell (i.e. after running :code:`pipenv shell`).
+To run the linter on changed files only, commit your changes and run
+:code:`scripts/lint.sh --diff`.
+
+Finally, all python files in the repository must display the copyright
+of the project, to protect the terms of the license. Please make sure
+that your files start with a line like:
+
+::
+
+   # Copyright 20xx-present Kensho Technologies, LLC.
+
+Python 2 vs Python 3
+--------------------
+
+In order to ensure that tests run with a fixed set of packages in both
+Python 2 and Python 3, we always run the tests in a virtualenv managed
+by pipenv. However, since some of our dependencies have different
+requirements for Python 2 and Python 3, we have to keep two pipenv
+lockfiles -- one per Python version.
+
+We have chosen to make the Python 3 lockfile the default (hence named
+:code:`Pipfile.lock`), since Python 3 offers better performance and we like
+our tests and linters running quickly. The Python 2 lockfile is named
+:code:`Pipfile.py2.lock`.
+
+If you need to set up a Python 2 virtualenv locally, simply run the
+following script:
+
+::
+
+   ./scripts/make_py2_venv.sh
+
+If you change the Pipfile or the package requirements, please make sure
+to regenerate the lockfiles for both Python versions. The easiest way to
+do so is with the following script:
+
+::
+
+   ./scripts/make_pipenv_lockfiles.sh
+
+Then, re-run
+
+::
+
+   pipenv sync --dev
+
+to install the relevant dependencies.
+
+Read the Docs
+-------------
+
+We are currently in the process of moving most of our documentation to
+Read the Docs, a web utility that makes it easy to view and present
+documentation. We first plan to get the Read the Docs documentation up
+to date with the markdown documentation present as of commit
+16fd083e78551f866a0cf0c7397542aea1c214d9 and then working on adding the
+documentation added since that commit.
+
+Since Read the Docs does not currently `support
+Pipfiles <https://github.com/readthedocs/readthedocs.org/issues/3181>`__
+the package requirements are in:
+
+::
+
+   docs/requirements.txt
+
+The relevant source code lives in:
+
+::
+
+   docs/source
+
+To build the website run:
+
+::
+
+   cd docs
+   make html
+
+Then open :code:`docs/build/index.html` with a web browser to view it.

--- a/docs/source/about/contributing.rst
+++ b/docs/source/about/contributing.rst
@@ -41,14 +41,13 @@ run:
    py.test graphql_compiler/tests
 
 Some snapshot and integration tests take longer to setup, run, and
-teardown. These can be optionally skipped during development by running
-the tests with the :code:`--skip-slow` flag:
+teardown. These can be optionally skipped during development by running:
 
 .. code:: bash
 
-   py.test graphql_compiler/tests --skip-slow
+   py.test -m 'now-slow'
 
-If you run into any issues, please consult the TROUBLESHOOTING.md file.
+If you run into any issues, please consult the :ref:`troubleshooting guide <troubleshooting>`.
 If you encounter and resolve an issue that is not already part of the
 troubleshooting guide, we'd appreciate it if you open a pull request and
 update the guide to make future development easier.
@@ -59,8 +58,8 @@ fashion by decorating with the :code:`@pytest.mark.slow` flag.
 Code of Conduct
 ---------------
 
-This project adheres to the Contributor Covenant `code of
-conduct <CODE_OF_CONDUCT.md>`__. By participating, you are expected to
+This project adheres to the Contributor Covenant :doc:`code of
+conduct <code_of_conduct>`. By participating, you are expected to
 uphold this code. Please report unacceptable behavior at
 graphql-compiler-maintainer@kensho.com.
 
@@ -165,3 +164,139 @@ To build the website run:
    make html
 
 Then open :code:`docs/build/index.html` with a web browser to view it.
+
+.. _troubleshooting:
+
+Troubleshooting Guide
+---------------------
+
+Issues starting MySQL, PostgreSQL, or redis server with docker-compose
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you have any trouble starting the MySQL/PostgreSQL database or the
+redis server, make sure any database service or any other related
+service is not already running outside of docker. On OSX, you can stop
+the MySQL, PostgreSQL, and redis server services by executing:
+
+.. code:: bash
+
+   brew services stop mysql
+   brew services stop postgresql
+   brew services stop redis-server
+
+or on Ubuntu with:
+
+.. code:: bash
+
+   service mysql stop
+   service postgresql stop
+   service redis-server stop
+
+Issues installing the Python MySQL package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes, precompiled wheels for the Python MySQL package are not
+available, and your pipenv may try to build the wheels itself. This has
+happened on OSX and Ubuntu.
+
+OSX
+^^^
+
+You may then sometimes see an error like the following:
+
+::
+
+   [pipenv.exceptions.InstallError]:   File "/usr/local/lib/python3.7/site-packages/pipenv/core.py", line 1874, in do_install
+   [pipenv.exceptions.InstallError]:       keep_outdated=keep_outdated
+   [pipenv.exceptions.InstallError]:   File "/usr/local/lib/python3.7/site-packages/pipenv/core.py", line 1253, in do_init
+   [pipenv.exceptions.InstallError]:       pypi_mirror=pypi_mirror,
+   [pipenv.exceptions.InstallError]:   File "/usr/local/lib/python3.7/site-packages/pipenv/core.py", line 859, in do_install_dependencies
+   [pipenv.exceptions.InstallError]:       retry_list, procs, failed_deps_queue, requirements_dir, **install_kwargs
+   [pipenv.exceptions.InstallError]:   File "/usr/local/lib/python3.7/site-packages/pipenv/core.py", line 763, in batch_install
+   [pipenv.exceptions.InstallError]:       _cleanup_procs(procs, not blocking, failed_deps_queue, retry=retry)
+   [pipenv.exceptions.InstallError]:   File "/usr/local/lib/python3.7/site-packages/pipenv/core.py", line 681, in _cleanup_procs
+   [pipenv.exceptions.InstallError]:       raise exceptions.InstallError(c.dep.name, extra=err_lines)
+   [pipenv.exceptions.InstallError]: ['Collecting mysqlclient==1.3.14
+   ...
+   < lots of error output >
+   ...
+   ld: library not found for -lssl
+   ...
+   < lots more error output >
+   ...
+   error: command 'clang' failed with exit status 1
+   ...
+
+The solution is to install OpenSSL on your system:
+
+::
+
+   brew install openssl
+
+Then, make sure that :code:`clang` is able to find it by adding the
+following line to your :code:`.bashrc`.
+
+::
+
+   export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
+
+.. _ubuntu-1804:
+
+Ubuntu 18.04
+^^^^^^^^^^^^
+
+When running
+
+::
+
+   pipenv install --dev
+
+you might get an error like the following:
+
+::
+
+   [pipenv.exceptions.InstallError]:   File "/home/$USERNAME/.local/lib/python2.7/site-packages/pipenv/core.py", line 1875, in do_install
+
+   [pipenv.exceptions.InstallError]:       keep_outdated=keep_outdated
+
+   [pipenv.exceptions.InstallError]:   File "/home/$USERNAME/.local/lib/python2.7/site-packages/pipenv/core.py", line 1253, in do_init
+
+   [pipenv.exceptions.InstallError]:       pypi_mirror=pypi_mirror,
+
+   [pipenv.exceptions.InstallError]:   File "/home/$USERNAME/.local/lib/python2.7/site-packages/pipenv/core.py", line 859, in do_install_dependencies
+
+   [pipenv.exceptions.InstallError]:       retry_list, procs, failed_deps_queue, requirements_dir, **install_kwargs
+
+   [pipenv.exceptions.InstallError]:   File "/home/$USERNAME/.local/lib/python2.7/site-packages/pipenv/core.py", line 763, in batch_install
+
+   [pipenv.exceptions.InstallError]:       _cleanup_procs(procs, not blocking, failed_deps_queue, retry=retry)
+
+   [pipenv.exceptions.InstallError]:   File "/home/$USERNAME/.local/lib/python2.7/site-packages/pipenv/core.py", line 681, in _cleanup_procs
+
+   [pipenv.exceptions.InstallError]:       raise exceptions.InstallError(c.dep.name, extra=err_lines)
+
+   [pipenv.exceptions.InstallError]: ['Collecting mysqlclient==1.3.14 (from -r /tmp/pipenv-ZMU3RA-requirements/pipenv-n_utvZ-requirement.txt (line 1))', '  Using cached https://files.pythonhosted.org/packages/f7/a2/1230ebbb4b91f42ad6b646e59eb8855559817ad5505d81c1ca2b5a216040/mysqlclient-1.3.14.tar.gz']
+
+   [pipenv.exceptions.InstallError]: ['ERROR: Complete output from command python setup.py egg_info:', '    ERROR: /bin/sh: 1: mysql_config: not found', '    Traceback (most recent call last):', '      File "<string>", line 1, in <module>', '      File "/tmp/pip-install-ekmq8s3j/mysqlclient/setup.py", line 16, in <module>', '        metadata, options = get_config()', '      File "/tmp/pip-install-ekmq8s3j/mysqlclient/setup_posix.py", line 53, in get_config', '        libs = mysql_config("libs_r")', '      File "/tmp/pip-install-ekmq8s3j/mysqlclient/setup_posix.py", line 28, in mysql_config', '        raise EnvironmentError("%s not found" % (mysql_config.path,))', '    OSError: mysql_config not found', '    ----------------------------------------', 'ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-ekmq8s3j/mysqlclient/']
+
+The solution is to install MySQL:
+
+::
+
+   sudo apt-get install python3.6-dev libmysqlclient-dev
+
+after which
+
+::
+
+   pipenv install --dev
+
+should work fine.
+
+This error might happen even if you've run
+
+::
+
+   apt-get install python-mysqldb
+
+because that only installs the interface to MySQL.

--- a/docs/source/about/contributing.rst
+++ b/docs/source/about/contributing.rst
@@ -45,7 +45,7 @@ teardown. These can be optionally skipped during development by running:
 
 .. code:: bash
 
-   py.test -m 'now-slow'
+   py.test -m 'no-slow'
 
 If you run into any issues, please consult the :ref:`troubleshooting guide <troubleshooting>`.
 If you encounter and resolve an issue that is not already part of the

--- a/docs/source/about/faq.rst
+++ b/docs/source/about/faq.rst
@@ -10,8 +10,9 @@ GraphQL core library for parsing and type checking. However, since the
 database queries produced by compiling GraphQL are subject to the
 limitations of the database system they run on, our execution model is
 somewhat different compared to the one described in the standard GraphQL
-specification. See the `Execution model <#execution-model>`__ section
-for more details.
+specification.
+
+.. TODO: Add a link to the execution model section. Once it is added.
 
 **Q: Does this project come with a GraphQL server implementation?**
 

--- a/docs/source/about/faq.rst
+++ b/docs/source/about/faq.rst
@@ -1,0 +1,42 @@
+Frequently Asked Questions
+==========================
+
+**Q: Do you really use GraphQL, or do you just use GraphQL-like
+syntax?**
+
+A: We really use GraphQL. Any query that the compiler will accept is
+entirely valid GraphQL, and we actually use the Python port of the
+GraphQL core library for parsing and type checking. However, since the
+database queries produced by compiling GraphQL are subject to the
+limitations of the database system they run on, our execution model is
+somewhat different compared to the one described in the standard GraphQL
+specification. See the `Execution model <#execution-model>`__ section
+for more details.
+
+**Q: Does this project come with a GraphQL server implementation?**
+
+A: No -- there are many existing frameworks for running a web server. We
+simply built a tool that takes GraphQL query strings (and their
+parameters) and returns a query string you can use with your database.
+The compiler does not execute the query string against the database, nor
+does it deserialize the results. Therefore, it is agnostic to the choice
+of server framework and database client library used.
+
+**Q: Do you plan to support other databases / more GraphQL features in
+the future?**
+
+A: We'd love to, and we could really use your help! Please consider
+contributing to this project by opening issues, opening pull requests,
+or participating in discussions.
+
+**Q: I think I found a bug, what do I do?**
+
+A: Please check if an issue has already been created for the bug, and
+open a new one if not. Make sure to describe the bug in as much detail
+as possible, including any stack traces or error messages you may have
+seen, which database you're using, and what query you compiled.
+
+**Q: I think I found a security vulnerability, what do I do?**
+
+A: Please reach out to us at graphql-compiler-maintainer@kensho.com so
+we can triage the issue and take appropriate action.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -216,3 +216,20 @@ To learn more about the advanced features in the GraphQL compiler see:
 
    Macro System <advanced_features/macro_system>
    Schema Graph <advanced_features/schema_graph>
+
+About the GraphQL Compiler
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To learn more about the GraphQL project:
+
+- :doc:`Contributing <about/contributing>` for instructions on how you can contribute.
+- :doc:`FAQ <about/faq>` for a list of frequently asked questions.
+- :doc:`Changelog <about/changelog>` to see a history of changes.
+
+.. toctree::
+   :caption: About the GraphQL Compiler
+   :hidden:
+
+   Contributing <about/contributing>
+   FAQ <about/faq>
+   Changelog <about/changelog>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -220,16 +220,18 @@ To learn more about the advanced features in the GraphQL compiler see:
 About the GraphQL Compiler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To learn more about the GraphQL project:
+To learn more about the GraphQL project see:
 
 - :doc:`Contributing <about/contributing>` for instructions on how you can contribute.
+- :doc:`Code of Conduct <about/code_of_conduct>` for the contributor code of conduct.
+- :doc:`Changelog <about/changelog>` for a history of changes.
 - :doc:`FAQ <about/faq>` for a list of frequently asked questions.
-- :doc:`Changelog <about/changelog>` to see a history of changes.
 
 .. toctree::
    :caption: About the GraphQL Compiler
    :hidden:
 
    Contributing <about/contributing>
-   FAQ <about/faq>
+   Code of Conduct <about/code_of_conduct>
    Changelog <about/changelog>
+   FAQ <about/faq>

--- a/docs/source/supported_databases/orientdb.rst
+++ b/docs/source/supported_databases/orientdb.rst
@@ -19,10 +19,10 @@ End-to-End Example
 
 See :ref:`getting-started` for an end-to-end OrientDB example.
 
-
 Performance Penalties
 ---------------------
 
+.. _compound_optional_performance_penalty:
 
 Compound :code:`optional` Performance Penalty
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In this section, I add the "About the GraphQL Compiler" section to readthedocs. The only part of this PR that is not copy-paste is the section that I add to the index.rst file. 

Here is a link to see what the latest docs look like:
https://graphql-compiler.readthedocs.io/en/latest/