### PR TITLE
Implement pagination parameterizer

### DIFF
--- a/graphql_compiler/global_utils.py
+++ b/graphql_compiler/global_utils.py
@@ -1,6 +1,20 @@
 # Copyright 2017-present Kensho Technologies, LLC.
-from graphql import GraphQLList, GraphQLNamedType, GraphQLNonNull
+from dataclasses import dataclass
+from graphql import GraphQLList, GraphQLNamedType, GraphQLNonNull, DocumentNode
+from typing import Dict, Any
 import six
+
+
+@dataclass
+class QueryStringWithParameters:
+    query_string: str
+    parameters: Dict[str, Any]
+
+
+@dataclass
+class ASTWithParameters:
+    query_ast: DocumentNode
+    parameters: Dict[str, Any]
 
 
 def merge_non_overlapping_dicts(merge_target, new_data):

--- a/graphql_compiler/global_utils.py
+++ b/graphql_compiler/global_utils.py
@@ -1,13 +1,15 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 from dataclasses import dataclass
-from graphql import GraphQLList, GraphQLNamedType, GraphQLNonNull, DocumentNode
-from typing import Dict, Any
+from typing import Any, Dict
+
+from graphql import DocumentNode, GraphQLList, GraphQLNamedType, GraphQLNonNull
 import six
 
 
 @dataclass
 class QueryStringWithParameters:
     """A query string and parameters that validate against the query."""
+
     query_string: str
     parameters: Dict[str, Any]
 
@@ -15,6 +17,7 @@ class QueryStringWithParameters:
 @dataclass
 class ASTWithParameters:
     """A query AST and parameters that validate against the query."""
+
     query_ast: DocumentNode
     parameters: Dict[str, Any]
 

--- a/graphql_compiler/global_utils.py
+++ b/graphql_compiler/global_utils.py
@@ -7,12 +7,14 @@ import six
 
 @dataclass
 class QueryStringWithParameters:
+    """A query string and parameters that validate against the query."""
     query_string: str
     parameters: Dict[str, Any]
 
 
 @dataclass
 class ASTWithParameters:
+    """A query AST and parameters that validate against the query."""
     query_ast: DocumentNode
     parameters: Dict[str, Any]
 

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -1,14 +1,10 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from collections import namedtuple
-
 from graphql.language.printer import print_ast
 
-from ..global_utils import QueryStringWithParameters, ASTWithParameters
 from ..ast_manipulation import safe_parse_graphql
 from ..cost_estimation.cardinality_estimator import estimate_number_of_pages
-from ..query_pagination.query_splitter import (
-    split_into_page_query_and_remainder_query,
-)
+from ..global_utils import ASTWithParameters, QueryStringWithParameters
+from ..query_pagination.query_splitter import split_into_page_query_and_remainder_query
 
 
 def paginate_query_ast(schema_info, query_ast, parameters, page_size):

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -3,20 +3,11 @@ from collections import namedtuple
 
 from graphql.language.printer import print_ast
 
+from ..global_utils import QueryStringWithParameters, ASTWithParameters
 from ..ast_manipulation import safe_parse_graphql
 from ..cost_estimation.cardinality_estimator import estimate_number_of_pages
 from ..query_pagination.query_splitter import (
-    ASTWithParameters,
     split_into_page_query_and_remainder_query,
-)
-
-
-QueryStringWithParameters = namedtuple(
-    "QueryStringWithParameters",
-    (
-        "query_string",  # str, describing a GraphQL query.
-        "parameters",  # dict, parameters for executing the given query.
-    ),
 )
 
 
