### PR TITLE
Use general range reasoning in the cost estimator

### DIFF
--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -373,7 +373,7 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
                     upper_bound = convert_int_to_field_value(
                         schema_info, location_name, field_name, interval.upper_bound
                     )
-                value_interval = Interval[int](lower_bound, upper_bound)
+                value_interval = Interval(lower_bound, upper_bound)
 
                 # Compute selectivity
                 quantiles = schema_info.statistics.get_field_quantiles(location_name, field_name)

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -4,12 +4,21 @@ from __future__ import division
 import bisect
 from collections import namedtuple
 import sys
-from uuid import UUID
+from typing import Any, Dict, List
 
 import six
 
 from ..compiler.helpers import get_parameter_name
-from ..cost_estimation.helpers import is_int_field_type, is_uuid4_type
+from ..compiler.metadata import FilterInfo
+from ..schema.schema_info import QueryPlanningSchemaInfo
+from .helpers import is_uuid4_type
+from .int_value_conversion import (
+    MAX_UUID_INT,
+    MIN_UUID_INT,
+    convert_field_value_to_int,
+    convert_int_to_field_value,
+    field_supports_range_reasoning,
+)
 
 
 # The Selectivity represents the selectivity of a filter or a set of filters
@@ -37,11 +46,6 @@ ABSOLUTE_SELECTIVITY = "absolute"
 FRACTIONAL_SELECTIVITY = "fractional"
 
 INEQUALITY_OPERATORS = frozenset(["<", "<=", ">", ">=", "between"])
-
-# UUIDs are defined in RFC-4122 as a 128-bit identifier. This means that the minimum UUID value
-# (represented as a natural number) is 0, and the maximal value is 2^128-1.
-MIN_UUID_INT = 0
-MAX_UUID_INT = 2 ** 128 - 1
 
 
 def _is_absolute(selectivity):
@@ -72,11 +76,6 @@ def _are_filter_fields_uniquely_indexed(filter_fields, unique_indexes):
         if filter_fields_frozenset == unique_index.fields:
             return True
     return False
-
-
-def _convert_uuid_string_to_int(uuid_string):
-    """Return the integer representation of a UUID string."""
-    return UUID(uuid_string).int
 
 
 def _create_integer_interval(lower_bound, upper_bound):
@@ -395,6 +394,33 @@ def _get_selectivity_fraction_of_interval(interval, quantiles):
     return float(interval_size) / domain_interval_size
 
 
