### PR TITLE
Add type hints to a few files in the compiler submodule.

### DIFF
--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -30,9 +30,6 @@ class QueryRoot(BasicBlock):
                          This will generally be a set of length 1, except when using Gremlin
                          with a non-final class, where we have to include all subclasses
                          of the start class. This is done using a Gremlin-only IR lowering step.
-
-        Returns:
-            new QueryRoot object
         """
         super(QueryRoot, self).__init__(start_class)
         self.start_class = start_class
@@ -80,9 +77,6 @@ class CoerceType(BasicBlock):
                           This will generally be a set of length 1, except when using Gremlin
                           with a non-final class, where we have to include all subclasses
                           of the target class. This is done using a Gremlin-only IR lowering step.
-
-        Returns:
-            new CoerceType object
         """
         super(CoerceType, self).__init__(target_class)
         self.target_class = target_class
@@ -122,9 +116,6 @@ class ConstructResult(BasicBlock):
         Args:
             fields: dict, variable name string -> Expression
                     see rules for variable names in validate_safe_string().
-
-        Returns:
-            new ConstructResult object
         """
         self.fields = {ensure_unicode_string(key): value for key, value in six.iteritems(fields)}
 
@@ -227,9 +218,6 @@ class MarkLocation(BasicBlock):
 
         Args:
             location: BaseLocation object, must not be at a property field in the query
-
-        Returns:
-            new MarkLocation object
         """
         super(MarkLocation, self).__init__(location)
         self.location = location
@@ -265,9 +253,8 @@ class Traverse(BasicBlock):
             edge_name: string obeying variable name rules (see validate_safe_string).
             optional: optional bool, specifying whether the traversal to the given location
                       is optional (i.e. non-filtering) or mandatory (filtering).