@@ -61,7 +52,7 @@ def paginate_query_ast(schema_info, query_ast, parameters, page_size):
     num_pages = estimate_number_of_pages(schema_info, graphql_query_string, parameters, page_size)
     if num_pages > 1:
         result_queries = split_into_page_query_and_remainder_query(
-            schema_info, query_ast, parameters, num_pages
+            schema_info, ASTWithParameters(query_ast, parameters), num_pages
         )
 
     return result_queries

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -238,29 +238,3 @@ def generate_parameters_for_vertex_partition(
         return _compute_parameters_for_non_uuid_field(
             schema_info, field_value_interval, vertex_partition, vertex_type, pagination_field
         )
-
-
-def generate_parameters_for_parameterized_query(
-    schema_info, parameterized_pagination_queries, num_pages
-):
-    """Generate parameters for the given parameterized pagination queries.
-
-    Args:
-        schema_info: QueryPlanningSchemaInfo
-        parameterized_pagination_queries: ParameterizedPaginationQueries namedtuple, parameterized
-                                          queries for which parameters are being generated.
-        num_pages: int, number of pages to split the query into.
-
-    Returns:
-        two dicts:
-            - dict, parameters with which to execute the page query. The next page query's
-              parameters are generated such that only a page of the original query's result data is
-              produced when executed.
-            - dict, parameters with which to execute the remainder query. The remainder query
-              parameters are generated such that they produce the remainder of the original query's
-              result data when executed.
-    """
-    # TODO(bojanserafimov): Replace this method with generate_parameters_for_vertex_partition. Its
-    #                       api is simpler (no dependence on parameterization), and it uses the
-    #                       VertexPartitionPlan.
-    raise NotImplementedError()

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -1,7 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 import bisect
 import itertools
-from typing import Any, Dict, Iterable, cast
+from typing import Any, Dict, Iterator, cast
 
 from graphql import DocumentNode
 from graphql.language.printer import print_ast
@@ -20,7 +20,7 @@ from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import VertexPartitionPlan
 
 
-def _sum_partition(number: int, num_splits: int) -> Iterable[int]:
+def _sum_partition(number: int, num_splits: int) -> Iterator[int]:
     """Represent an integer as a sum of N almost equal integers, sorted in descending order.
 
     Example: _sum_partition(5, 3) = [2, 2, 1]
@@ -43,7 +43,7 @@ def _sum_partition(number: int, num_splits: int) -> Iterable[int]:
     )
 
 
-def _deduplicate_sorted_generator(generator: Iterable[Any]) -> Iterable[Any]:
+def _deduplicate_sorted_generator(generator: Iterator[Any]) -> Iterator[Any]:
     """Return a generator that skips repeated values in the given sorted generator."""
     prev = object()
     for i in generator:
@@ -75,7 +75,7 @@ def _compute_parameters_for_uuid_field(
     vertex_partition: VertexPartitionPlan,
     vertex_type: str,
     field: str,
-) -> Iterable[Any]:
+) -> Iterator[Any]:
     """Return a generator of parameter values for the vertex partition at a uuid field.
 
     See generate_parameters_for_vertex_partition for more details.
@@ -118,7 +118,7 @@ def _compute_parameters_for_non_uuid_field(
     vertex_partition: VertexPartitionPlan,
     vertex_type: str,
     field: str,
-) -> Iterable[Any]:
+) -> Iterator[Any]:
     """Return a generator of parameter values for the vertex partition at a non-uuid field.
 
     See generate_parameters_for_vertex_partition for more details.
@@ -179,7 +179,7 @@ def generate_parameters_for_vertex_partition(
     query_ast: DocumentNode,
     parameters: Dict[str, Any],
     vertex_partition: VertexPartitionPlan,
-) -> Iterable[Any]:
+) -> Iterator[Any]:
     """Return a generator of parameter values that realize the vertex partition.
 
     Composability guarantee: The values returned can be used to create

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -94,10 +94,7 @@ def _make_directive(op_name, param_name):
     return DirectiveNode(
         name=NameNode(value="filter"),
         arguments=[
-            ArgumentNode(
-                name=NameNode(value="op_name"),
-                value=StringValueNode(value=op_name),
-            ),
+            ArgumentNode(name=NameNode(value="op_name"), value=StringValueNode(value=op_name),),
             ArgumentNode(
                 name=NameNode(value="value"),
                 value=ListValueNode(values=[StringValueNode(value="$" + param_name)]),
@@ -122,17 +119,25 @@ def generate_parameterized_queries(schema_info, query_ast, parameters, vertex_pa
     query_type = get_only_query_definition(query_ast, GraphQLError)
 
     param_name = _generate_new_name("__paged_param", parameters.keys())
-    next_page_ast = DocumentNode(definitions=[_add_pagination_filters(
-        query_type,
-        vertex_partition.query_path,
-        vertex_partition.pagination_field,
-        _make_directive("<", param_name),
-    )])
-    remainder_ast = DocumentNode(definitions=[_add_pagination_filters(
-        query_type,
-        vertex_partition.query_path,
-        vertex_partition.pagination_field,
-        _make_directive(">=", param_name),
-    )])
+    next_page_ast = DocumentNode(
+        definitions=[
+            _add_pagination_filters(
+                query_type,
+                vertex_partition.query_path,
+                vertex_partition.pagination_field,
+                _make_directive("<", param_name),
+            )
+        ]
+    )
+    remainder_ast = DocumentNode(
+        definitions=[
+            _add_pagination_filters(
+                query_type,
+                vertex_partition.query_path,
+                vertex_partition.pagination_field,
+                _make_directive(">=", param_name),
+            )
+        ]
+    )
 
     return next_page_ast, remainder_ast, param_name

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -90,8 +90,7 @@ def _add_pagination_filters(query_ast, query_path, pagination_field, directive_t
     return new_ast
 
 
-def _make_directive(param_name, lower_page):
-    op_name = "<" if lower_page else ">="
+def _make_directive(op_name, param_name):
     return DirectiveNode(
         name=NameNode(value="filter"),
         arguments=[
@@ -123,20 +122,17 @@ def generate_parameterized_queries(schema_info, query_ast, parameters, vertex_pa
     query_type = get_only_query_definition(query_ast, GraphQLError)
 
     param_name = _generate_new_name("__paged_param", parameters.keys())
-    lower_page_directive = _make_directive(param_name, True)
-    upper_page_directive = _make_directive(param_name, False)
-
     next_page_ast = DocumentNode(definitions=[_add_pagination_filters(
         query_type,
         vertex_partition.query_path,
         vertex_partition.pagination_field,
-        lower_page_directive,
+        _make_directive("<", param_name),
     )])
     remainder_ast = DocumentNode(definitions=[_add_pagination_filters(
         query_type,
         vertex_partition.query_path,
         vertex_partition.pagination_field,
-        upper_page_directive,
+        _make_directive(">=", param_name),
     )])
 
     return next_page_ast, remainder_ast, param_name

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -164,9 +164,7 @@ def generate_parameterized_queries(
 
     Returns:
         next_page_ast: Ast for the first page. Includes an additional filter.
-        next_page_removed_params: ???
         remainder_ast: Ast for the remainder query. Includes an additional filter.
-        remainder_removed_params: ???
         param_name: The parameter name used in the new filters.
     """
     query_type = get_only_query_definition(query_ast, GraphQLError)

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -1,7 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from collections import namedtuple
 from copy import copy
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, cast
+from typing import Any, Dict, List, Set, Tuple, cast
 
 from graphql.language.ast import (
     ArgumentNode,
@@ -46,7 +45,7 @@ def _get_binary_filter_node_parameter(filter_directive: DirectiveNode) -> str:
     """Return the parameter name for a binary Filter Directive."""
     filter_arguments = cast(ListValueNode, filter_directive.arguments[1].value).values
     if len(filter_arguments) != 1:
-        raise AssertionError(u"Expected one argument in filter {}".format(filter_directive))
+        raise AssertionError("Expected one argument in filter {}".format(filter_directive))
 
     argument_name = cast(StringValueNode, filter_arguments[0]).value
     parameter_name = get_parameter_name(argument_name)
@@ -79,8 +78,7 @@ def _add_pagination_filter(
     """
     if not isinstance(query_ast, (FieldNode, InlineFragmentNode, OperationDefinitionNode)):
         raise AssertionError(
-            u'Input AST is of type "{}", which should not be a selection.'
-            u"".format(type(query_ast).__name__)
+            f'Input AST is of type "{type(query_ast).__name__}", which should not be a selection.'
         )
 
     removed_parameters = []
@@ -170,13 +168,13 @@ def generate_parameterized_queries(
     query_type = get_only_query_definition(query_ast, GraphQLError)
 
     param_name = _generate_new_name("__paged_param", set(parameters.keys()))
-    next_page_root, next_page_removed_param_names = _add_pagination_filter(
+    next_page_root, _ = _add_pagination_filter(
         query_type,
         vertex_partition.query_path,
         vertex_partition.pagination_field,
         _make_binary_filter_directive_node("<", param_name),
     )
-    remainder_root, remainder_removed_param_names = _add_pagination_filter(
+    remainder_root, _ = _add_pagination_filter(
         query_type,
         vertex_partition.query_path,
         vertex_partition.pagination_field,

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -281,7 +281,8 @@ def generate_parameterized_queries(
     Returns:
         tuple (next_page, remainder)
         next_page: AST and params for next page.
-        remainder: AST and params for the remainder query that returns all results not on the next page.
+        remainder: AST and params for the remainder query that returns all results
+                   not on the next page.
     """
     query_string = print_ast(query.query_ast)
     query_root = get_only_query_definition(query.query_ast, GraphQLError)

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -1,6 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from copy import copy
-from typing import Any, Dict, List, Set, Tuple, cast
+from typing import Any, Dict, Set, Tuple, cast
 
 from graphql.language.ast import (
     ArgumentNode,
@@ -15,10 +15,10 @@ from graphql.language.ast import (
     StringValueNode,
 )
 
-from ..global_utils import ASTWithParameters
 from ..ast_manipulation import get_ast_field_name, get_only_query_definition
 from ..compiler.helpers import get_parameter_name
 from ..exceptions import GraphQLError
+from ..global_utils import ASTWithParameters
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import VertexPartitionPlan
 
@@ -60,18 +60,18 @@ def _get_filter_node_operation(filter_directive: DirectiveNode) -> str:
 
 def _is_new_filter_stronger(operation, new_filter_value, old_filter_value):
     # TODO assert types are comparable
-    if operation == '<':
+    if operation == "<":
         return new_filter_value <= old_filter_value
-    elif operation == '>=':
+    elif operation == ">=":
         return new_filter_value >= old_filter_value
     else:
         raise NotImplementedError()
 
 
 def _is_filter_redundant(filter_operation_1, filter_operation_2):
-    if filter_operation_1 == '<' and filter_operation_2 == '<':
+    if filter_operation_1 == "<" and filter_operation_2 == "<":
         return True
-    if filter_operation_1 == '>=' and filter_operation_2 == '>=':
+    if filter_operation_1 == ">=" and filter_operation_2 == ">=":
         return True
     return False
 
@@ -82,7 +82,7 @@ def _add_pagination_filter(
     pagination_field: str,
     directive_to_add: DirectiveNode,
     extended_parameters: Dict[str, Any],
-) -> Tuple[DocumentNode, List[str]]:
+) -> Tuple[DocumentNode, Dict[str, Any]]:
     """Add the filter to the target field, returning a query and the names of removed filters.
 
     Args:
@@ -127,7 +127,9 @@ def _add_pagination_filter(
                     if _is_filter_redundant(new_directive_operation, operation):
                         parameter_name = _get_binary_filter_node_parameter(directive)
                         parameter_value = new_parameters[parameter_name]
-                        if not _is_new_filter_stronger(operation, new_directive_parameter_value, parameter_value):
+                        if not _is_new_filter_stronger(
+                            operation, new_directive_parameter_value, parameter_value
+                        ):
                             raise AssertionError()
                         del new_parameters[parameter_name]
                     else:
@@ -152,7 +154,11 @@ def _add_pagination_filter(
             if field_name == query_path[0]:
                 found_field = True
                 new_selection_ast, new_parameters = _add_pagination_filter(
-                    selection_ast, query_path[1:], pagination_field, directive_to_add, extended_parameters
+                    selection_ast,
+                    query_path[1:],
+                    pagination_field,
+                    directive_to_add,
+                    extended_parameters,
                 )
             new_selections.append(new_selection_ast)
 

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -84,7 +84,7 @@ def _add_pagination_filter_at_node(
     directive_to_add: DirectiveNode,
     extended_parameters: Dict[str, Any],
 ) -> Tuple[DocumentNode, Dict[str, Any]]:
-    """Add the filter to the target field, returning a query and its new parameters
+    """Add the filter to the target field, returning a query and its new parameters.
 
     Args:
         query_ast: The query in which we are adding a filter

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -105,14 +105,17 @@ def _make_directive(op_name, param_name):
 
 def generate_parameterized_queries(schema_info, query_ast, parameters, vertex_partition):
     """Generate two parameterized queries that can be used to paginate over a given query.
+
     In order to paginate arbitrary GraphQL queries, additional filters may need to be added to be
     able to limit the number of results in the original query. This function creates two new queries
     with additional filters stored as PaginationFilters with which the query result size can be
     controlled.
+
     Args:
         schema_info: QueryPlanningSchemaInfo
         query_ast: Document, query that is being paginated.
         parameters: dict, list of parameters for the given query.
+
     Returns:
         ParameterizedPaginationQueries namedtuple
     """

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -162,7 +162,6 @@ def generate_parameterized_queries(
         vertex_partition: pagination plan
 
     Returns:
-        # TODO use ASTWithParameters struct to simplify API
         next_page: Ast and params for next page.
         remainder_ast: Ast and params for remainder.
         param_name: The parameter name used in the new filters.

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -84,6 +84,7 @@ def _add_pagination_filter(
     removed_parameters = []
     new_selections = []
     if len(query_path) == 0:
+        # Add the filter to the correct field on this vertex and remove any redundant filters.
         found_field = False
         for selection_ast in query_ast.selection_set.selections:
             new_selection_ast = selection_ast
@@ -108,6 +109,7 @@ def _add_pagination_filter(
                 0, FieldNode(name=NameNode(value=pagination_field), directives=[directive_to_add])
             )
     else:
+        # Recurse until the target vertex is reached.
         if query_ast.selection_set is None:
             raise AssertionError()
 

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -66,8 +66,7 @@ def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters
     remainder_parameters = dict(parameters)
     remainder_parameters.update({param_name: first_param})
 
-    # Function is complete, but not tested.
-    raise NotImplementedError(
+    return (
         ASTWithParameters(page_query, page_parameters),
         ASTWithParameters(remainder_query, remainder_parameters),
     )

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -1,36 +1,34 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
-from graphql_compiler.query_pagination.parameter_generator import (
-    generate_parameters_for_parameterized_query,
+from .parameter_generator import (
+    generate_parameters_for_vertex_partition
 )
-from graphql_compiler.query_pagination.query_parameterizer import generate_parameterized_queries
+from .query_parameterizer import generate_parameterized_queries
+from .pagination_planning import get_pagination_plan
 
 
 ASTWithParameters = namedtuple(
-    "ASTWithParameters",
+    'ASTWithParameters',
     (
-        "query_ast",  # Document, AST describing a GraphQL query.
-        "parameters",  # dict, parameters for executing the given query.
+        'query_ast',        # Document, AST describing a GraphQL query.
+        'parameters',       # dict, parameters for executing the given query.
     ),
 )
 
 
 def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters, num_pages):
     """Split a query into two equivalent queries, one of which will return roughly a page of data.
-
     First, two parameterized queries are generated that contain filters usable for pagination i.e.
     filters with which the number of results can be constrained. Parameters for these filters are
     then generated such that one of the new queries will return roughly a page of results, while the
     other query will generate the rest of the results. This ensures that the two new queries' result
     data is equivalent to the original query's result data.
-
     Args:
         schema_info: QueryPlanningSchemaInfo
         query_ast: Document, AST of the GraphQL query that will be split.
         parameters: dict, parameters with which query will be estimated.
         num_pages: int, number of pages to split the query into.
-
     Returns:
         tuple of (ASTWithParameters namedtuple, ASTWithParameters namedtuple), describing two
         queries: the first query when executed will return roughly a page of results of the original
@@ -39,24 +37,32 @@ def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters
         data. There are no guarantees on the order of the result rows for the two generated queries.
     """
     if num_pages <= 1:
-        raise AssertionError(
-            u"Could not split query {} into pagination queries for the next page"
-            u" of results, as the number of pages {} must be greater than 1: {}".format(
-                query_ast, num_pages, parameters
-            )
-        )
+        raise AssertionError(u'Could not split query {} into pagination queries for the next page'
+                             u' of results, as the number of pages {} must be greater than 1: {}'
+                             .format(query_ast, num_pages, parameters))
 
-    parameterized_queries = generate_parameterized_queries(schema_info, query_ast, parameters)
+    pagination_plan, advisories = get_pagination_plan(schema_info, query_ast, num_pages)
+    if len(pagination_plan.vertex_partitions) != 1:
+        raise NotImplementedError(u'We only support pagination plans with one vertex partition. '
+                                  u'Reveived {}'.format(pagination_plan))
 
-    next_page_parameters, remainder_parameters = generate_parameters_for_parameterized_query(
-        schema_info, parameterized_queries, num_pages
+    parameter_generator = generate_parameters_for_vertex_partition(
+        schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0])
+    first_param = next(parameter_generator)
+
+    (page_query, page_param), (remainder_query, remainder_param) = generate_parameterized_queries(
+        schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0])
+
+    page_parameters = dict(parameters)
+    page_parameters.update({
+        page_param: first_param
+    })
+    remainder_parameters = dict(parameters)
+    remainder_parameters.update({
+        remainder_param: first_param
+    })
+    raise NotImplementedError()
+    return (
+        ASTWithParameters(page_query, page_parameters),
+        ASTWithParameters(remainder_query, remainder_parameters),
     )
-
-    next_page_ast_with_parameters = ASTWithParameters(
-        parameterized_queries.page_query, next_page_parameters
-    )
-    remainder_ast_with_parameters = ASTWithParameters(
-        parameterized_queries.remainder_query, remainder_parameters,
-    )
-
-    return next_page_ast_with_parameters, remainder_ast_with_parameters

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -1,18 +1,16 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
 
-from .parameter_generator import (
-    generate_parameters_for_vertex_partition
-)
-from .query_parameterizer import generate_parameterized_queries
 from .pagination_planning import get_pagination_plan
+from .parameter_generator import generate_parameters_for_vertex_partition
+from .query_parameterizer import generate_parameterized_queries
 
 
 ASTWithParameters = namedtuple(
-    'ASTWithParameters',
+    "ASTWithParameters",
     (
-        'query_ast',        # Document, AST describing a GraphQL query.
-        'parameters',       # dict, parameters for executing the given query.
+        "query_ast",  # Document, AST describing a GraphQL query.
+        "parameters",  # dict, parameters for executing the given query.
     ),
 )
 
@@ -37,30 +35,33 @@ def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters
         data. There are no guarantees on the order of the result rows for the two generated queries.
     """
     if num_pages <= 1:
-        raise AssertionError(u'Could not split query {} into pagination queries for the next page'
-                             u' of results, as the number of pages {} must be greater than 1: {}'
-                             .format(query_ast, num_pages, parameters))
+        raise AssertionError(
+            u"Could not split query {} into pagination queries for the next page"
+            u" of results, as the number of pages {} must be greater than 1: {}".format(
+                query_ast, num_pages, parameters
+            )
+        )
 
     pagination_plan, advisories = get_pagination_plan(schema_info, query_ast, num_pages)
     if len(pagination_plan.vertex_partitions) != 1:
-        raise NotImplementedError(u'We only support pagination plans with one vertex partition. '
-                                  u'Reveived {}'.format(pagination_plan))
+        raise NotImplementedError(
+            u"We only support pagination plans with one vertex partition. "
+            u"Reveived {}".format(pagination_plan)
+        )
 
     parameter_generator = generate_parameters_for_vertex_partition(
-        schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0])
+        schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0]
+    )
     first_param = next(parameter_generator)
 
     page_query, remainder_query, param_name = generate_parameterized_queries(
-        schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0])
+        schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0]
+    )
 
     page_parameters = dict(parameters)
-    page_parameters.update({
-        param_name: first_param
-    })
+    page_parameters.update({param_name: first_param})
     remainder_parameters = dict(parameters)
-    remainder_parameters.update({
-        param_name: first_param
-    })
+    remainder_parameters.update({param_name: first_param})
 
     # Function is complete, but not tested.
     raise NotImplementedError(

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -1,13 +1,14 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from collections import namedtuple
-
 from ..global_utils import ASTWithParameters
+from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import get_pagination_plan
 from .parameter_generator import generate_parameters_for_vertex_partition
 from .query_parameterizer import generate_parameterized_queries
 
 
-def split_into_page_query_and_remainder_query(schema_info, query, num_pages):
+def split_into_page_query_and_remainder_query(
+    schema_info: QueryPlanningSchemaInfo, query: ASTWithParameters, num_pages: int
+):
     """Split a query into two equivalent queries, one of which will return roughly a page of data.
 
     First, two parameterized queries are generated that contain filters usable for pagination i.e.
@@ -32,7 +33,7 @@ def split_into_page_query_and_remainder_query(schema_info, query, num_pages):
         raise AssertionError(
             u"Could not split query {} into pagination queries for the next page"
             u" of results, as the number of pages {} must be greater than 1: {}".format(
-                query_ast, num_pages, parameters
+                query.query_ast, num_pages, query.parameters
             )
         )
 
@@ -50,4 +51,5 @@ def split_into_page_query_and_remainder_query(schema_info, query, num_pages):
     first_param = next(parameter_generator)
 
     return generate_parameterized_queries(
-        schema_info, query, pagination_plan.vertex_partitions[0], first_param)
+        schema_info, query, pagination_plan.vertex_partitions[0], first_param
+    )

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -61,8 +61,9 @@ def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters
     remainder_parameters.update({
         param_name: first_param
     })
-    raise NotImplementedError()
-    return (
+
+    # Function is complete, but not tested.
+    raise NotImplementedError(
         ASTWithParameters(page_query, page_parameters),
         ASTWithParameters(remainder_query, remainder_parameters),
     )

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -45,7 +45,8 @@ def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters
             )
         )
 
-    pagination_plan, advisories = get_pagination_plan(schema_info, query_ast, num_pages)
+    # TODO propagate advisories to top-level
+    pagination_plan, _ = get_pagination_plan(schema_info, query_ast, num_pages)
     if len(pagination_plan.vertex_partitions) != 1:
         raise NotImplementedError(
             u"We only support pagination plans with one vertex partition. "
@@ -57,13 +58,17 @@ def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters
     )
     first_param = next(parameter_generator)
 
-    page_query, remainder_query, param_name = generate_parameterized_queries(
+    (
+        (page_query, page_parameters),
+        (remainder_query, remainder_parameters),
+        param_name,
+    ) = generate_parameterized_queries(
         schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0]
     )
 
-    page_parameters = dict(parameters)
+    page_parameters = dict(page_parameters)
     page_parameters.update({param_name: first_param})
-    remainder_parameters = dict(parameters)
+    remainder_parameters = dict(remainder_parameters)
     remainder_parameters.update({param_name: first_param})
 
     return (

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -50,16 +50,16 @@ def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters
         schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0])
     first_param = next(parameter_generator)
 
-    (page_query, page_param), (remainder_query, remainder_param) = generate_parameterized_queries(
+    page_query, remainder_query, param_name = generate_parameterized_queries(
         schema_info, query_ast, parameters, pagination_plan.vertex_partitions[0])
 
     page_parameters = dict(parameters)
     page_parameters.update({
-        page_param: first_param
+        param_name: first_param
     })
     remainder_parameters = dict(parameters)
     remainder_parameters.update({
-        remainder_param: first_param
+        param_name: first_param
     })
     raise NotImplementedError()
     return (

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -22,11 +22,13 @@ def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters
     then generated such that one of the new queries will return roughly a page of results, while the
     other query will generate the rest of the results. This ensures that the two new queries' result
     data is equivalent to the original query's result data.
+
     Args:
         schema_info: QueryPlanningSchemaInfo
         query_ast: Document, AST of the GraphQL query that will be split.
         parameters: dict, parameters with which query will be estimated.
         num_pages: int, number of pages to split the query into.
+
     Returns:
         tuple of (ASTWithParameters namedtuple, ASTWithParameters namedtuple), describing two
         queries: the first query when executed will return roughly a page of results of the original

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -49,15 +49,5 @@ def split_into_page_query_and_remainder_query(schema_info, query, num_pages):
     )
     first_param = next(parameter_generator)
 
-    page, remainder, param_name = generate_parameterized_queries(
-        schema_info, query, pagination_plan.vertex_partitions[0])
-
-    page_parameters = dict(page.parameters)
-    page_parameters.update({param_name: first_param})
-    remainder_parameters = dict(remainder.parameters)
-    remainder_parameters.update({param_name: first_param})
-
-    return (
-        ASTWithParameters(page.query_ast, page_parameters),
-        ASTWithParameters(remainder.query_ast, remainder_parameters),
-    )
+    return generate_parameterized_queries(
+        schema_info, query, pagination_plan.vertex_partitions[0], first_param)

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -17,6 +17,7 @@ ASTWithParameters = namedtuple(
 
 def split_into_page_query_and_remainder_query(schema_info, query_ast, parameters, num_pages):
     """Split a query into two equivalent queries, one of which will return roughly a page of data.
+
     First, two parameterized queries are generated that contain filters usable for pagination i.e.
     filters with which the number of results can be constrained. Parameters for these filters are
     then generated such that one of the new queries will return roughly a page of results, while the

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -492,9 +492,7 @@ class QueryPaginationTests(unittest.TestCase):
                      @filter(op_name: "!=", value: ["$__paged_param_0"])
             }
         }"""
-        args = {
-            '__paged_param_0': 'Cow'
-        }
+        args = {"__paged_param_0": "Cow"}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
         next_page_ast, remainder_ast, param_name = generate_parameterized_queries(
@@ -548,7 +546,7 @@ class QueryPaginationTests(unittest.TestCase):
             }
         }"""
         args = {
-            'limbs_more_than': 100,
+            "limbs_more_than": 100,
         }
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -6,11 +6,11 @@ import unittest
 from graphql import print_ast
 import pytest
 
-from ...global_utils import ASTWithParameters, QueryStringWithParameters
 from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.cardinality_estimator import estimate_query_result_cardinality
 from ...cost_estimation.statistics import LocalStatistics
-from ...query_pagination import QueryStringWithParameters, paginate_query
+from ...global_utils import ASTWithParameters, QueryStringWithParameters
+from ...query_pagination import paginate_query
 from ...query_pagination.pagination_planning import (
     InsufficientQuantiles,
     PaginationAdvisory,
@@ -505,7 +505,6 @@ class QueryPaginationTests(unittest.TestCase):
                 name @output(out_name: "species_name")
             }
         }"""
-        expected_param_name = "__paged_param_0"
         compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
         compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))
 
@@ -557,7 +556,6 @@ class QueryPaginationTests(unittest.TestCase):
                      @filter(op_name: "!=", value: ["$__paged_param_0"])
             }
         }"""
-        expected_param_name = "__paged_param_1"
         compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
         compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))
 
@@ -610,6 +608,5 @@ class QueryPaginationTests(unittest.TestCase):
                 name @output(out_name: "species_name")
             }
         }"""
-        expected_param_name = "__paged_param_0"
         compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
         compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -7,8 +7,8 @@ from graphql import print_ast
 import pytest
 
 from ...ast_manipulation import safe_parse_graphql
-from ...cost_estimation.statistics import LocalStatistics
 from ...cost_estimation.cardinality_estimator import estimate_query_result_cardinality
+from ...cost_estimation.statistics import LocalStatistics
 from ...query_pagination import QueryStringWithParameters, paginate_query
 from ...query_pagination.pagination_planning import (
     InsufficientQuantiles,
@@ -159,9 +159,7 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_fields=uuid4_fields,
         )
 
-        first, remainder = paginate_query(
-            schema_info, test_data, parameters, 1
-        )
+        first, remainder = paginate_query(schema_info, test_data, parameters, 1)
 
         expected_first = QueryStringWithParameters(
             """{
@@ -191,36 +189,36 @@ class QueryPaginationTests(unittest.TestCase):
 
         # Check that the first page is estimated to fit into a page
         first_page_cardinality_estimate = estimate_query_result_cardinality(
-            schema_info, first.query_string, first.parameters)
+            schema_info, first.query_string, first.parameters
+        )
         self.assertAlmostEqual(1, first_page_cardinality_estimate)
 
         # Get the second page
         second, remainder = paginate_query(
-            schema_info, remainder.query_string, remainder.parameters, 1)
+            schema_info, remainder.query_string, remainder.parameters, 1
+        )
 
         expected_second = QueryStringWithParameters(
-            '''{
+            """{
                 Animal {
                     uuid @filter(op_name: ">=", value: ["$__paged_param_0"])
                          @filter(op_name: "<", value: ["$__paged_param_1"])
                     name @output(out_name: "animal")
                 }
-            }''',
+            }""",
             {
-                '__paged_param_0': '40000000-0000-0000-0000-000000000000',
-                '__paged_param_1': '80000000-0000-0000-0000-000000000000',
+                "__paged_param_0": "40000000-0000-0000-0000-000000000000",
+                "__paged_param_1": "80000000-0000-0000-0000-000000000000",
             },
         )
         expected_remainder = QueryStringWithParameters(
-            '''{
+            """{
                 Animal {
                     uuid @filter(op_name: ">=", value: ["$__paged_param_1"])
                     name @output(out_name: "animal")
                 }
-            }''',
-            {
-                '__paged_param_1': '80000000-0000-0000-0000-000000000000',
-            },
+            }""",
+            {"__paged_param_1": "80000000-0000-0000-0000-000000000000",},
         )
 
         # Check that the correct queries are generated
@@ -231,7 +229,8 @@ class QueryPaginationTests(unittest.TestCase):
 
         # Check that the second page is estimated to fit into a page
         second_page_cardinality_estimate = estimate_query_result_cardinality(
-            schema_info, second.query_string, second.parameters)
+            schema_info, second.query_string, second.parameters
+        )
         self.assertAlmostEqual(1, second_page_cardinality_estimate)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
@@ -489,7 +488,7 @@ class QueryPaginationTests(unittest.TestCase):
         args = {}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        next_page_ast, remainder_ast, param_name = generate_parameterized_queries(
+        (next_page_ast, _), (remainder_ast, _), param_name = generate_parameterized_queries(
             schema_info, query_ast, args, vertex_partition
         )
 
@@ -540,7 +539,7 @@ class QueryPaginationTests(unittest.TestCase):
         args = {"__paged_param_0": "Cow"}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        next_page_ast, remainder_ast, param_name = generate_parameterized_queries(
+        (next_page_ast, _), (remainder_ast, _), param_name = generate_parameterized_queries(
             schema_info, query_ast, args, vertex_partition
         )
 
@@ -595,7 +594,7 @@ class QueryPaginationTests(unittest.TestCase):
         }
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        next_page_ast, remainder_ast, param_name = generate_parameterized_queries(
+        (next_page_ast, _), (remainder_ast, _), param_name = generate_parameterized_queries(
             schema_info, query_ast, args, vertex_partition
         )
 

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -489,8 +489,8 @@ class QueryPaginationTests(unittest.TestCase):
         args = {}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        next_page, remainder, param_name = generate_parameterized_queries(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
+        next_page, remainder = generate_parameterized_queries(
+            schema_info, ASTWithParameters(query_ast, args), vertex_partition, 100
         )
 
         expected_next_page = """{
@@ -508,7 +508,6 @@ class QueryPaginationTests(unittest.TestCase):
         expected_param_name = "__paged_param_0"
         compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
         compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))
-        self.assertEqual(expected_param_name, param_name)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_query_parameterizer_name_conflict(self):
@@ -540,8 +539,8 @@ class QueryPaginationTests(unittest.TestCase):
         args = {"__paged_param_0": "Cow"}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        next_page, remainder, param_name = generate_parameterized_queries(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
+        next_page, remainder = generate_parameterized_queries(
+            schema_info, ASTWithParameters(query_ast, args), vertex_partition, 100
         )
 
         expected_next_page = """{
@@ -561,7 +560,6 @@ class QueryPaginationTests(unittest.TestCase):
         expected_param_name = "__paged_param_1"
         compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
         compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))
-        self.assertEqual(expected_param_name, param_name)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_query_parameterizer_filter_deduplication(self):
@@ -595,8 +593,8 @@ class QueryPaginationTests(unittest.TestCase):
         }
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        next_page, remainder, param_name = generate_parameterized_queries(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
+        next_page, remainder = generate_parameterized_queries(
+            schema_info, ASTWithParameters(query_ast, args), vertex_partition, 100
         )
 
         expected_next_page = """{
@@ -615,4 +613,3 @@ class QueryPaginationTests(unittest.TestCase):
         expected_param_name = "__paged_param_0"
         compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
         compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))
-        self.assertEqual(expected_param_name, param_name)

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -519,3 +519,57 @@ class QueryPaginationTests(unittest.TestCase):
         compare_graphql(self, expected_next_page, print_ast(next_page_ast))
         compare_graphql(self, expected_remainder, print_ast(remainder_ast))
         self.assertEqual(expected_param_name, param_name)
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_query_parameterizer_filter_deduplication(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {"Species": 1000}
+        statistics = LocalStatistics(
+            class_counts,
+            field_quantiles={("Species", "limbs"): [0 for i in range(1000)] + list(range(101))},
+        )
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields,
+        )
+
+        query = """{
+            Species {
+                limbs @filter(op_name: ">=", value: ["$limbs_more_than"])
+                name @output(out_name: "species_name")
+            }
+        }"""
+        args = {
+            'limbs_more_than': 100,
+        }
+        query_ast = safe_parse_graphql(query)
+        vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
+        next_page_ast, remainder_ast, param_name = generate_parameterized_queries(
+            schema_info, query_ast, args, vertex_partition
+        )
+
+        expected_next_page = """{
+            Species {
+                limbs @filter(op_name: ">=", value: ["$limbs_more_than"])
+                      @filter(op_name: "<", value: ["$__paged_param_0"])
+                name @output(out_name: "species_name")
+            }
+        }"""
+        expected_remainder = """{
+            Species {
+                limbs @filter(op_name: ">=", value: ["$__paged_param_0"])
+                name @output(out_name: "species_name")
+            }
+        }"""
+        expected_param_name = "__paged_param_0"
+        compare_graphql(self, expected_next_page, print_ast(next_page_ast))
+        compare_graphql(self, expected_remainder, print_ast(remainder_ast))
+        self.assertEqual(expected_param_name, param_name)

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -3,8 +3,8 @@ import datetime
 from typing import Any, Dict, Tuple
 import unittest
 
-import pytest
 from graphql import print_ast
+import pytest
 
 from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.statistics import LocalStatistics
@@ -20,7 +20,7 @@ from ...query_pagination.parameter_generator import generate_parameters_for_vert
 from ...query_pagination.query_parameterizer import generate_parameterized_queries
 from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
-from ..test_helpers import generate_schema_graph, compare_graphql
+from ..test_helpers import compare_graphql, generate_schema_graph
 
 
 # The following TestCase class uses the 'snapshot_orientdb_client' fixture
@@ -445,7 +445,8 @@ class QueryPaginationTests(unittest.TestCase):
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
         next_page_ast, remainder_ast, param_name = generate_parameterized_queries(
-            schema_info, query_ast, args, vertex_partition)
+            schema_info, query_ast, args, vertex_partition
+        )
 
         expected_next_page = """{
             Species {

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -158,20 +158,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_fields=uuid4_fields,
         )
 
-        # Since query pagination is still a skeleton, we expect a NotImplementedError for this test.
-        # Once query pagination is fully implemented, the result of this call should be equal to
-        # expected_query_list.
-        # pylint: disable=unused-variable
-        with self.assertRaises(NotImplementedError):
-            paginated_queries = paginate_query(  # noqa: unused-variable
-                schema_info, test_data, parameters, 1
-            )
+        paginated_queries = paginate_query(
+            schema_info, test_data, parameters, 1
+        )
 
-        expected_query_list = (  # noqa: unused-variable
+        expected_query_list = (
             QueryStringWithParameters(
                 """{
                     Animal {
-                        uuid @filter(op_name: "<", value: ["$_paged_upper_param_on_Animal_uuid"])
+                        uuid @filter(op_name: "<", value: ["$__paged_param_0"])
                         name @output(out_name: "animal")
                     }
                 }""",
@@ -180,14 +175,15 @@ class QueryPaginationTests(unittest.TestCase):
             QueryStringWithParameters(
                 """{
                     Animal {
-                        uuid @filter(op_name: ">=", value: ["$_paged_lower_param_on_Animal_uuid"])
+                        uuid @filter(op_name: ">=", value: ["$__paged_param_0"])
                         name @output(out_name: "animal")
                     }
                 }""",
                 {"_paged_lower_param_on_Animal_uuid": "40000000-0000-0000-0000-000000000000",},
             ),
         )
-        # pylint: enable=unused-variable
+        compare_graphql(self, expected_query_list[0].query_string, paginated_queries[0].query_string)
+
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_parameter_value_generation_int(self):

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -6,6 +6,7 @@ import unittest
 from graphql import print_ast
 import pytest
 
+from ...global_utils import ASTWithParameters, QueryStringWithParameters
 from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.cardinality_estimator import estimate_query_result_cardinality
 from ...cost_estimation.statistics import LocalStatistics
@@ -488,8 +489,8 @@ class QueryPaginationTests(unittest.TestCase):
         args = {}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        (next_page_ast, _), (remainder_ast, _), param_name = generate_parameterized_queries(
-            schema_info, query_ast, args, vertex_partition
+        next_page, remainder, param_name = generate_parameterized_queries(
+            schema_info, ASTWithParameters(query_ast, args), vertex_partition
         )
 
         expected_next_page = """{
@@ -505,8 +506,8 @@ class QueryPaginationTests(unittest.TestCase):
             }
         }"""
         expected_param_name = "__paged_param_0"
-        compare_graphql(self, expected_next_page, print_ast(next_page_ast))
-        compare_graphql(self, expected_remainder, print_ast(remainder_ast))
+        compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
+        compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))
         self.assertEqual(expected_param_name, param_name)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
@@ -539,8 +540,8 @@ class QueryPaginationTests(unittest.TestCase):
         args = {"__paged_param_0": "Cow"}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        (next_page_ast, _), (remainder_ast, _), param_name = generate_parameterized_queries(
-            schema_info, query_ast, args, vertex_partition
+        next_page, remainder, param_name = generate_parameterized_queries(
+            schema_info, ASTWithParameters(query_ast, args), vertex_partition
         )
 
         expected_next_page = """{
@@ -558,8 +559,8 @@ class QueryPaginationTests(unittest.TestCase):
             }
         }"""
         expected_param_name = "__paged_param_1"
-        compare_graphql(self, expected_next_page, print_ast(next_page_ast))
-        compare_graphql(self, expected_remainder, print_ast(remainder_ast))
+        compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
+        compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))
         self.assertEqual(expected_param_name, param_name)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
@@ -594,8 +595,8 @@ class QueryPaginationTests(unittest.TestCase):
         }
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        (next_page_ast, _), (remainder_ast, _), param_name = generate_parameterized_queries(
-            schema_info, query_ast, args, vertex_partition
+        next_page, remainder, param_name = generate_parameterized_queries(
+            schema_info, ASTWithParameters(query_ast, args), vertex_partition
         )
 
         expected_next_page = """{
@@ -612,6 +613,6 @@ class QueryPaginationTests(unittest.TestCase):
             }
         }"""
         expected_param_name = "__paged_param_0"
-        compare_graphql(self, expected_next_page, print_ast(next_page_ast))
-        compare_graphql(self, expected_remainder, print_ast(remainder_ast))
+        compare_graphql(self, expected_next_page, print_ast(next_page.query_ast))
+        compare_graphql(self, expected_remainder, print_ast(remainder.query_ast))
         self.assertEqual(expected_param_name, param_name)


### PR DESCRIPTION
1. Implement the parameterizer: It modifies the query ast to add filters
2. Remove traces of the old method, and update the `query_splitter` module to work with the new APIs. The one end-to-end test we have now passes, but we still need more end-to-end tests.
3. Add tests for the parameterizer