### PR TITLE
Query Planning: Add generic range reasoning method

### DIFF
--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -1,7 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from graphql import GraphQLInt
 
-from ..schema import GraphQLDateTime, GraphQLDate
+from ..schema import GraphQLDate, GraphQLDateTime
 
 
 def is_datetime_field_type(schema_info, vertex_name, field_name):

--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -3,26 +3,33 @@ from graphql import GraphQLInt
 
 from ..global_utils import is_same_type
 from ..schema import GraphQLDate, GraphQLDateTime
+from ..schema.schema_info import QueryPlanningSchemaInfo
 
 
-def is_datetime_field_type(schema_info, vertex_name, field_name):
+def is_datetime_field_type(
+    schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
+) -> bool:
     """Return whether the field is of type GraphQLDateTime."""
     field_type = schema_info.schema.get_type(vertex_name).fields[field_name].type
     return is_same_type(GraphQLDateTime, field_type)
 
 
-def is_date_field_type(schema_info, vertex_name, field_name):
+def is_date_field_type(
+    schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
+) -> bool:
     """Return whether the field is of type GraphQLDate."""
     field_type = schema_info.schema.get_type(vertex_name).fields[field_name].type
     return is_same_type(GraphQLDate, field_type)
 
 
-def is_int_field_type(schema_info, vertex_name, field_name):
+def is_int_field_type(
+    schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
+) -> bool:
     """Return whether the field is of type GraphQLInt."""
     field_type = schema_info.schema.get_type(vertex_name).fields[field_name].type
     return is_same_type(GraphQLInt, field_type)
 
 
-def is_uuid4_type(schema_info, vertex_name, field_name):
+def is_uuid4_type(schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str) -> bool:
     """Return whether the field is a uniformly distributed uuid4 type."""
     return field_name in schema_info.uuid4_fields.get(vertex_name, {})

--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -1,6 +1,20 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from graphql import GraphQLInt
 
