### PR TITLE
Build pushes to master branch and new version tags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+# In addition to building PRs, build pushes to the following branches and tag names.
+branches:
+  only:
+  - master
+  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/  # tagged commits with new release versions
+
 language: python
 cache: pip
 dist: bionic


### PR DESCRIPTION
This should ensure we always have master branch coverage available for codecov to compare against.