+def get_integer_interval_for_filters_on_field(
+    schema_info: QueryPlanningSchemaInfo,
+    filters_on_field: List[FilterInfo],
+    location_name: str,
+    field_name: str,
+    parameters: Dict[str, Any],
+) -> IntegerInterval:
+    interval = _create_integer_interval(None, None)
+    for filter_info in filters_on_field:
+        if filter_info.op_name in INEQUALITY_OPERATORS:
+            parameter_values = [
+                convert_field_value_to_int(
+                    schema_info,
+                    location_name,
+                    field_name,
+                    parameters[get_parameter_name(filter_argument)],
+                )
+                for filter_argument in filter_info.args
+            ]
+
+            filter_interval = _get_query_interval_of_integer_inequality_filter(
+                parameter_values, filter_info.op_name
+            )
+            interval = _get_intersection_of_intervals(interval, filter_interval)
+    return interval
+
+
 def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, location_name):
     """Get the combined selectivity of all filters at the vertex.
 
@@ -425,31 +451,14 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
         interval = _create_integer_interval(None, None)
 
         # Process inequality filters
-        is_uuid4_field = is_uuid4_type(schema_info, location_name, field_name)
-        is_int_field = is_int_field_type(schema_info, location_name, field_name)
-        is_inequality_filter_estimation_supported = is_uuid4_field or is_int_field
-        if is_inequality_filter_estimation_supported:
-            for filter_info in filters_on_field:
-                if filter_info.op_name in INEQUALITY_OPERATORS:
-                    parameter_values = [
-                        parameters[get_parameter_name(filter_argument)]
-                        for filter_argument in filter_info.args
-                    ]
-
-                    # Map uuid4 values to their corresponding integer values
-                    if is_uuid4_field:
-                        parameter_values = [
-                            _convert_uuid_string_to_int(value) for value in parameter_values
-                        ]
-
-                    filter_interval = _get_query_interval_of_integer_inequality_filter(
-                        parameter_values, filter_info.op_name
-                    )
-                    interval = _get_intersection_of_intervals(interval, filter_interval)
+        if field_supports_range_reasoning(schema_info, location_name, field_name):
+            interval = get_integer_interval_for_filters_on_field(
+                schema_info, filters_on_field, location_name, field_name, parameters
+            )
 
             if interval is None:
                 selectivity_at_field = Selectivity(kind=ABSOLUTE_SELECTIVITY, value=0.0)
-            elif is_uuid4_field:
+            elif is_uuid4_type(schema_info, location_name, field_name):
                 # uuid4 fields are uniformly distributed, so we simply divide the fraction of
                 # the domain queried with the size of the domain.
                 domain_interval = _create_integer_interval(MIN_UUID_INT, MAX_UUID_INT)
@@ -463,22 +472,31 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
                 selectivity_at_field = _combine_filter_selectivities(
                     [selectivity_at_field, selectivity]
                 )
-            elif is_int_field:
-                # int fields are not uniformly distributed but we have quantile information.
+            else:
+                # Get value interval
+                # HACK(bojanserafimov): Abuse of IntegerInterval spec. Constructed with non-interval
+                #                       endpoints. The type should be renamed to allow this usage.
+                lower_bound, upper_bound = None, None
+                if interval.lower_bound is not None:
+                    lower_bound = convert_int_to_field_value(
+                        schema_info, location_name, field_name, interval.lower_bound
+                    )
+                if interval.upper_bound is not None:
+                    upper_bound = convert_int_to_field_value(
+                        schema_info, location_name, field_name, interval.upper_bound
+                    )
+                value_interval = _create_integer_interval(lower_bound, upper_bound)
+
+                # Compute selectivity
                 quantiles = schema_info.statistics.get_field_quantiles(location_name, field_name)
                 if quantiles is not None:
                     selectivity = Selectivity(
                         kind=FRACTIONAL_SELECTIVITY,
-                        value=_get_selectivity_fraction_of_interval(interval, quantiles),
+                        value=_get_selectivity_fraction_of_interval(value_interval, quantiles),
                     )
                     selectivity_at_field = _combine_filter_selectivities(
                         [selectivity_at_field, selectivity]
                     )
-            else:
-                raise AssertionError(
-                    u"Field {}.{} is not uuid4 or int. Inequality filters are "
-                    u"not supported".format(location_name, field_name)
-                )
 
         # Process in_collection filters
         for filter_info in filters_on_field:

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -31,15 +31,14 @@ Selectivity = namedtuple(
     ),
 )
 
-# Interval is used to denote a continuous non-empty interval of values.
-Interval = namedtuple(
-    "Interval",
+# IntegerInterval is used to denote a continuous non-empty interval of integers.
+IntegerInterval = namedtuple(
+    "IntegerInterval",
     (
-        "lower_bound",  # Any or None, inclusive lower bound of integers in the interval.
+        "lower_bound",  # int or None, inclusive lower bound of integers in the interval.
         # Intervals that do not have a lower bound denote this by using None.
-        "upper_bound",  # Any or None, inclusive upper bound of integers in the interval.
-        # Intervals that do not have an upper bound denote this by using None. The lower
-        # and upper bound must be of the same type.
+        "upper_bound",  # int or None, inclusive upper bound of integers in the interval.
+        # Intervals that do not have an upper bound denote this by using None.
     ),
 )
 
@@ -80,7 +79,7 @@ def _are_filter_fields_uniquely_indexed(filter_fields, unique_indexes):
 
 
 def _create_integer_interval(lower_bound, upper_bound):
-    """Return Interval for the given bounds, or None if the interval is empty.
+    """Return IntegerInterval for the given bounds, or None if the interval is empty.
 
     Args:
         lower_bound: int or None, describing the inclusive lower bound of the integer interval.
@@ -89,7 +88,7 @@ def _create_integer_interval(lower_bound, upper_bound):
                      If the bound does not exist, the argument value should be None.
 
     Returns:
-        - Interval namedtuple, describing the non-empty interval of integers between the two
+        - IntegerInterval namedtuple, describing the non-empty interval of integers between the two
           bounds.
         - None if the interval defined by the bounds is empty.
     """
@@ -98,7 +97,7 @@ def _create_integer_interval(lower_bound, upper_bound):
     if lower_bound is not None and upper_bound is not None and lower_bound > upper_bound:
         interval = None
     else:
-        interval = Interval(lower_bound, upper_bound)
+        interval = IntegerInterval(lower_bound, upper_bound)
 
     return interval
 
@@ -154,14 +153,14 @@ def _get_stronger_upper_bound(upper_bound_a, upper_bound_b):
 
 
 def _get_intersection_of_intervals(interval_a, interval_b):
-    """Return the intersection of two Intervals, or None if the intervals are disjoint.
+    """Return the intersection of two IntegerIntervals, or None if the intervals are disjoint.
 
     Args:
-        interval_a: None or Interval namedtuple. None means empty interval.
-        interval_b: None or Interval namedtuple. None means empty interval.
+        interval_a: None or IntegerInterval namedtuple. None means empty interval.
+        interval_b: None or IntegerInterval namedtuple. None means empty interval.
 
     Returns:
