### PR TITLE
Add the first batch of type hints.

### DIFF
--- a/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
@@ -1,8 +1,10 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from functools import reduce
+from typing import Any, Dict
 import warnings
 
 from graphql.type import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLString
+from graphql.type.definitions import GraphQLType
 import sqlalchemy.dialects.mssql.base as mssqltypes
 import sqlalchemy.dialects.mysql.base as mysqltypes
 import sqlalchemy.dialects.postgresql as postgrestypes
@@ -162,7 +164,7 @@ MYSQL_CLASS_TO_GRAPHQL_TYPE = {
 }
 
 
-SQL_CLASS_TO_GRAPHQL_TYPE = reduce(
+SQL_CLASS_TO_GRAPHQL_TYPE: Dict[Any, GraphQLType] = reduce(
     merge_non_overlapping_dicts,
     (
         GENERIC_SQL_CLASS_TO_GRAPHQL_TYPE,

--- a/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
@@ -3,8 +3,7 @@ from functools import reduce
 from typing import Any, Dict
 import warnings
 
-from graphql.type import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLString
-from graphql.type.definitions import GraphQLType
+from graphql.type import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLScalarType, GraphQLString
 import sqlalchemy.dialects.mssql.base as mssqltypes
 import sqlalchemy.dialects.mysql.base as mysqltypes
 import sqlalchemy.dialects.postgresql as postgrestypes
@@ -164,7 +163,7 @@ MYSQL_CLASS_TO_GRAPHQL_TYPE = {
 }
 
 
-SQL_CLASS_TO_GRAPHQL_TYPE: Dict[Any, GraphQLType] = reduce(
+SQL_CLASS_TO_GRAPHQL_TYPE: Dict[Any, GraphQLScalarType] = reduce(
     merge_non_overlapping_dicts,
     (
         GENERIC_SQL_CLASS_TO_GRAPHQL_TYPE,

--- a/graphql_compiler/tests/integration_tests/integration_test_helpers.py
+++ b/graphql_compiler/tests/integration_tests/integration_test_helpers.py
@@ -1,13 +1,25 @@
 # Copyright 2018-present Kensho Technologies, LLC.
+from datetime import date
 from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
+from graphql.type.schema import GraphQLSchema
+from pyorient.orient import OrientDB
+from redisgraph.client import Graph
 import six
+from sqlalchemy.engine.base import Engine
+
+from graphql_compiler.schema.schema_info import SQLAlchemySchemaInfo
+from graphql_compiler.tests.test_data_tools.neo4j_graph import Neo4jClient
 
 from ... import graphql_to_match, graphql_to_redisgraph_cypher, graphql_to_sql
 from ...compiler import compile_graphql_to_cypher
 
 
-def sort_db_results(results):
+T = TypeVar('T')
+
+
+def sort_db_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Deterministically sort DB results.
 
     Args:
@@ -16,15 +28,17 @@ def sort_db_results(results):
     Returns:
         List[Dict], sorted DB results.
     """
-    sort_order = []
+    sort_order: List[str] = []
     if len(results) > 0:
         sort_order = sorted(six.iterkeys(results[0]))
 
-    def sort_key(result):
+    def sort_key(
+        result: Dict[str, Any]
+    ) -> Tuple[Tuple[bool, Any], ...]:
         """Convert None/Not None to avoid comparisons of None to a non-None type."""
         return tuple((result[col] is not None, result[col]) for col in sort_order)
 
-    def sorted_value(value):
+    def sorted_value(value: T) -> Union[List[Any], T]:
         """Return a sorted version of a value, if it is a list."""
         if isinstance(value, list):
             return sorted(value)
@@ -35,7 +49,7 @@ def sort_db_results(results):
     )
 
 
-def try_convert_decimal_to_string(value):
+def try_convert_decimal_to_string(value: T) -> Any:
     """Return Decimals as string if value is a Decimal, return value otherwise."""
     if isinstance(value, list):
         return [try_convert_decimal_to_string(subvalue) for subvalue in value]
@@ -44,7 +58,12 @@ def try_convert_decimal_to_string(value):
     return value
 
 
-def compile_and_run_match_query(schema, graphql_query, parameters, orientdb_client):
+def compile_and_run_match_query(
+    schema: GraphQLSchema,
+    graphql_query: str,
+    parameters: Dict[str, Any],
+    orientdb_client: OrientDB,
+) -> List[Dict[str, Any]]:
     """Compile and run a MATCH query against the supplied graph client."""
     # MATCH code emitted by the compiler expects Decimals to be passed in as strings
     converted_parameters = {
@@ -64,7 +83,12 @@ def compile_and_run_match_query(schema, graphql_query, parameters, orientdb_clie
     return results
 
 
-def compile_and_run_sql_query(sql_schema_info, graphql_query, parameters, engine):
+def compile_and_run_sql_query(
+    sql_schema_info: SQLAlchemySchemaInfo,
+    graphql_query: str,
+    parameters: Dict[str, Any],
+    engine: Engine,
+) -> List[Dict[str, Any]]:
     """Compile and run a SQL query against the supplied SQL backend."""
     compilation_result = graphql_to_sql(sql_schema_info, graphql_query, parameters)
     query = compilation_result.query
@@ -74,7 +98,12 @@ def compile_and_run_sql_query(sql_schema_info, graphql_query, parameters, engine
     return results
 
 
-def compile_and_run_neo4j_query(schema, graphql_query, parameters, neo4j_client):
+def compile_and_run_neo4j_query(
+    schema: GraphQLSchema,
+    graphql_query: str,
+    parameters: Dict[str, Any],
+    neo4j_client: Neo4jClient,
+) -> List[Dict[str, Any]]:
     """Compile and run a Cypher query against the supplied graph client."""
     compilation_result = compile_graphql_to_cypher(
         schema, graphql_query, type_equivalence_hints=None
@@ -85,7 +114,9 @@ def compile_and_run_neo4j_query(schema, graphql_query, parameters, neo4j_client)
     return results.data()
 
 
-def compile_and_run_redisgraph_query(schema, graphql_query, parameters, redisgraph_client):
+def compile_and_run_redisgraph_query(
+    schema: GraphQLSchema, graphql_query: str, parameters: Dict[str, Any], redisgraph_client: Graph
+) -> List[Dict[str, Any]]:
     """Compile and run a Cypher query against the supplied graph client."""
     compilation_result = graphql_to_redisgraph_cypher(schema, graphql_query, parameters)
     query = compilation_result.query

--- a/graphql_compiler/tests/integration_tests/integration_test_helpers.py
+++ b/graphql_compiler/tests/integration_tests/integration_test_helpers.py
@@ -16,7 +16,7 @@ from ... import graphql_to_match, graphql_to_redisgraph_cypher, graphql_to_sql
 from ...compiler import compile_graphql_to_cypher
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 def sort_db_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -32,9 +32,7 @@ def sort_db_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     if len(results) > 0:
         sort_order = sorted(six.iterkeys(results[0]))
 
-    def sort_key(
-        result: Dict[str, Any]
-    ) -> Tuple[Tuple[bool, Any], ...]:
+    def sort_key(result: Dict[str, Any]) -> Tuple[Tuple[bool, Any], ...]:
         """Convert None/Not None to avoid comparisons of None to a non-None type."""
         return tuple((result[col] is not None, result[col]) for col in sort_order)
 

--- a/graphql_compiler/tests/integration_tests/integration_test_helpers.py
+++ b/graphql_compiler/tests/integration_tests/integration_test_helpers.py
@@ -1,7 +1,6 @@
 # Copyright 2018-present Kensho Technologies, LLC.
-from datetime import date
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, List, Tuple, TypeVar, Union
 
 from graphql.type.schema import GraphQLSchema
 from pyorient.orient import OrientDB

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -107,10 +107,7 @@ class IntegrationTests(TestCase):
 
     @classmethod
     def compile_and_run_query(
-        cls,
-        graphql_query: str,
-        parameters: Dict[str, Any],
-        backend_name: str,
+        cls, graphql_query: str, parameters: Dict[str, Any], backend_name: str,
     ) -> Any:
         """Compiles and runs the graphql query with the supplied parameters against all backends.
 

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -1,6 +1,5 @@
 # Copyright 2018-present Kensho Technologies, LLC.
 import datetime
-from datetime import date
 from decimal import Decimal
 from typing import Any, Dict, List, Tuple
 from unittest import TestCase


### PR DESCRIPTION
Steps:
- `pip install pytest-annotate` (another Kensho open-source project, a plugin for `pytest` that uses `pyannotate` on each test)
- `pytest --annotate-output=./localdata/annotations.json` to run tests and capture the *actual* types with which functions are called.
- Work around https://github.com/dropbox/pyannotate/issues/92 by opening the file and removing all entries with `<locals>` in them. If any annotations list becomes empty, delete the entire dict.
- Pick a few files to annotate, and run `pyannotate --py3 --type-info ./localdata/annotations.json <your files>`. This will preview all the changes, spot-check them quickly for any major issues. Don't worry about smaller things, you'll touch this up by hand in the next step.
- The last command was a dry-run, append `-w` to actually perform the changes.
- Touch up the types in the file as necessary. You'll probably see a lot of things like `Union[List[str], List[date], List[int]]` that may need to be replaced with `List[Any]` depending on what the function does. Read the function and *engage your brain* to figure out what makes sense :)
- Fix import style with `isort --settings-path=setup.cfg --recursive ./graphql_compiler/`
- Paint it black: `black .`
- Argue with `mypy` until no errors show up in `mypy --ignore-missing-imports <your files>`. Repeat the last few steps as necessary, using `type: ignore` only as a last resort.
- Yay more type hints! Open a PR.