### PR TITLE
Only start dockerized databases for tests, not for lint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ install:
   - pip install --upgrade setuptools pipenv
   - pipenv install --dev --deploy --system
   - pipenv install --system --skip-lock -e .
-before_script:
-  - docker-compose up -d
 matrix:
   include:
   - name: "Lint and static analysis"
@@ -29,15 +27,17 @@ matrix:
   - name: "Python 3.6 unit tests"
     python: "3.6"
     script:
+      - docker-compose up -d  # Only start the database docker containers for tests, not for lint.
       - pipenv run py.test --cov=graphql_compiler graphql_compiler/tests
   - name: "Python 3.7 unit tests"
     python: "3.7"
     script:
+      - docker-compose up -d  # Only start the database docker containers for tests, not for lint.
       - pipenv run py.test --cov=graphql_compiler graphql_compiler/tests
   - name: "Python 3.8 unit tests"
     python: "3.8"
     script:
+      - docker-compose up -d  # Only start the database docker containers for tests, not for lint.
       - pipenv run py.test --cov=graphql_compiler graphql_compiler/tests
 after_success:
   - codecov
-  - docker-compose down


### PR DESCRIPTION
Linting time currently dominates test time. However, a large portion of the time taken is actually downloading the docker images for the various databases we test on -- which are not used at all in the lint checks. Not downloading the docker images in the lint configuration should even out the time taken by the various runs in the test matrix, and shorten the overall "time to approval" from Travis.

This PR's test run suggests that this cuts about a minute off of linting time.