-        - Interval namedtuple, intersection of the two given Interval, if the
+        - IntegerInterval namedtuple, intersection of the two given IntegerIntervals, if the
           intersection is not empty.
         - None otherwise.
     """
@@ -175,17 +174,15 @@ def _get_intersection_of_intervals(interval_a, interval_b):
     return intersection
 
 
-def _get_query_interval_of_binary_integer_inequality_filter(
-    parameter_values: List[int], filter_operator
-):
-    """Return Interval or None of values passing through a binary integer inequality filter.
+def _get_query_interval_of_binary_integer_inequality_filter(parameter_values, filter_operator):
+    """Return IntegerInterval or None of values passing through a binary integer inequality filter.
 
     Args:
         parameter_values: List[int], describing the parameters for the inequality filter.
         filter_operator: str, describing the binary inequality filter operation being performed.
 
     Returns:
-        - Interval namedtuple, non-empty interval of int values that pass through the filter.
+        - IntegerInterval namedtuple, non-empty interval of values that pass through the filter.
         - None if the interval is empty.
 
     Raises:
@@ -219,14 +216,14 @@ def _get_query_interval_of_binary_integer_inequality_filter(
 
 
 def _get_query_interval_of_ternary_integer_inequality_filter(parameter_values, filter_operator):
-    """Return Interval or None of values passing through a ternary integer inequality filter.
+    """Return IntegerInterval or None of values passing through a ternary integer inequality filter.
 
     Args:
         parameter_values: List[int], describing the parameters for the inequality filter.
         filter_operator: str, describing the ternary inequality filter operation being performed.
 
     Returns:
-        - Interval namedtuple, non-empty interval of values that pass through the filter.
+        - IntegerInterval namedtuple, non-empty interval of values that pass through the filter.
         - None if the interval is empty.
 
     Raises:
@@ -254,14 +251,14 @@ def _get_query_interval_of_ternary_integer_inequality_filter(parameter_values, f
 
 
 def _get_query_interval_of_integer_inequality_filter(parameter_values, filter_operator):
-    """Return Interval or None of values passing through a given integer inequality filter.
+    """Return IntegerInterval or None of values passing through a given integer inequality filter.
 
     Args:
         parameter_values: List[int], describing the parameters for the inequality filter.
         filter_operator: str, describing the inequality filter operation being performed.
 
     Returns:
-        - Interval namedtuple, non-empty interval of values that pass through the filter.
+        - IntegerInterval namedtuple, non-empty interval of values that pass through the filter.
         - None if the interval is empty.
     """
     if len(parameter_values) == 1:
@@ -360,7 +357,7 @@ def _get_selectivity_fraction_of_interval(interval, quantiles):
     of the whole domain.
 
     Args:
-        interval: Interval defining the range of values
+        interval: IntegerInterval defining the range of values
         quantiles: a sorted list of N values separating the values of the field into N-1
                    groups of almost equal size. The first element of the list is the
                    smallest known value, and the last element is the largest known value.
@@ -403,7 +400,7 @@ def get_integer_interval_for_filters_on_field(
     location_name: str,
     field_name: str,
     parameters: Dict[str, Any],
-) -> Interval:
+) -> IntegerInterval:
     """Get the interval of possible values on this field, constrained by its inequality filters."""
     interval = _create_integer_interval(None, None)
     for filter_info in filters_on_field:
@@ -478,6 +475,8 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
                 )
             else:
                 # Get value interval
+                # HACK(bojanserafimov): Abuse of IntegerInterval spec. Constructed with non-interval
+                #                       endpoints. The type should be renamed to allow this usage.
                 lower_bound, upper_bound = None, None
                 if interval.lower_bound is not None:
                     lower_bound = convert_int_to_field_value(

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -89,7 +89,7 @@ def _create_integer_interval(lower_bound, upper_bound):
                      If the bound does not exist, the argument value should be None.
 
     Returns:
-        - Integer namedtuple, describing the non-empty interval of integers between the two
+        - Interval namedtuple, describing the non-empty interval of integers between the two
           bounds.
         - None if the interval defined by the bounds is empty.
     """
@@ -185,7 +185,7 @@ def _get_query_interval_of_binary_integer_inequality_filter(
         filter_operator: str, describing the binary inequality filter operation being performed.
 
     Returns:
-        - Integer namedtuple, non-empty interval of int values that pass through the filter.
+        - Interval namedtuple, non-empty interval of int values that pass through the filter.
         - None if the interval is empty.
 
     Raises:

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -401,6 +401,7 @@ def get_integer_interval_for_filters_on_field(
     field_name: str,
     parameters: Dict[str, Any],
 ) -> IntegerInterval:
+    """Get the interval of possible values on this field, constrained by its inequality filters."""
     interval = _create_integer_interval(None, None)
     for filter_info in filters_on_field:
         if filter_info.op_name in INEQUALITY_OPERATORS:


### PR DESCRIPTION
Context: The paginator returns a query describing the first page, and a query describing the rest of the results. The paginator can then be ran again on the remainder, producing the second page, and the remainder. This process continues until we run out of pages. However, to make sure we eventually run out of pages, the cost estimator must be able to understand any filters produced by the paginator. A useful sanity check is that the estimated number of pages of a paginator-generated page is one page.

To satisfy this property, both the paginator and the cost estimator will use the same range reasoning method, using the `int_value_conversion.py` module. In this PR I integrate this module into the cost estimator. In future PRs, the paginator will be built using the same `int_value_conversion` methods.

Since the generic range reasoning methods can reason about datetimes, the functionality of the cost estimator is implicitly extended, so I add a test with cost estimation on datetimes.