-
-        Returns:
-            new Traverse object
+            within_optional_scope: optional bool, set to True to indicate that this Traverse
+                                   is located within a scope marked @optional
         """
         super(Traverse, self).__init__(
             direction, edge_name, optional=optional, within_optional_scope=within_optional_scope
@@ -361,9 +348,8 @@ class Recurse(BasicBlock):
             direction: string, 'in' or 'out'.
             edge_name: string obeying variable name rules (see validate_safe_string).
             depth: int, always greater than or equal to 1.
-
-        Returns:
-            new Recurse object
+            within_optional_scope: optional bool, set to True to indicate that this Recurse
+                                   is located within a scope marked @optional
         """
         super(Recurse, self).__init__(
             direction, edge_name, depth, within_optional_scope=within_optional_scope
@@ -430,9 +416,6 @@ class Backtrack(BasicBlock):
             location: BaseLocation object, specifying where to backtrack to
             optional: optional bool, specifying whether the steps between the current location
                       and the location to which Backtrack is returning were optional or not
-
-        Returns:
-            new Backtrack object
         """
         super(Backtrack, self).__init__(location, optional=optional)
         self.location = location

--- a/graphql_compiler/compiler/blocks.py
+++ b/graphql_compiler/compiler/blocks.py
@@ -1,10 +1,13 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Definitions of the basic blocks of the compiler."""
 
+from typing import Callable, Dict, Set
+
 import six
 
 from .compiler_entities import BasicBlock, Expression, MarkerBlock
 from .helpers import (
+    BaseLocation,
     FoldScopeLocation,
     ensure_unicode_string,
     safe_quoted_string,
@@ -19,7 +22,7 @@ class QueryRoot(BasicBlock):
 
     __slots__ = ("start_class",)
 
-    def __init__(self, start_class):
+    def __init__(self, start_class: Set[str]) -> None:
         """Construct a QueryRoot object that starts querying at the specified class name.
 
         Args:
@@ -35,7 +38,7 @@ class QueryRoot(BasicBlock):
         self.start_class = start_class
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure that the QueryRoot block is valid."""
         if not (
             isinstance(self.start_class, set)
@@ -50,7 +53,7 @@ class QueryRoot(BasicBlock):
         for cls in self.start_class:
             validate_safe_string(cls)
 
-    def to_gremlin(self):
+    def to_gremlin(self) -> str:
         """Return a unicode object with the Gremlin representation of this block."""
         self.validate()
         if len(self.start_class) == 1:
@@ -69,7 +72,7 @@ class CoerceType(BasicBlock):
 
     __slots__ = ("target_class",)
 
-    def __init__(self, target_class):
+    def __init__(self, target_class: Set[str]) -> None:
         """Construct a CoerceType object that filters out any data that is not of the given types.
 
         Args:
@@ -85,7 +88,7 @@ class CoerceType(BasicBlock):
         self.target_class = target_class
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure that the CoerceType block is valid."""
         if not (
             isinstance(self.target_class, set)
@@ -100,7 +103,7 @@ class CoerceType(BasicBlock):
         for cls in self.target_class:
             validate_safe_string(cls)
 
-    def to_gremlin(self):
+    def to_gremlin(self) -> str:
         """Not implemented, should not be used."""
         raise AssertionError(
             u"CoerceType blocks must be appropriately lowered before being "
@@ -113,7 +116,7 @@ class ConstructResult(BasicBlock):
 
     __slots__ = ("fields",)
 
-    def __init__(self, fields):
+    def __init__(self, fields: Dict[str, Expression]) -> None:
         """Construct a ConstructResult object that maps the given field names to their expressions.
 
         Args:
@@ -130,7 +133,7 @@ class ConstructResult(BasicBlock):
         super(ConstructResult, self).__init__(self.fields)
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure that the ConstructResult block is valid."""
         if not isinstance(self.fields, dict):
             raise TypeError(
@@ -145,7 +148,9 @@ class ConstructResult(BasicBlock):
                     u"{} -> {}".format(key, value)
                 )
 
-    def visit_and_update_expressions(self, visitor_fn):
+    def visit_and_update_expressions(
+        self, visitor_fn: Callable[[Expression], Expression]
+    ) -> "ConstructResult":
         """Create an updated version (if needed) of the ConstructResult via the visitor pattern."""
         new_fields = {}
 
@@ -159,7 +164,7 @@ class ConstructResult(BasicBlock):
         else:
             return self
 
-    def to_gremlin(self):
+    def to_gremlin(self) -> str:
         """Return a unicode object with the Gremlin representation of this block."""
         self.validate()
 
@@ -181,13 +186,13 @@ class Filter(BasicBlock):
 
     __slots__ = ("predicate",)
 
-    def __init__(self, predicate):
+    def __init__(self, predicate: Expression) -> None:
         """Create a new Filter with the specified Expression as a predicate."""
         super(Filter, self).__init__(predicate)
         self.predicate = predicate
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure that the Filter block is valid."""
         if not isinstance(self.predicate, Expression):
             raise TypeError(
@@ -196,7 +201,9 @@ class Filter(BasicBlock):
                 )
             )
 
-    def visit_and_update_expressions(self, visitor_fn):
+    def visit_and_update_expressions(
+        self, visitor_fn: Callable[[Expression], Expression]
+    ) -> "Filter":
         """Create an updated version (if needed) of the Filter via the visitor pattern."""
         new_predicate = self.predicate.visit_and_update(visitor_fn)
         if new_predicate is not self.predicate:
@@ -204,22 +211,22 @@ class Filter(BasicBlock):
         else:
             return self
 
-    def to_gremlin(self):
+    def to_gremlin(self) -> str:
         """Return a unicode object with the Gremlin representation of this block."""
         self.validate()
         return u"filter{{it, m -> {}}}".format(self.predicate.to_gremlin())
 
 
 class MarkLocation(BasicBlock):
-    """A block that assigns a name to a given location in the query."""
+    """A block that assigns a name to a given BaseLocation in the query."""
 
     __slots__ = ("location",)
 
-    def __init__(self, location):
-        """Create a new MarkLocation at the specified Location.
+    def __init__(self, location: BaseLocation) -> None:
+        """Create a new MarkLocation at the specified BaseLocation.
 
         Args:
-            location: Location object, must not be at a property field in the query
+            location: BaseLocation object, must not be at a property field in the query
 
         Returns:
             new MarkLocation object
@@ -228,11 +235,11 @@ class MarkLocation(BasicBlock):
         self.location = location
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure that the MarkLocation block is valid."""
         validate_marked_location(self.location)
 
-    def to_gremlin(self):
+    def to_gremlin(self) -> str:
         """Return a unicode object with the Gremlin representation of this block."""
         self.validate()
         mark_name, _ = self.location.get_location_name()
@@ -244,7 +251,13 @@ class Traverse(BasicBlock):
 
     __slots__ = ("direction", "edge_name", "optional", "within_optional_scope")
 
-    def __init__(self, direction, edge_name, optional=False, within_optional_scope=False):
+    def __init__(
+        self,
+        direction: str,
+        edge_name: str,
+        optional: bool = False,
+        within_optional_scope: bool = False,
+    ) -> None:
         """Create a new Traverse block in the given direction and across the given edge.
 
         Args:
@@ -266,7 +279,7 @@ class Traverse(BasicBlock):
         self.within_optional_scope = within_optional_scope
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure that the Traverse block is valid."""
         if not isinstance(self.direction, six.string_types):
             raise TypeError(
@@ -291,11 +304,11 @@ class Traverse(BasicBlock):
                 u"{}".format(type(self.within_optional_scope).__name__, self.within_optional_scope)
             )
 
-    def get_field_name(self):
+    def get_field_name(self) -> str:
         """Return the field name corresponding to the edge being traversed."""
         return u"{}_{}".format(self.direction, self.edge_name)
 
-    def to_gremlin(self):
+    def to_gremlin(self) -> str:
         """Return a unicode object with the Gremlin representation of this block."""
         self.validate()
         if self.optional:
@@ -339,7 +352,9 @@ class Recurse(BasicBlock):
 
     __slots__ = ("direction", "edge_name", "depth", "within_optional_scope")
 
-    def __init__(self, direction, edge_name, depth, within_optional_scope=False):
+    def __init__(
+        self, direction: str, edge_name: str, depth: int, within_optional_scope: bool = False
+    ) -> None:
         """Create a new Recurse block which traverses the given edge up to "depth" times.
 
         Args:
@@ -360,7 +375,7 @@ class Recurse(BasicBlock):
         self.within_optional_scope = within_optional_scope
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure that the Traverse block is valid."""
         validate_edge_direction(self.direction)
         validate_safe_string(self.edge_name)
@@ -379,7 +394,7 @@ class Recurse(BasicBlock):
         if not (self.depth >= 1):
             raise ValueError(u"depth ({}) >= 1 does not hold!".format(self.depth))
 
-    def to_gremlin(self):
+    def to_gremlin(self) -> str:
         """Return a unicode object with the Gremlin representation of this block."""
         self.validate()
         template = "copySplit({recurse}).exhaustMerge"
@@ -404,15 +419,15 @@ class Recurse(BasicBlock):
 
 
 class Backtrack(BasicBlock):
-    """A block that specifies a return to a given Location in the query."""
+    """A block that specifies a return to a given BaseLocation in the query."""
 
     __slots__ = ("location", "optional")
 
-    def __init__(self, location, optional=False):
+    def __init__(self, location: BaseLocation, optional: bool = False) -> None:
         """Create a new Backtrack block, returning to the given location in the query.
 
         Args:
-            location: Location object, specifying where to backtrack to
+            location: BaseLocation object, specifying where to backtrack to
             optional: optional bool, specifying whether the steps between the current location
                       and the location to which Backtrack is returning were optional or not
 
@@ -424,7 +439,7 @@ class Backtrack(BasicBlock):
         self.optional = optional
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure that the Backtrack block is valid."""
         validate_marked_location(self.location)
         if not isinstance(self.optional, bool):
@@ -434,7 +449,7 @@ class Backtrack(BasicBlock):
                 )
             )
 
-    def to_gremlin(self):
+    def to_gremlin(self) -> str:
         """Return a unicode object with the Gremlin representation of this BasicBlock."""
         self.validate()
         if self.optional:
@@ -471,13 +486,13 @@ class Fold(MarkerBlock):
 
     __slots__ = ("fold_scope_location",)
 
-    def __init__(self, fold_scope_location):
+    def __init__(self, fold_scope_location: FoldScopeLocation) -> None:
         """Create a new Fold block rooted at the given location."""
         super(Fold, self).__init__(fold_scope_location)
         self.fold_scope_location = fold_scope_location
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Ensure the Fold block is valid."""
         if not isinstance(self.fold_scope_location, FoldScopeLocation):
             raise TypeError(
@@ -491,7 +506,7 @@ class Unfold(MarkerBlock):
 
     __slots__ = ()
 
-    def validate(self):
+    def validate(self) -> None:
         """Unfold blocks are always valid in isolation."""
 
 
@@ -503,7 +518,7 @@ class EndOptional(MarkerBlock):
 
     __slots__ = ()
 
-    def validate(self):
+    def validate(self) -> None:
         """In isolation, EndOptional blocks are always valid."""
 
 
@@ -517,5 +532,5 @@ class GlobalOperationsStart(MarkerBlock):
 
     __slots__ = ()
 
-    def validate(self):
+    def validate(self) -> None:
         """In isolation, GlobalOperationsStart blocks are always valid."""

--- a/graphql_compiler/compiler/compiler_entities.py
+++ b/graphql_compiler/compiler/compiler_entities.py
@@ -79,13 +79,8 @@ class CompilerEntity(object):
 
 
 AliasType = Union[Alias, CTE]
-AliasesDictType = Dict[
-    Tuple[
-        Tuple[str, ...],
-        Optional[Tuple[Tuple[str, str], ...]],
-    ],
-    AliasType
-]
+AliasesDictType = Dict[Tuple[Tuple[str, ...], Optional[Tuple[Tuple[str, str], ...]],], AliasType]
+
 
 @six.add_metaclass(ABCMeta)
 class Expression(CompilerEntity):

--- a/graphql_compiler/compiler/compiler_entities.py
+++ b/graphql_compiler/compiler/compiler_entities.py
@@ -72,7 +72,6 @@ class CompilerEntity(object):
         """Check another object for non-equality against this one."""
         return not self.__eq__(other)
 
-    @abstractmethod
     def to_gremlin(self) -> str:
         """Return the Gremlin unicode string representation of this object."""
         raise NotImplementedError()
@@ -109,17 +108,14 @@ class Expression(CompilerEntity):
         # Any Expressions that contain Expressions will override this method.
         return visitor_fn(self)
 
-    @abstractmethod
     def to_match(self) -> str:
         """Return a string with the MATCH representation of this Expression."""
         raise NotImplementedError()
 
-    @abstractmethod
     def to_cypher(self) -> str:
         """Return a string with the Cypher representation of this Expression."""
         raise NotImplementedError()
 
-    @abstractmethod
     def to_sql(self, dialect: Any, aliases: AliasesDictType, current_alias: AliasType) -> Any:
         """Return a SQLAlchemy object with the SQL representation of this Expression."""
         raise NotImplementedError()

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -1431,9 +1431,6 @@ class BinaryComposition(Expression):
         )
 
 
-ExpressionT2 = TypeVar("ExpressionT2", bound=Expression)
-
-
 class TernaryConditional(Expression):
     """A ternary conditional expression, returning one of two expressions depending on a third."""
 
@@ -1502,7 +1499,7 @@ class TernaryConditional(Expression):
         # emitting MATCH code for TernaryConditional that contains another TernaryConditional
         # anywhere within the predicate expression. This is because the predicate expression
         # must be surrounded in quotes, and it is unclear whether nested/escaped quotes would work.
-        def visitor_fn(expression: ExpressionT2) -> ExpressionT2:
+        def visitor_fn(expression: ExpressionT) -> ExpressionT:
             """Visitor function that ensures the predicate does not contain TernaryConditionals."""
             if isinstance(expression, TernaryConditional):
                 raise ValueError(

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -1,11 +1,20 @@
 # Copyright 2017-present Kensho Technologies, LLC.
-from abc import ABCMeta
 import operator as python_operator
-from typing import Any, Callable, Dict, FrozenSet, Generic, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Generic,
+    List,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from graphql import GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString
-from graphql.type.definition import GraphQLList, GraphQLObjectType, GraphQLOutputType, GraphQLScalarType
-from mypy_extensions import NoReturn
+from graphql.type.definition import GraphQLOutputType
 import six
 import sqlalchemy
 from sqlalchemy import bindparam, sql
@@ -57,7 +66,10 @@ ExpressionT = TypeVar("ExpressionT", bound=Expression)
 ReplacementExpressionT = TypeVar("ReplacementExpressionT", bound=Expression)
 ReplacementT = Union[ExpressionT, ReplacementExpressionT]
 
-def make_replacement_visitor(find_expression: Expression, replace_expression: ReplacementExpressionT) -> Callable[[ExpressionT], ReplacementT]:
+
+def make_replacement_visitor(
+    find_expression: Expression, replace_expression: ReplacementExpressionT
+) -> Callable[[ExpressionT], ReplacementT]:
     """Return a visitor function that replaces every instance of one expression with another one."""
 
     def visitor_fn(expression: ExpressionT) -> ReplacementT:
@@ -70,7 +82,10 @@ def make_replacement_visitor(find_expression: Expression, replace_expression: Re
     return visitor_fn
 
 
-def make_type_replacement_visitor(find_types: Union[Type[Expression], Tuple[Type[Expression], ...]], replacement_func: Callable[[ExpressionT], ReplacementT]) -> Callable[[ExpressionT], ReplacementT]:
+def make_type_replacement_visitor(
+    find_types: Union[Type[Expression], Tuple[Type[Expression], ...]],
+    replacement_func: Callable[[ExpressionT], ReplacementT],
+) -> Callable[[ExpressionT], ReplacementT]:
     """Return a visitor function that replaces expressions of a given type with new expressions."""
 
     def visitor_fn(expression: ExpressionT) -> ReplacementT:
@@ -84,6 +99,7 @@ def make_type_replacement_visitor(find_types: Union[Type[Expression], Tuple[Type
 
 
 ValueT = TypeVar("ValueT")
+
 
 class Literal(Generic[ValueT], Expression):
     """A literal, such as a boolean value, null, or a fixed string value.
@@ -777,7 +793,9 @@ class FoldedContextField(Expression):
 
     __slots__ = ("fold_scope_location", "field_type")
 
-    def __init__(self, fold_scope_location: FoldScopeLocation, field_type: GraphQLOutputType) -> None:
+    def __init__(
+        self, fold_scope_location: FoldScopeLocation, field_type: GraphQLOutputType
+    ) -> None:
         """Construct a new FoldedContextField object for this folded field.
 
         Args:
@@ -892,7 +910,8 @@ class FoldedContextField(Expression):
         if self.fold_scope_location.field is None:
             raise AssertionError(
                 u"Unreachable code reached, expected a location at a field "
-                u"but got {}: {}".format(self.fold_scope_location, self))
+                u"but got {}: {}".format(self.fold_scope_location, self)
+            )
 
         # _x_count is a special case that has already been coalesced to 0.
         # _x_count's intermediate output name is always fold_output__x_count
@@ -1285,9 +1304,7 @@ class BinaryComposition(Expression):
 
         match_operator, format_spec = translation_table.get(self.operator, (None, None))
         if not match_operator or not format_spec:
-            raise AssertionError(
-                u"Unrecognized operator used: {} {}".format(self.operator, self)
-            )
+            raise AssertionError(u"Unrecognized operator used: {} {}".format(self.operator, self))
 
         return format_spec % dict(
             operator=match_operator, left=self.left.to_match(), right=self.right.to_match()
@@ -1328,9 +1345,7 @@ class BinaryComposition(Expression):
 
         gremlin_operator, format_spec = translation_table.get(self.operator, (None, None))
         if not gremlin_operator or not format_spec:
-            raise AssertionError(
-                u"Unrecognized operator used: {} {}".format(self.operator, self)
-            )
+            raise AssertionError(u"Unrecognized operator used: {} {}".format(self.operator, self))
 
         return format_spec.format(
             operator=gremlin_operator, left=self.left.to_gremlin(), right=self.right.to_gremlin()
@@ -1378,9 +1393,7 @@ class BinaryComposition(Expression):
 
         cypher_operator, format_spec = translation_table.get(self.operator, (None, None))
         if not cypher_operator or not format_spec:
-            raise AssertionError(
-                u"Unrecognized operator used: {} {}".format(self.operator, self)
-            )
+            raise AssertionError(u"Unrecognized operator used: {} {}".format(self.operator, self))
 
         return format_spec.format(
             operator=cypher_operator, left=self.left.to_cypher(), right=self.right.to_cypher()
@@ -1419,6 +1432,7 @@ class BinaryComposition(Expression):
 
 
 ExpressionT2 = TypeVar("ExpressionT2", bound=Expression)
+
 
 class TernaryConditional(Expression):
     """A ternary conditional expression, returning one of two expressions depending on a third."""

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -748,6 +748,7 @@ class OutputContextField(Expression):
         return template.format(mark_name=mark_name, field_name=field_name)
 
     def to_sql(self, dialect: Any, aliases: AliasesDictType, current_alias: AliasType) -> Any:
+        """Return a SQLAlchemy Column picked from the appropriate alias."""
         if isinstance(self.field_type, GraphQLList):
             raise NotImplementedError(
                 u"The SQL backend does not support lists. Cannot "

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -783,7 +783,7 @@ class FoldedContextField(Expression):
     __slots__ = ("fold_scope_location", "field_type")
 
     def __init__(
-        self, fold_scope_location: FoldScopeLocation, field_type: GraphQLOutputType
+        self, fold_scope_location: FoldScopeLocation, field_type: GraphQLList[GraphQLOutputType]
     ) -> None:
         """Construct a new FoldedContextField object for this folded field.
 

--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -1,17 +1,6 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 import operator as python_operator
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    FrozenSet,
-    Generic,
-    List,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, FrozenSet, Generic, List, Tuple, Type, TypeVar, Union
 
 from graphql import GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString
 from graphql.type.definition import GraphQLOutputType

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -335,6 +335,15 @@ class BaseLocation(object):
         """Return a tuple of a unique name of the location, and the current field name (or None)."""
         raise NotImplementedError()
 
+    def get_location_at_field_name(self) -> Tuple[str, str]:
+        """Assert the location is at a field, then return the same value as get_location_name()."""
+        mark_name, field_name = self.get_location_name()
+        if field_name is None:
+            raise AssertionError(
+                u"Expected the location {} to be at a field, but it was not."
+                u"This is a bug.".format(self))
+        return (mark_name, field_name)
+
     @abstractmethod
     def _check_if_object_of_same_type_is_smaller(self: LocationT, other: LocationT) -> bool:
         """Return True if the other object is smaller than self in the total ordering."""

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -378,6 +378,11 @@ class BaseLocation(object):
 
 @six.python_2_unicode_compatible
 class Location(BaseLocation):
+    """A location in the GraphQL query, anywhere except within a @fold scope."""
+
+    query_path: Tuple[str, ...]
+    visit_counter: int
+
     def __init__(
         self, query_path: Tuple[str, ...], field: Optional[str] = None, visit_counter: int = 1
     ) -> None:
@@ -537,6 +542,11 @@ class Location(BaseLocation):
 
 @six.python_2_unicode_compatible
 class FoldScopeLocation(BaseLocation):
+    """A location within a @fold scope."""
+
+    base_location: Location
+    fold_path: Tuple[Tuple[str, str], ...]
+
     def __init__(
         self,
         base_location: Location,

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -366,7 +366,7 @@ class BaseLocation(object):
         elif isinstance(self, Location) and isinstance(other, FoldScopeLocation):
             return _compare_location_and_fold_scope_location(self, other)
         elif isinstance(self, FoldScopeLocation) and isinstance(other, Location):
-            return _compare_location_and_fold_scope_location(other, self)
+            return not _compare_location_and_fold_scope_location(other, self)
         else:
             raise AssertionError(
                 u"Received objects of types {}, {} in BaseLocation comparison. "

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 from functools import total_ordering
 import string
-from typing import Any, Collection, Dict, Hashable, Iterable, Optional, Tuple, TypeVar, Union
+from typing import Any, Collection, Dict, Hashable, Iterable, Optional, Tuple, TypeVar, Union, cast
 
 import funcy
 from graphql import GraphQLNonNull, GraphQLString, is_type
@@ -76,7 +76,7 @@ def get_field_type_from_schema(
 
 def get_vertex_field_type(
     current_schema_type: Union[GraphQLInterfaceType, GraphQLObjectType], vertex_field_name: str
-) -> GraphQLOutputType:
+) -> Union[GraphQLInterfaceType, GraphQLObjectType]:
     """Return the type of the vertex within the specified vertex field name of the given type."""
     # According to the schema, the vertex field itself is of type GraphQLList, and this is
     # what get_field_type_from_schema returns. We care about what the type *inside* the list is,
@@ -94,7 +94,9 @@ def get_vertex_field_type(
             u"Found an edge whose schema type was not GraphQLList: "
             u"{} {} {}".format(current_schema_type, vertex_field_name, raw_field_type)
         )
-    return raw_field_type.of_type
+
+    field_type = cast(GraphQLList[Union[GraphQLInterfaceType, GraphQLObjectType]], raw_field_type)
+    return field_type.of_type
 
 
 def strip_non_null_from_type(graphql_type: GraphQLOutputType) -> Any:

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -341,7 +341,8 @@ class BaseLocation(object):
         if field_name is None:
             raise AssertionError(
                 u"Expected the location {} to be at a field, but it was not."
-                u"This is a bug.".format(self))
+                u"This is a bug.".format(self)
+            )
         return (mark_name, field_name)
 
     @abstractmethod

--- a/graphql_compiler/compiler/ir_lowering_match/utils.py
+++ b/graphql_compiler/compiler/ir_lowering_match/utils.py
@@ -126,10 +126,6 @@ class BetweenClause(Expression):
             upper_bound=self.upper_bound.to_match(),
         )
 
-    def to_gremlin(self):
-        """Must never be called."""
-        raise NotImplementedError()
-
 
 def filter_edge_field_non_existence(edge_expression):
     """Return an Expression that is True iff the specified edge (edge_expression) does not exist."""

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -1,5 +1,4 @@
 # Copyright 2017-present Kensho Technologies, LLC.
-from typing import cast
 import unittest
 
 from graphql import GraphQLString
@@ -540,8 +539,8 @@ class EmitCypherTests(unittest.TestCase):
                     # see compiler.ir_lowering_cypher's replace_local_fields_with_context_fields
                     # method LocalField(u"name", GraphQLString) gets replaced with the
                     # child_location field "name"
-                    ContextField(child_location.navigate_to_field(u"name"), GraphQLString),
-                    ContextField(base_location.navigate_to_field(u"name"), GraphQLString),
+                    ContextField(child_name_location, GraphQLString),
+                    ContextField(base_name_location, GraphQLString),
                 )
             ),
             MarkLocation(child_location),

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -558,7 +558,7 @@ class EmitCypherTests(unittest.TestCase):
 
         expected_cypher = """
             MATCH (Animal___1:Animal)
-            MATCH (Animal___1)-[:Animal_BornAt]->(Animal__out_Animal_BornAt___1:BornAt)
+            MATCH (Animal___1)-[:Animal_BornAt]->(Animal__out_Animal_BornAt___1:BirthEvent)
               WHERE (Animal__out_Animal_BornAt___1.name = Animal___1.name)
             RETURN
               Animal___1.name AS `animal_name`
@@ -575,7 +575,6 @@ class EmitCypherTests(unittest.TestCase):
         #     }
         # }'''
         base_location = Location(("Animal",))
-        base_name_location = base_location.navigate_to_field("name")
         schema = get_schema()
         base_location_info = LocationInfo(
             parent_location=None,

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -1,4 +1,5 @@
 # Copyright 2017-present Kensho Technologies, LLC.
+from typing import cast
 import unittest
 
 from graphql import GraphQLString
@@ -465,7 +466,7 @@ class EmitCypherTests(unittest.TestCase):
         schema = get_schema()
         base_location_info = LocationInfo(
             parent_location=None,
-            type=schema.get_type(base_name_location.field),
+            type=schema.get_type("Animal"),
             coerced_from_type=None,
             optional_scopes_depth=0,
             recursive_scopes_depth=0,
@@ -508,7 +509,7 @@ class EmitCypherTests(unittest.TestCase):
         schema = get_schema()
         base_location_info = LocationInfo(
             parent_location=None,
-            type=schema.get_type(base_name_location.field),
+            type=schema.get_type("Animal"),
             coerced_from_type=None,
             optional_scopes_depth=0,
             recursive_scopes_depth=0,
@@ -519,7 +520,7 @@ class EmitCypherTests(unittest.TestCase):
         child_name_location = child_location.navigate_to_field("name")
         child_location_info = LocationInfo(
             parent_location=base_location,
-            type=schema.get_type(child_name_location.field),
+            type=schema.get_type("BirthEvent"),
             coerced_from_type=None,
             optional_scopes_depth=1,
             recursive_scopes_depth=0,
@@ -531,7 +532,7 @@ class EmitCypherTests(unittest.TestCase):
             MarkLocation(base_location),
             Traverse("out", "Animal_BornAt"),
             CoerceType(
-                {"BornAt"}
+                {"BirthEvent"}
             ),  # see compiler.ir_lowering_cypher's insert_explicit_type_bounds method
             Filter(
                 BinaryComposition(
@@ -579,7 +580,7 @@ class EmitCypherTests(unittest.TestCase):
         schema = get_schema()
         base_location_info = LocationInfo(
             parent_location=None,
-            type=schema.get_type(base_name_location.field),
+            type=schema.get_type("Animal"),
             coerced_from_type=None,
             optional_scopes_depth=0,
             recursive_scopes_depth=0,
@@ -590,7 +591,7 @@ class EmitCypherTests(unittest.TestCase):
         child_name_location = child_location.navigate_to_field("name")
         child_location_info = LocationInfo(
             parent_location=base_location,
-            type=child_name_location.field,
+            type=schema.get_type("BirthEvent"),
             coerced_from_type=None,
             optional_scopes_depth=1,
             recursive_scopes_depth=0,
@@ -602,7 +603,7 @@ class EmitCypherTests(unittest.TestCase):
             MarkLocation(base_location),
             Traverse("out", "Animal_BornAt", optional=True),
             CoerceType(
-                {"BornAt"}
+                {"BirthEvent"}
             ),  # see compiler.ir_lowering_cypher's insert_explicit_type_bounds method
             MarkLocation(child_location),
             Backtrack(base_location, optional=True),
@@ -636,7 +637,7 @@ class EmitCypherTests(unittest.TestCase):
 
         expected_cypher = """
             MATCH (Animal___1:Animal)
-            OPTIONAL MATCH (Animal___1)-[:Animal_BornAt]->(Animal__out_Animal_BornAt___1:BornAt)
+            OPTIONAL MATCH (Animal___1)-[:Animal_BornAt]->(Animal__out_Animal_BornAt___1:BirthEvent)
             RETURN
                 (CASE WHEN (Animal__out_Animal_BornAt___1 IS NOT null)
                 THEN Animal__out_Animal_BornAt___1.name ELSE null END) AS `bornat_name`
@@ -656,7 +657,7 @@ class EmitCypherTests(unittest.TestCase):
         schema = get_schema()
         base_location_info = LocationInfo(
             parent_location=None,
-            type=schema.get_type(base_event_date_location.field),
+            type=schema.get_type("BirthEvent"),
             coerced_from_type=None,
             optional_scopes_depth=0,
             recursive_scopes_depth=0,

--- a/graphql_compiler/tests/test_location.py
+++ b/graphql_compiler/tests/test_location.py
@@ -15,7 +15,15 @@ def compare_sorted_locations_list(
             second_location = sorted_locations[j]
             expected_comparison = i < j
             received_comparison = first_location < second_location
-            test_case.assertEqual(expected_comparison, received_comparison)
+            test_case.assertEqual(
+                expected_comparison,
+                received_comparison,
+                msg=(
+                    "{} < {}, expected result {} but got {}".format(
+                        first_location, second_location, expected_comparison, received_comparison
+                    )
+                ),
+            )
 
 
 class LocationTests(unittest.TestCase):


### PR DESCRIPTION
Before reviewing, please make sure you are familiar with [this part of PEP 484](https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods), since some of the generic type hints depend on that functionality.

This PR consists of:
- auto-generated type hints where possible;
- some hand-written type hints where more sophistication (e.g. generics) was necessary;
- some minor tweaks to logic and a couple of helper methods to make mypy happy, and
- a fix in the `test_emit_output.py` file's Cypher section which I caught thanks to mypy.

Would appreciate it if someone more familiar with the SQL backend double-checked the type signature on `to_sql()` and looked into whether we can put a tighter signature there, since the current one uses a couple of `Any` types.