+from ..schema import GraphQLDateTime, GraphQLDate
+
+
+def is_datetime_field_type(schema_info, vertex_name, field_name):
+    """Return whether the field is of type GraphQLDateTime."""
+    field_type = schema_info.schema.get_type(vertex_name).fields[field_name].type
+    return GraphQLDateTime.is_same_type(field_type)
+
+
+def is_date_field_type(schema_info, vertex_name, field_name):
+    """Return whether the field is of type GraphQLDate."""
+    field_type = schema_info.schema.get_type(vertex_name).fields[field_name].type
+    return GraphQLDate.is_same_type(field_type)
+
 
 def is_int_field_type(schema_info, vertex_name, field_name):
     """Return whether the field is of type GraphQLInt."""

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -67,15 +67,15 @@ def convert_int_to_field_value(
     """
     if is_int_field_type(schema_info, vertex_class, property_field):
         return int_value
-    if is_datetime_field_type(schema_info, vertex_class, property_field):
+    elif is_datetime_field_type(schema_info, vertex_class, property_field):
         return DATETIME_EPOCH_UTC + datetime.timedelta(microseconds=int_value)
-    if is_date_field_type(schema_info, vertex_class, property_field):
+    elif is_date_field_type(schema_info, vertex_class, property_field):
         return datetime.date.fromordinal(int_value)
     elif is_uuid4_type(schema_info, vertex_class, property_field):
         if not MIN_UUID_INT <= int_value <= MAX_UUID_INT:
             raise AssertionError(
-                u"Integer value {} could not be converted to UUID, as it"
-                u" is not in the range of valid UUIDs {} - {}: {} {}".format(
+                u"Integer value {} could not be converted to UUID, as it "
+                u"is not in the range of valid UUIDs {} - {}: {} {}".format(
                     int_value, MIN_UUID_INT, MAX_UUID_INT, vertex_class, property_field
                 )
             )
@@ -99,15 +99,11 @@ def convert_field_value_to_int(
     """Return the integer representation of a property field value."""
     if is_int_field_type(schema_info, vertex_class, property_field):
         return value
-    if is_datetime_field_type(schema_info, vertex_class, property_field):
-        if value.tzinfo != pytz.utc:
-            raise ValueError(
-                u"Invalid datetime value {}. Expected utc timezone, got {}".format(
-                    value, value.tzinfo
-                )
-            )
-        return int((value - DATETIME_EPOCH_UTC) // datetime.timedelta(microseconds=1))
-    if is_date_field_type(schema_info, vertex_class, property_field):
+    elif is_datetime_field_type(schema_info, vertex_class, property_field):
+        return (value.astimezone(pytz.utc) - DATETIME_EPOCH_UTC) // datetime.timedelta(
+            microseconds=1
+        )
+    elif is_date_field_type(schema_info, vertex_class, property_field):
         return value.toordinal()
     elif is_uuid4_type(schema_info, vertex_class, property_field):
         return UUID(value).int

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -24,7 +24,7 @@ from .helpers import is_date_field_type, is_datetime_field_type, is_int_field_ty
 # UUIDs are defined in RFC-4122 as a 128-bit identifier. This means that the minimum UUID value
 # (represented as a natural number) is 0, and the maximal value is 2^128-1.
 MIN_UUID_INT = 0
-MAX_UUID_INT = 2**128 - 1
+MAX_UUID_INT = 2 ** 128 - 1
 
 
 DATETIME_1970 = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
@@ -32,12 +32,14 @@ DATETIME_1970 = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
 
 def field_supports_range_reasoning(schema_info, vertex_class, property_field):
     """Return whether range reasoning is supported. See module docstring for definition."""
-    return any((
-        is_uuid4_type(schema_info, vertex_class, property_field),
-        is_int_field_type(schema_info, vertex_class, property_field),
-        is_datetime_field_type(schema_info, vertex_class, property_field),
-        is_date_field_type(schema_info, vertex_class, property_field),
-    ))
+    return any(
+        (
+            is_uuid4_type(schema_info, vertex_class, property_field),
+            is_int_field_type(schema_info, vertex_class, property_field),
+            is_datetime_field_type(schema_info, vertex_class, property_field),
+            is_date_field_type(schema_info, vertex_class, property_field),
+        )
+    )
 
 
 def convert_int_to_field_value(schema_info, vertex_class, property_field, int_value):
@@ -66,18 +68,24 @@ def convert_int_to_field_value(schema_info, vertex_class, property_field, int_va
         return datetime.date.fromordinal(int_value)
     elif is_uuid4_type(schema_info, vertex_class, property_field):
         if not MIN_UUID_INT <= int_value <= MAX_UUID_INT:
-            raise ValueError(u'Integer value {} could not be converted to UUID, as it'
-                             u' is not in the range of valid UUIDs {} - {}: {} {}'
-                             .format(int_value, MIN_UUID_INT, MAX_UUID_INT, vertex_class,
-                                     property_field))
+            raise ValueError(
+                u"Integer value {} could not be converted to UUID, as it"
+                u" is not in the range of valid UUIDs {} - {}: {} {}".format(
+                    int_value, MIN_UUID_INT, MAX_UUID_INT, vertex_class, property_field
+                )
+            )
 
         return str(UUID(int=int(int_value)))
     elif field_supports_range_reasoning(schema_info, vertex_class, property_field):
-        raise AssertionError(u'Could not represent int {} as {} {}, but should be able to.'
-                             .format(int_value, vertex_class, property_field))
+        raise AssertionError(
+            u"Could not represent int {} as {} {}, but should be able to.".format(
+                int_value, vertex_class, property_field
+            )
+        )
     else:
-        raise NotImplementedError(u'Could not represent int {} as {} {}.'
-                                  .format(int_value, vertex_class, property_field))
+        raise NotImplementedError(
+            u"Could not represent int {} as {} {}.".format(int_value, vertex_class, property_field)
+        )
 
 
 def convert_field_value_to_int(schema_info, vertex_class, property_field, value):
@@ -86,16 +94,25 @@ def convert_field_value_to_int(schema_info, vertex_class, property_field, value)
         return value
     if is_datetime_field_type(schema_info, vertex_class, property_field):
         if value.tzinfo != pytz.utc:
-            raise ValueError(u'Invalid datetime value {}. Expected utc timezone, got {}'
-                             .format(value, value.tzinfo))
-        return int(DATETIME_1970 / datetime.timedelta(microseconds=1))
+            raise ValueError(
+                u"Invalid datetime value {}. Expected utc timezone, got {}".format(
+                    value, value.tzinfo
+                )
+            )
+        return int((value - DATETIME_1970) / datetime.timedelta(microseconds=1))
     if is_date_field_type(schema_info, vertex_class, property_field):
         return value.toordinal()
     elif is_uuid4_type(schema_info, vertex_class, property_field):
         return UUID(value).int
     elif field_supports_range_reasoning(schema_info, vertex_class, property_field):
-        raise AssertionError(u'Could not represent {} {} value {} as int, but should be able to'
-                             .format(vertex_class, property_field, value))
+        raise AssertionError(
+            u"Could not represent {} {} value {} as int, but should be able to".format(
+                vertex_class, property_field, value
+            )
+        )
     else:
-        raise NotImplementedError(u'Could not represent {} {} value {} as int.'
-                                  .format(vertex_class, property_field, value))
+        raise NotImplementedError(
+            u"Could not represent {} {} value {} as int.".format(
+                vertex_class, property_field, value
+            )
+        )

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -1,0 +1,94 @@
+# Copyright 2019-present Kensho Technologies, LLC.
+from uuid import UUID
+import datetime
+
+from .helpers import is_int_field_type, is_uuid4_type, is_datetime_field_type, is_date_field_type
+
+
+# UUIDs are defined in RFC-4122 as a 128-bit identifier. This means that the minimum UUID value
+# (represented as a natural number) is 0, and the maximal value is 2^128-1.
+MIN_UUID_INT = 0
+MAX_UUID_INT = 2**128 - 1
+
+
+# This module is a utility for reasoning about intervals when computing filter selectivities,
+# and generating parameters for pagination. Since integers are the easiest type to deal with
+# in this context, when we encounter a different type we represent it as an int, do all the
+# computation in the integer domain, and transfer the computation back into the original domain.
+#
+# In order to be able to reason about value intervals and successor/predecessor values, we
+# make sure these mappings to integers are increasing bijective functions.
+#
+# This kind of mapping is easy to do for int, uuid and datetime types, but not possible for other
+# types, like string. When the need for other types arises, the precise interface for range
+# reasoning can be defined and implemented separately for each type.
+
+
+def field_supports_range_reasoning(schema_info, vertex_class, property_field):
+    return any((
+        is_uuid4_type(schema_info, vertex_class, property_field),
+        is_int_field_type(schema_info, vertex_class, property_field),
+        is_datetime_field_type(schema_info, vertex_class, property_field),
+        is_date_field_type(schema_info, vertex_class, property_field),
+    ))
+
+
+def convert_int_to_field_value(schema_info, vertex_class, property_field, int_value):
+    """Return the given integer's corresponding property field value.
+    Note that the property field values need not be integers. For example, all UUID values can be
+    converted to integers and vice versa, but they are provided in a string format (e.g.
+    00000000-0000-0000-0000-000000000000).
+    Example: If int_value is 9, and the property field is a uuid, then the resulting field
+    value will be 00000000-0000-0000-0000-000000000009.
+    Args:
+        schema_graph: SchemaGraph instance.
+        vertex_class: str, name of vertex class to which the property field belongs.
+        property_field: str, name of property field for which the domain of values is computed.
+        int_value: int, integer value which will be represented as a property field value.
+    Returns:
+        Any, the given integer's corresponding property field value.
+    Raises:
+        ValueError, if the given int_value is outside the range of valid values for the given
+        property field.
+    """
+    if is_int_field_type(schema_info, vertex_class, property_field):
+        return int_value
+    if is_datetime_field_type(schema_info, vertex_class, property_field):
+        return datetime.datetime.utcfromtimestamp(int_value)
+    if is_date_field_type(schema_info, vertex_class, property_field):
+        # TODO(bojanserafimov): this is not tested
+        return datetime.date.fromordinal(int_value)
+    elif is_uuid4_type(schema_info, vertex_class, property_field):
+        if not MIN_UUID_INT <= int_value <= MAX_UUID_INT:
+            raise AssertionError(u'Integer value {} could not be converted to UUID, as it'
+                                 u' is not in the range of valid UUIDs {} - {}: {} {}'
+                                 .format(int_value, MIN_UUID_INT, MAX_UUID_INT, vertex_class,
+                                         property_field))
+
+        return str(UUID(int=int(int_value)))
+    elif field_supports_range_reasoning(schema_info, vertex_class, property_field):
+        raise AssertionError(u'Could not represent int {} as {} {}, but should be able to.'
+                             .format(int_value, vertex_class, property_field))
+    else:
+        raise AssertionError(u'Could not represent int {} as {} {}. Currently,'
+                             u' only uniform uuid4 and int fields are supported.'
+                             .format(int_value, vertex_class, property_field))
+
+
+def convert_field_value_to_int(schema_info, vertex_class, property_field, value):
+    """Return the integer representation of a property field value."""
+    if is_int_field_type(schema_info, vertex_class, property_field):
+        return value
+    if is_datetime_field_type(schema_info, vertex_class, property_field):
+        return int((value - datetime.datetime(1970, 1, 1)).total_seconds())
+    if is_date_field_type(schema_info, vertex_class, property_field):
+        return value.toordinal()
+    elif is_uuid4_type(schema_info, vertex_class, property_field):
+        return UUID(value).int
+    elif field_supports_range_reasoning(schema_info, vertex_class, property_field):
+        raise AssertionError(u'Could not represent {} {} value {} as int, but should be able to'
+                             .format(vertex_class, property_field, value))
+    else:
+        raise AssertionError(u'Could not represent {} {} value {} as int. Currently,'
+                             u' only uniform uuid4 and int fields are supported.'
+                             .format(vertex_class, property_field, value))

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -1,9 +1,24 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from uuid import UUID
+"""Int value conversion.
+
+This module is a utility for reasoning about intervals when computing filter selectivities,
+and generating parameters for pagination. Since integers are the easiest type to deal with
+in this context, when we encounter a different type we represent it as an int, do all the
+computation in the integer domain, and transfer the computation back into the original domain.
+
+In order to be able to reason about value intervals and successor/predecessor values, we
+make sure these mappings to integers are increasing bijective functions.
+
+This kind of mapping is easy to do for int, uuid and datetime types, but not possible for other
+types, like string. When the need for other types arises, the precise interface for range
+reasoning can be defined and implemented separately for each type.
+"""
 import datetime
+from uuid import UUID
+
 import pytz
 
-from .helpers import is_int_field_type, is_uuid4_type, is_datetime_field_type, is_date_field_type
+from .helpers import is_date_field_type, is_datetime_field_type, is_int_field_type, is_uuid4_type
 
 
 # UUIDs are defined in RFC-4122 as a 128-bit identifier. This means that the minimum UUID value
@@ -12,20 +27,11 @@ MIN_UUID_INT = 0
 MAX_UUID_INT = 2**128 - 1
 
 
-# This module is a utility for reasoning about intervals when computing filter selectivities,
-# and generating parameters for pagination. Since integers are the easiest type to deal with
-# in this context, when we encounter a different type we represent it as an int, do all the
-# computation in the integer domain, and transfer the computation back into the original domain.
-#
-# In order to be able to reason about value intervals and successor/predecessor values, we
-# make sure these mappings to integers are increasing bijective functions.
-#
-# This kind of mapping is easy to do for int, uuid and datetime types, but not possible for other
-# types, like string. When the need for other types arises, the precise interface for range
-# reasoning can be defined and implemented separately for each type.
+DATETIME_1970 = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
 
 
 def field_supports_range_reasoning(schema_info, vertex_class, property_field):
+    """Return whether range reasoning is supported. See module docstring for definition."""
     return any((
         is_uuid4_type(schema_info, vertex_class, property_field),
         is_int_field_type(schema_info, vertex_class, property_field),
@@ -36,18 +42,18 @@ def field_supports_range_reasoning(schema_info, vertex_class, property_field):
 
 def convert_int_to_field_value(schema_info, vertex_class, property_field, int_value):
     """Return the given integer's corresponding property field value.
-    Note that the property field values need not be integers. For example, all UUID values can be
-    converted to integers and vice versa, but they are provided in a string format (e.g.
-    00000000-0000-0000-0000-000000000000).
-    Example: If int_value is 9, and the property field is a uuid, then the resulting field
-    value will be 00000000-0000-0000-0000-000000000009.
+
+    See module docstring for details.
+
     Args:
-        schema_graph: SchemaGraph instance.
+        schema_info: QueryPlanningSchemaInfo
         vertex_class: str, name of vertex class to which the property field belongs.
-        property_field: str, name of property field for which the domain of values is computed.
+        property_field: str, name of property field that the value refers to.
         int_value: int, integer value which will be represented as a property field value.
+
     Returns:
         Any, the given integer's corresponding property field value.
+
     Raises:
         ValueError, if the given int_value is outside the range of valid values for the given
         property field.
@@ -55,25 +61,23 @@ def convert_int_to_field_value(schema_info, vertex_class, property_field, int_va
     if is_int_field_type(schema_info, vertex_class, property_field):
         return int_value
     if is_datetime_field_type(schema_info, vertex_class, property_field):
-        return datetime.datetime(1970, 1, 1, tzinfo=pytz.utc) + datetime.timedelta(microseconds=int_value)
+        return DATETIME_1970 + datetime.timedelta(microseconds=int_value)
     if is_date_field_type(schema_info, vertex_class, property_field):
-        # TODO(bojanserafimov): this is not tested
         return datetime.date.fromordinal(int_value)
     elif is_uuid4_type(schema_info, vertex_class, property_field):
         if not MIN_UUID_INT <= int_value <= MAX_UUID_INT:
-            raise AssertionError(u'Integer value {} could not be converted to UUID, as it'
-                                 u' is not in the range of valid UUIDs {} - {}: {} {}'
-                                 .format(int_value, MIN_UUID_INT, MAX_UUID_INT, vertex_class,
-                                         property_field))
+            raise ValueError(u'Integer value {} could not be converted to UUID, as it'
+                             u' is not in the range of valid UUIDs {} - {}: {} {}'
+                             .format(int_value, MIN_UUID_INT, MAX_UUID_INT, vertex_class,
+                                     property_field))
 
         return str(UUID(int=int(int_value)))
     elif field_supports_range_reasoning(schema_info, vertex_class, property_field):
         raise AssertionError(u'Could not represent int {} as {} {}, but should be able to.'
                              .format(int_value, vertex_class, property_field))
     else:
-        raise AssertionError(u'Could not represent int {} as {} {}. Currently,'
-                             u' only uniform uuid4 and int fields are supported.'
-                             .format(int_value, vertex_class, property_field))
+        raise NotImplementedError(u'Could not represent int {} as {} {}.'
+                                  .format(int_value, vertex_class, property_field))
 
 
 def convert_field_value_to_int(schema_info, vertex_class, property_field, value):
@@ -82,8 +86,9 @@ def convert_field_value_to_int(schema_info, vertex_class, property_field, value)
         return value
     if is_datetime_field_type(schema_info, vertex_class, property_field):
         if value.tzinfo != pytz.utc:
-            raise AssertionError()
-        return int((value - datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)) / datetime.timedelta(microseconds=1))
+            raise ValueError(u'Invalid datetime value {}. Expected utc timezone, got {}'
+                             .format(value, value.tzinfo))
+        return int(DATETIME_1970 / datetime.timedelta(microseconds=1))
     if is_date_field_type(schema_info, vertex_class, property_field):
         return value.toordinal()
     elif is_uuid4_type(schema_info, vertex_class, property_field):
@@ -92,6 +97,5 @@ def convert_field_value_to_int(schema_info, vertex_class, property_field, value)
         raise AssertionError(u'Could not represent {} {} value {} as int, but should be able to'
                              .format(vertex_class, property_field, value))
     else:
-        raise AssertionError(u'Could not represent {} {} value {} as int. Currently,'
-                             u' only uniform uuid4 and int fields are supported.'
-                             .format(vertex_class, property_field, value))
+        raise NotImplementedError(u'Could not represent {} {} value {} as int.'
+                                  .format(vertex_class, property_field, value))

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -52,6 +52,8 @@ def convert_int_to_field_value(
     See module docstring for details. The int_value is expected to be in the range of
     convert_field_value_to_int.
 
+    Datetimes are returned in the UTC timezone.
+
     Args:
         schema_info: QueryPlanningSchemaInfo
         vertex_class: str, name of vertex class to which the property field belongs.

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -14,10 +14,12 @@ types, like string. When the need for other types arises, the precise interface 
 reasoning can be defined and implemented separately for each type.
 """
 import datetime
+from typing import Any
 from uuid import UUID
 
 import pytz
 
+from ..schema.schema_info import QueryPlanningSchemaInfo
 from .helpers import is_date_field_type, is_datetime_field_type, is_int_field_type, is_uuid4_type
 
 
@@ -30,7 +32,9 @@ MAX_UUID_INT = 2 ** 128 - 1
 DATETIME_EPOCH_UTC = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
 
 
-def field_supports_range_reasoning(schema_info, vertex_class, property_field):
+def field_supports_range_reasoning(
+    schema_info: QueryPlanningSchemaInfo, vertex_class: str, property_field: str
+) -> bool:
     """Return whether range reasoning is supported. See module docstring for definition."""
     return (
         is_uuid4_type(schema_info, vertex_class, property_field)
@@ -40,7 +44,9 @@ def field_supports_range_reasoning(schema_info, vertex_class, property_field):
     )
 
 
-def convert_int_to_field_value(schema_info, vertex_class, property_field, int_value):
+def convert_int_to_field_value(
+    schema_info: QueryPlanningSchemaInfo, vertex_class: str, property_field: str, int_value: int
+) -> Any:
     """Return the given integer's corresponding property field value.
 
     See module docstring for details. The int_value is expected to be in the range of
@@ -87,7 +93,9 @@ def convert_int_to_field_value(schema_info, vertex_class, property_field, int_va
         )
 
 
-def convert_field_value_to_int(schema_info, vertex_class, property_field, value):
+def convert_field_value_to_int(
+    schema_info: QueryPlanningSchemaInfo, vertex_class: str, property_field: str, value: Any
+) -> int:
     """Return the integer representation of a property field value."""
     if is_int_field_type(schema_info, vertex_class, property_field):
         return value

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -98,7 +98,7 @@ def convert_field_value_to_int(schema_info, vertex_class, property_field, value)
                     value, value.tzinfo
                 )
             )
