### PR TITLE
Fix contributing docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,12 +69,11 @@ Once the dev environment is prepared, you can run the tests, from the root repos
    py.test graphql_compiler/tests
 
 Some snapshot and integration tests take longer to setup, run, and
-teardown. These can be optionally skipped during development by running
-the tests with the :code:`--skip-slow` flag:
+teardown. These can be optionally skipped during development by running:
 
 .. code:: bash
 
-   py.test graphql_compiler/tests --skip-slow
+   py.test -m 'no-slow'
 
 If you run into any issues, please consult the TROUBLESHOOTING.md file.
 If you encounter and resolve an issue that is not already part of the

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,14 +66,14 @@ Once the dev environment is prepared, you can run the tests, from the root repos
    pipenv sync --dev
    pipenv shell
 
-   py.test graphql_compiler/tests
+   pytest graphql_compiler/tests
 
 Some snapshot and integration tests take longer to setup, run, and
 teardown. These can be optionally skipped during development by running:
 
 .. code:: bash
 
-   py.test -m 'no-slow'
+   pytest -m 'no-slow'
 
 If you run into any issues, please consult the TROUBLESHOOTING.md file.
 If you encounter and resolve an issue that is not already part of the
@@ -87,7 +87,7 @@ Code of Conduct
 ---------------
 
 This project adheres to the Contributor Covenant `code of
-conduct <CODE_OF_CONDUCT.md>`__. By participating, you are expected to
+conduct <CODE_OF_CONDUCT.rst>`__. By participating, you are expected to
 uphold this code. Please report unacceptable behavior at
 graphql-compiler-maintainer@kensho.com.
 

--- a/TROUBLESHOOTING.rst
+++ b/TROUBLESHOOTING.rst
@@ -135,8 +135,6 @@ because that only installs the interface to MySQL.
 Issues with pyodbc
 ------------------
 
-.. TODO: Add link to ODBC driver installation instructions once we move to Read The Docs.
-
 If you have any issues installing :Code:`pydobc` when running :code:`pipenv install`, then it might
 mean that you have failed to correctly install the ODBC driver.
 
@@ -147,4 +145,4 @@ can be resolved on Ubuntu by running:
 .. bash::
 
     # Please modify command to match the version of python you use for development.
-    sudo apt-get install python3.6-dev
+    sudo apt-get install python3.8-dev

--- a/docs/source/about/contributing.rst
+++ b/docs/source/about/contributing.rst
@@ -66,14 +66,14 @@ Once the dev environment is prepared, you can run the tests, from the root repos
    pipenv sync --dev
    pipenv shell
 
-   py.test graphql_compiler/tests
+   pytest graphql_compiler/tests
 
 Some snapshot and integration tests take longer to setup, run, and
 teardown. These can be optionally skipped during development by running:
 
 .. code:: bash
 
-   py.test -m 'no-slow'
+   pytest -m 'no-slow'
 
 If you run into any issues, please consult the :ref:`troubleshooting guide <troubleshooting>`.
 If you encounter and resolve an issue that is not already part of the
@@ -86,8 +86,8 @@ fashion by decorating with the :code:`@pytest.mark.slow` flag.
 Code of Conduct
 ---------------
 
-This project adheres to the Contributor Covenant `code of
-conduct <CODE_OF_CONDUCT.md>`__. By participating, you are expected to
+This project adheres to the Contributor Covenant :doc:`code of
+conduct <code_of_conduct>`. By participating, you are expected to
 uphold this code. Please report unacceptable behavior at
 graphql-compiler-maintainer@kensho.com.
 

--- a/docs/source/about/contributing.rst
+++ b/docs/source/about/contributing.rst
@@ -8,10 +8,16 @@ To get started, make sure that you have :code:`pipenv`, :code:`docker` and
 you have Python 3.8+ installed locally. If you do not already have it installed,
 consider doing so using `pyenv <https://github.com/pyenv/pyenv>`__.
 
-Integration tests are run against multiple SQL databases, some of which
-require dialect specific installations to be available in the
-development environment. Currently this affects MySQL. A compatible
-driver can be installed on OSX with:
+Database Driver Installations
+-----------------------------
+
+Integration tests are run against multiple databases, some of which
+require that you install specific drivers.
+
+MySQL Driver
+~~~~~~~~~~~~
+
+For MySQL a compatible driver can be installed on OSX with:
 
 .. code:: bash
 
@@ -26,8 +32,33 @@ or on Ubuntu with:
 For more details on other systems please refer to `MySQL dialect
 information <https://docs.sqlalchemy.org/en/latest/dialects/mysql.html>`__.
 
-Once the dev environment is prepared, from the root of the repository,
-run:
+Microsoft SQL Server ODBC Driver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For MSSQL, you can install the required ODBC driver on OSX with:
+
+.. code:: bash
+
+    brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
+    brew install msodbcsql17 mssql-tools
+
+Or Ubuntu with:
+
+.. code:: bash
+
+    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+    sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/"$(lsb_release -r -s)"/prod.list)"
+    sudo apt-get update
+    sudo ACCEPT_EULA=Y apt-get install msodbcsql17
+    sudo apt-get install unixodbc-dev
+
+To see the installation instructions for other operating systems, please follow this `link
+<https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-2017&viewFallbackFrom=ssdt-18vs2017>`__.
+
+Running tests
+-------------
+
+Once the dev environment is prepared, you can run the tests, from the root repository, with:
 
 ::
 
@@ -55,8 +86,8 @@ fashion by decorating with the :code:`@pytest.mark.slow` flag.
 Code of Conduct
 ---------------
 
-This project adheres to the Contributor Covenant :doc:`code of
-conduct <code_of_conduct>`. By participating, you are expected to
+This project adheres to the Contributor Covenant `code of
+conduct <CODE_OF_CONDUCT.md>`__. By participating, you are expected to
 uphold this code. Please report unacceptable behavior at
 graphql-compiler-maintainer@kensho.com.
 
@@ -257,3 +288,18 @@ This error might happen even if you've run
    apt-get install python-mysqldb
 
 because that only installs the interface to MySQL.
+
+Issues with pyodbc
+^^^^^^^^^^^^^^^^^^
+
+If you have any issues installing :Code:`pydobc` when running :code:`pipenv install`, then it might
+mean that you have failed to correctly install the ODBC driver.
+
+Another reason that your `pyodbc` installation might fail is because your python installation
+did not include the required header files. This issue has only affected Ubuntu users so far and
+can be resolved on Ubuntu by running:
+
+.. ::
+
+    # Please modify command to match the version of python you use for development.
+    sudo apt-get install python3.8-dev


### PR DESCRIPTION
The contributing docs in readthedocs and the old contributing and troubleshoting docs got out of sync. Each set of docs contained improvements/additions that the other did not contain. In this diff, I add these missing improvements/additions.

I do not suspect that other docs are suffering from the same issue since we have only recently updated the contributing docs and the schema info API, which was adjusted correctly in both the README and in readthedocs. I am trying to move us to readthedocs soon to prevent these sort of errors from happening again.