-        return int((value - DATETIME_EPOCH_UTC) / datetime.timedelta(microseconds=1))
+        return int((value - DATETIME_EPOCH_UTC) // datetime.timedelta(microseconds=1))
     if is_date_field_type(schema_info, vertex_class, property_field):
         return value.toordinal()
     elif is_uuid4_type(schema_info, vertex_class, property_field):

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -127,6 +127,8 @@ class LocalStatistics(Statistics):
                              element is a value greater than or equal to i/N of all present
                              values. The number N can be different for each entry. N has to be at
                              least 2 for every entry present in the dict.
+            TODO(bojanserafimov): Enforce a canonical representation for quantile values. Datetimes
+                                  should be in utc, decimals should have type float, etc.
         """
         if vertex_edge_vertex_counts is None:
             vertex_edge_vertex_counts = dict()

--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -119,13 +119,15 @@ def _validate_non_required_macro_definition_directives(
             subselection_inside_fold_scope = True
         elif name == MacroEdgeTargetDirective.name:
             if inside_optional_scope:
-                raise GraphQLInvalidMacroError(
-                    u"The @macro_edge_target cannot be inside an @optional scope."
-                )
+                pass  # XXX Allow the @macro edge target to be in @optional scope
+                # raise GraphQLInvalidMacroError(
+                #     u"The @macro_edge_target cannot be inside an @optional scope."
+                # )
             if OptionalDirective.name in names_of_directives_at_ast:
-                raise GraphQLInvalidMacroError(
-                    u"The @macro_edge_target cannot be placed at a field marked @optional."
-                )
+                pass  # XXX Allow the @macro edge target to be in @optional scope
+                # raise GraphQLInvalidMacroError(
+                #     u"The @macro_edge_target cannot be placed at a field marked @optional."
+                # )
 
             if inside_fold_scope:
                 raise GraphQLInvalidMacroError(

--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -119,15 +119,13 @@ def _validate_non_required_macro_definition_directives(
             subselection_inside_fold_scope = True
         elif name == MacroEdgeTargetDirective.name:
             if inside_optional_scope:
-                pass  # XXX Allow the @macro edge target to be in @optional scope
-                # raise GraphQLInvalidMacroError(
-                #     u"The @macro_edge_target cannot be inside an @optional scope."
-                # )
+                raise GraphQLInvalidMacroError(
+                    u"The @macro_edge_target cannot be inside an @optional scope."
+                )
             if OptionalDirective.name in names_of_directives_at_ast:
-                pass  # XXX Allow the @macro edge target to be in @optional scope
-                # raise GraphQLInvalidMacroError(
-                #     u"The @macro_edge_target cannot be placed at a field marked @optional."
-                # )
+                raise GraphQLInvalidMacroError(
+                    u"The @macro_edge_target cannot be placed at a field marked @optional."
+                )
 
             if inside_fold_scope:
                 raise GraphQLInvalidMacroError(

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1458,11 +1458,12 @@ class IntegerIntervalTests(unittest.TestCase):
         )
 
         datetime_values = [
-            datetime(2000, 1, 1, tzinfo=pytz.utc),
-            datetime(3000, 1, 1, tzinfo=pytz.utc),
+            datetime(2000, 1, 1),
+            datetime(3000, 1, 1, tzinfo=None),
             datetime(1000, 1, 1, tzinfo=pytz.utc),
             datetime(1, 1, 1, tzinfo=pytz.utc),
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.utc),
+            datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("GMT")),
         ]
         for datetime_value in datetime_values:
             int_value = convert_field_value_to_int(
@@ -1471,17 +1472,7 @@ class IntegerIntervalTests(unittest.TestCase):
             recovered_datetime = convert_int_to_field_value(
                 schema_info, "Event", "event_date", int_value
             )
-            self.assertAlmostEqual(0, (datetime_value - recovered_datetime).total_seconds())
-
-        invalid_datetime_values = [
-            datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=None),
-            datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("GMT")),
-        ]
-        for datetime_value in invalid_datetime_values:
-            with self.assertRaises(Exception):
-                int_value = convert_field_value_to_int(
-                    schema_info, "Event", "event_date", datetime_value
-                )
+            self.assertAlmostEqual(0, (datetime_value.astimezone(pytz.utc) - recovered_datetime).total_seconds())
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_date(self):

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1,5 +1,5 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from datetime import date
+from datetime import date, datetime
 from typing import Any, Dict, List
 import unittest
 
@@ -19,6 +19,7 @@ from ...cost_estimation.filter_selectivity_utils import (
     get_selectivity_of_filters_at_vertex,
 )
 from ...cost_estimation.statistics import LocalStatistics, Statistics
+from ...cost_estimation.int_value_conversion import convert_int_to_field_value, convert_field_value_to_int
 from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ...schema_generation.schema_graph import SchemaGraph
@@ -1398,3 +1399,37 @@ class IntegerIntervalTests(unittest.TestCase):
         expected_intersection = None
         received_intersection = _get_intersection_of_intervals(interval_a, interval_b)
         self.assertEqual(expected_intersection, received_intersection)
+
+    @pytest.mark.usefixtures('snapshot_orientdb_client')
+    def test_int_value_conversion_datetime(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
+        uuid4_fields = {vertex_name: {'uuid'} for vertex_name in schema_graph.vertex_class_names}
+        statistics = LocalStatistics(dict(), field_quantiles={
+            ('Event', 'event_date'): [
+                datetime(2019, 3, 1),
+                datetime(2019, 6, 1),
+                datetime(2019, 8, 1),
+                datetime(2019, 9, 1),
+            ],
+        })
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields)
+
+        datetime_values = [
+            datetime(2000, 1, 1),
+            datetime(3000, 1, 1),
+            datetime(1000, 1, 1),
+            datetime(1, 1, 1),
+        ]
+        for datetime_value in datetime_values:
+            int_value = convert_field_value_to_int(schema_info, 'Event', 'event_date', datetime_value)
+            recovered_datetime = convert_int_to_field_value(
+                schema_info, 'Event', 'event_date', int_value)
+            self.assertAlmostEqual(0, (datetime_value - recovered_datetime).total_seconds())

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1316,6 +1316,9 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
 # pylint: enable=no-member
 
 
+# The following TestCase class uses the 'snapshot_orientdb_client' fixture
+# which pylint does not recognize as a class member.
+# pylint: disable=no-member
 class IntegerIntervalTests(unittest.TestCase):
     """Test methods that create IntegerIntervals."""
 
@@ -1406,7 +1409,7 @@ class IntegerIntervalTests(unittest.TestCase):
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_uuid(self):
-        schema_graph = generate_schema_graph(self.orientdb_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
@@ -1440,7 +1443,7 @@ class IntegerIntervalTests(unittest.TestCase):
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_datetime(self):
-        schema_graph = generate_schema_graph(self.orientdb_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
@@ -1482,7 +1485,7 @@ class IntegerIntervalTests(unittest.TestCase):
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_date(self):
-        schema_graph = generate_schema_graph(self.orientdb_client)
+        schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1472,7 +1472,9 @@ class IntegerIntervalTests(unittest.TestCase):
             recovered_datetime = convert_int_to_field_value(
                 schema_info, "Event", "event_date", int_value
             )
-            self.assertAlmostEqual(0, (datetime_value.astimezone(pytz.utc) - recovered_datetime).total_seconds())
+            self.assertAlmostEqual(
+                0, (datetime_value.astimezone(pytz.utc) - recovered_datetime).total_seconds()
+            )
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_date(self):

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1462,7 +1462,8 @@ class IntegerIntervalTests(unittest.TestCase):
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.utc),
         ]
         for datetime_value in datetime_values:
-            int_value = convert_field_value_to_int(schema_info, 'Event', 'event_date', datetime_value)
+            int_value = convert_field_value_to_int(
+                schema_info, 'Event', 'event_date', datetime_value)
             recovered_datetime = convert_int_to_field_value(
                 schema_info, 'Event', 'event_date', int_value)
             self.assertAlmostEqual(0, (datetime_value - recovered_datetime).total_seconds())

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -2,9 +2,9 @@
 from datetime import date, datetime
 from typing import Any, Dict, List
 import unittest
-import pytz
 
 import pytest
+import pytz
 
 from .. import test_input_data
 from ...compiler.metadata import FilterInfo
@@ -19,8 +19,11 @@ from ...cost_estimation.filter_selectivity_utils import (
     adjust_counts_for_filters,
     get_selectivity_of_filters_at_vertex,
 )
+from ...cost_estimation.int_value_conversion import (
+    convert_field_value_to_int,
+    convert_int_to_field_value,
+)
 from ...cost_estimation.statistics import LocalStatistics, Statistics
-from ...cost_estimation.int_value_conversion import convert_int_to_field_value, convert_field_value_to_int
 from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ...schema_generation.schema_graph import SchemaGraph

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1404,12 +1404,12 @@ class IntegerIntervalTests(unittest.TestCase):
         received_intersection = _get_intersection_of_intervals(interval_a, interval_b)
         self.assertEqual(expected_intersection, received_intersection)
 
-    @pytest.mark.usefixtures('snapshot_orientdb_client')
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_uuid(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {'uuid'} for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
         statistics = LocalStatistics({})
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
@@ -1417,7 +1417,8 @@ class IntegerIntervalTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields)
+            uuid4_fields=uuid4_fields,
+        )
 
         uuid_values = [
             "00000000-0000-0000-0000-000000000000",
@@ -1426,9 +1427,8 @@ class IntegerIntervalTests(unittest.TestCase):
             "ffffffff-ffff-ffff-ffff-ffffffffffff",
         ]
         for uuid_value in uuid_values:
-            int_value = convert_field_value_to_int(schema_info, 'Event', 'uuid', uuid_value)
-            recovered_uuid = convert_int_to_field_value(
-                schema_info, 'Event', 'uuid', int_value)
+            int_value = convert_field_value_to_int(schema_info, "Event", "uuid", uuid_value)
+            recovered_uuid = convert_int_to_field_value(schema_info, "Event", "uuid", int_value)
             self.assertEqual(uuid_value, recovered_uuid)
 
         invalid_uuid_values = [
@@ -1436,15 +1436,14 @@ class IntegerIntervalTests(unittest.TestCase):
         ]
         for uuid_value in invalid_uuid_values:
             with self.assertRaises(Exception):
-                int_value = convert_field_value_to_int(
-                    schema_info, 'Event', 'uuid', uuid_value)
+                int_value = convert_field_value_to_int(schema_info, "Event", "uuid", uuid_value)
 
-    @pytest.mark.usefixtures('snapshot_orientdb_client')
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_datetime(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {'uuid'} for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
         statistics = LocalStatistics({})
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
@@ -1452,7 +1451,8 @@ class IntegerIntervalTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields)
+            uuid4_fields=uuid4_fields,
+        )
 
         datetime_values = [
             datetime(2000, 1, 1, tzinfo=pytz.utc),
@@ -1463,26 +1463,29 @@ class IntegerIntervalTests(unittest.TestCase):
         ]
         for datetime_value in datetime_values:
             int_value = convert_field_value_to_int(
-                schema_info, 'Event', 'event_date', datetime_value)
+                schema_info, "Event", "event_date", datetime_value
+            )
             recovered_datetime = convert_int_to_field_value(
-                schema_info, 'Event', 'event_date', int_value)
+                schema_info, "Event", "event_date", int_value
+            )
             self.assertAlmostEqual(0, (datetime_value - recovered_datetime).total_seconds())
 
         invalid_datetime_values = [
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=None),
-            datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone('GMT')),
+            datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("GMT")),
         ]
         for datetime_value in invalid_datetime_values:
             with self.assertRaises(Exception):
                 int_value = convert_field_value_to_int(
-                    schema_info, 'Event', 'event_date', datetime_value)
+                    schema_info, "Event", "event_date", datetime_value
+                )
 
-    @pytest.mark.usefixtures('snapshot_orientdb_client')
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_date(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: 'uuid' for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {'uuid'} for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
         statistics = LocalStatistics({})
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
@@ -1490,7 +1493,8 @@ class IntegerIntervalTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields)
+            uuid4_fields=uuid4_fields,
+        )
 
         date_values = [
             date(2000, 1, 1),
@@ -1499,7 +1503,8 @@ class IntegerIntervalTests(unittest.TestCase):
             date(1, 1, 1),
         ]
         for date_value in date_values:
-            int_value = convert_field_value_to_int(schema_info, 'Animal', 'birthday', date_value)
+            int_value = convert_field_value_to_int(schema_info, "Animal", "birthday", date_value)
             recovered_date = convert_int_to_field_value(
-                schema_info, 'Animal', 'birthday', int_value)
+                schema_info, "Animal", "birthday", int_value
+            )
             self.assertEqual(date_value, recovered_date)

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1464,6 +1464,7 @@ class IntegerIntervalTests(unittest.TestCase):
             datetime(1, 1, 1, tzinfo=pytz.utc),
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.utc),
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("GMT")),
+            datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("America/New_York")),
         ]
         for datetime_value in datetime_values:
             int_value = convert_field_value_to_int(


### PR DESCRIPTION
This allows the cost estimator and the paginator to reason about int, uuid, date and datetime ranges in a generic way. This reasoning entails understanding inequality filters, computing filter selectivity given quantile statistics, and choosing good pagination parameters given quantile statistics, respecting existing filters on the query.