### PR TITLE
Add end to end pagination tests, fix timezone issues

### DIFF
--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -102,6 +102,7 @@ def convert_field_value_to_int(
     if is_int_field_type(schema_info, vertex_class, property_field):
         return value
     elif is_datetime_field_type(schema_info, vertex_class, property_field):
+        # TODO is astimezone the right thing to use? Maybe value.replace(tzinfo=pytz.utc)?
         return (value.astimezone(pytz.utc) - DATETIME_EPOCH_UTC) // datetime.timedelta(
             microseconds=1
         )

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -102,8 +102,7 @@ def convert_field_value_to_int(
     if is_int_field_type(schema_info, vertex_class, property_field):
         return value
     elif is_datetime_field_type(schema_info, vertex_class, property_field):
-        # TODO is astimezone the right thing to use? Maybe value.replace(tzinfo=pytz.utc)?
-        return (value.astimezone(pytz.utc) - DATETIME_EPOCH_UTC) // datetime.timedelta(
+        return (value.replace(tzinfo=pytz.utc) - DATETIME_EPOCH_UTC) // datetime.timedelta(
             microseconds=1
         )
     elif is_date_field_type(schema_info, vertex_class, property_field):

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -1,8 +1,10 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from abc import ABCMeta, abstractmethod
+import datetime
 
 import six
 
+from ..global_utils import canonicalize_value
 
 @six.python_2_unicode_compatible
 @six.add_metaclass(ABCMeta)
@@ -138,12 +140,17 @@ class LocalStatistics(Statistics):
             field_quantiles = dict()
 
         # Validate arguments
-        for vertex_name, quantile_list in six.iteritems(field_quantiles):
+        for (vertex_name, field_name), quantile_list in six.iteritems(field_quantiles):
             if len(quantile_list) < 2:
                 raise AssertionError(
-                    u"The number of quantiles should be at least 2. Vertex "
-                    u"{} has {}.".format(vertex_name, len(quantile_list))
+                    u"The number of quantiles should be at least 2. Field "
+                    u"{}.{} has {}.".format(vertex_name, field_name, len(quantile_list))
                 )
+
+        # Canonicalize quantile values
+        # TODO canonicalize, or validate?
+        for key, quantile_list in six.iteritems(field_quantiles):
+            field_quantiles[key] = [canonicalize_value(value) for value in quantile_list]
 
         self._class_counts = class_counts
         self._vertex_edge_vertex_counts = vertex_edge_vertex_counts

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -1,10 +1,10 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from abc import ABCMeta, abstractmethod
-import datetime
 
 import six
 
 from ..global_utils import canonicalize_value
+
 
 @six.python_2_unicode_compatible
 @six.add_metaclass(ABCMeta)

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -129,8 +129,6 @@ class LocalStatistics(Statistics):
                              element is a value greater than or equal to i/N of all present
                              values. The number N can be different for each entry. N has to be at
                              least 2 for every entry present in the dict.
-            TODO(bojanserafimov): Enforce a canonical representation for quantile values. Datetimes
-                                  should be in utc, decimals should have type float, etc.
         """
         if vertex_edge_vertex_counts is None:
             vertex_edge_vertex_counts = dict()
@@ -148,7 +146,8 @@ class LocalStatistics(Statistics):
                 )
 
         # Canonicalize quantile values
-        # TODO canonicalize, or validate?
+        # TODO(bojanserafimov): Infer the desired type from the schema, not from the type of
+        #                       each individual quantile value.
         for key, quantile_list in six.iteritems(field_quantiles):
             field_quantiles[key] = [canonicalize_value(value) for value in quantile_list]
 

--- a/graphql_compiler/global_utils.py
+++ b/graphql_compiler/global_utils.py
@@ -14,6 +14,9 @@ class QueryStringWithParameters:
     """A query string and parameters that validate against the query."""
 
     query_string: str
+
+    # parameters are expected to be canonicalized:
+    # - all datetime objects should have a time zone
     parameters: Dict[str, Any]
 
 
@@ -22,6 +25,9 @@ class ASTWithParameters:
     """A query AST and parameters that validate against the query."""
 
     query_ast: DocumentNode
+
+    # parameters are expected to be canonicalized:
+    # - all datetime objects should have a time zone
     parameters: Dict[str, Any]
 
 

--- a/graphql_compiler/global_utils.py
+++ b/graphql_compiler/global_utils.py
@@ -1,6 +1,9 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 from dataclasses import dataclass
+import datetime
 from typing import Any, Dict
+
+import pytz
 
 from graphql import DocumentNode, GraphQLList, GraphQLNamedType, GraphQLNonNull
 import six
@@ -20,6 +23,19 @@ class ASTWithParameters:
 
     query_ast: DocumentNode
     parameters: Dict[str, Any]
+
+
+def canonicalize_datetime(value):
+    if value.tzinfo is None:
+        # TODO astimezone, or replace?
+        return value.astimezone(pytz.utc)
+    return value
+
+
+def canonicalize_value(value):
+    if isinstance(value, datetime.datetime):
+        return canonicalize_datetime(value)
+    return value
 
 
 def merge_non_overlapping_dicts(merge_target, new_data):

--- a/graphql_compiler/global_utils.py
+++ b/graphql_compiler/global_utils.py
@@ -3,9 +3,8 @@ from dataclasses import dataclass
 import datetime
 from typing import Any, Dict
 
-import pytz
-
 from graphql import DocumentNode, GraphQLList, GraphQLNamedType, GraphQLNonNull
+import pytz
 import six
 
 
@@ -33,8 +32,7 @@ class ASTWithParameters:
 
 def canonicalize_datetime(value):
     if value.tzinfo is None:
-        # TODO astimezone, or replace?
-        return value.astimezone(pytz.utc)
+        return value.replace(tzinfo=pytz.utc)
     return value
 
 

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -5,7 +5,7 @@ from graphql.language.printer import print_ast
 
 from ..ast_manipulation import safe_parse_graphql
 from ..cost_estimation.cardinality_estimator import estimate_number_of_pages
-from ..global_utils import ASTWithParameters, QueryStringWithParameters
+from ..global_utils import ASTWithParameters, QueryStringWithParameters, canonicalize_value
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import PaginationAdvisory
 from .query_splitter import split_into_page_query_and_remainder_query
@@ -89,9 +89,12 @@ def paginate_query(
             - Tuple of PaginationAdvisories that communicate what can be done to improve pagination
     """
     query_ast = safe_parse_graphql(query.query_string)
+    canonicalized_parameters = {
+        key: canonicalize_value(value) for key, value in query.parameters.items()
+    }
 
     next_page_ast_with_parameters, remainder_ast_with_parameters, advisories = paginate_query_ast(
-        schema_info, ASTWithParameters(query_ast, query.parameters), page_size
+        schema_info, ASTWithParameters(query_ast, canonicalized_parameters), page_size
     )
 
     page_query_with_parameters = QueryStringWithParameters(

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -169,7 +169,7 @@ def _compute_parameters_for_non_uuid_field(
     #                       that are known to be empty. This can cause the number of generated
     #                       pages to be less than the desired number of pages.
     return _deduplicate_sorted_generator(
-        proper_quantiles[index]
+        relevant_quantiles[index]
         for index in _sum_partition(len(relevant_quantiles) + 1, vertex_partition.number_of_splits)
     )
 

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1510,7 +1510,7 @@ class IntegerIntervalTests(unittest.TestCase):
                 schema_info, "Event", "event_date", int_value
             )
             self.assertAlmostEqual(
-                0, (datetime_value.astimezone(pytz.utc) - recovered_datetime).total_seconds()
+                0, (datetime_value.replace(tzinfo=pytz.utc) - recovered_datetime).total_seconds()
             )
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -298,9 +298,7 @@ class QueryPaginationTests(unittest.TestCase):
                 limbs @filter(op_name: ">=", value: ["$limbs_lower"])
             }
         }"""
-        args = {
-            "limbs_lower": 26
-        }
+        args = {"limbs_lower": 26}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
         generated_parameters = generate_parameters_for_vertex_partition(
@@ -336,9 +334,7 @@ class QueryPaginationTests(unittest.TestCase):
                 limbs @filter(op_name: "<", value: ["$limbs_upper"])
             }
         }"""
-        args = {
-            "limbs_upper": 76
-        }
+        args = {"limbs_upper": 76}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
         generated_parameters = generate_parameters_for_vertex_partition(
@@ -435,7 +431,9 @@ class QueryPaginationTests(unittest.TestCase):
         statistics = LocalStatistics(
             class_counts,
             field_quantiles={
-                ("Event", "event_date"): [datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)],
+                ("Event", "event_date"): [
+                    datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)
+                ],
             },
         )
         schema_info = QueryPlanningSchemaInfo(
@@ -738,7 +736,9 @@ class QueryPaginationTests(unittest.TestCase):
         statistics = LocalStatistics(
             class_counts,
             field_quantiles={
-                ("Event", "event_date"): [datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)],
+                ("Event", "event_date"): [
+                    datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)
+                ],
             },
         )
         schema_info = QueryPlanningSchemaInfo(
@@ -834,7 +834,7 @@ class QueryPaginationTests(unittest.TestCase):
         statistics = LocalStatistics(
             class_counts,
             field_quantiles={
-                ("Event", "event_date"): [datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)],
+                ("Event", "event_date"): [datetime.datetime(2000 + i, 1, 1) for i in range(101)],
             },
         )
         schema_info = QueryPlanningSchemaInfo(
@@ -853,15 +853,13 @@ class QueryPaginationTests(unittest.TestCase):
                 event_date @filter(op_name: ">=", value: ["$date_lower"])
             }
         }""",
-            {
-                "date_lower": datetime.datetime(2050, 1, 1, 0, 0)
-            },
+            {"date_lower": datetime.datetime(2050, 1, 1, 0, 0)},
         )
 
         first, remainder, _ = paginate_query(schema_info, query, 100)
 
         # There are 1000 dates uniformly spread out between year 2000 and 3000, so to get
-        # 100 results after 2050, we stop at 2055.
+        # 100 results after 2050, we stop at 2059.
         expected_page_query = QueryStringWithParameters(
             """{
                 Event {
@@ -871,8 +869,8 @@ class QueryPaginationTests(unittest.TestCase):
                 }
             }""",
             {
-                "date_lower": datetime.datetime(2050, 1, 1, 5, tzinfo=pytz.utc),
-                "__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),
+                "date_lower": datetime.datetime(2050, 1, 1, 0, tzinfo=pytz.utc),
+                "__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0, tzinfo=pytz.utc),
             },
         )
         expected_remainder_query = QueryStringWithParameters(
@@ -882,7 +880,7 @@ class QueryPaginationTests(unittest.TestCase):
                     event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
                 }
             }""",
-            {"__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),},
+            {"__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0, tzinfo=pytz.utc),},
         )
 
         # Check that the correct queries are generated

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -822,3 +822,72 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(1, len(remainder))
         compare_graphql(self, expected_remainder_query.query_string, remainder[0].query_string)
         self.assertEqual(expected_remainder_query.parameters, remainder[0].parameters)
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_pagination_datetime_existing_filter(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {"Event": 1000}
+        statistics = LocalStatistics(
+            class_counts,
+            field_quantiles={
+                ("Event", "event_date"): [datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)],
+            },
+        )
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields,
+        )
+
+        query = QueryStringWithParameters(
+            """{
+            Event {
+                name @output(out_name: "event_name")
+                event_date @filter(op_name: ">=", value: ["$date_lower"])
+            }
+        }""",
+            {
+                "date_lower": datetime.datetime(2050, 1, 1, 0, 0)
+            },
+        )
+
+        first, remainder, _ = paginate_query(schema_info, query, 100)
+
+        # There are 1000 dates uniformly spread out between year 2000 and 3000, so to get
+        # 100 results after 2050, we stop at 2055.
+        expected_page_query = QueryStringWithParameters(
+            """{
+                Event {
+                    name @output(out_name: "event_name")
+                    event_date @filter(op_name: ">=", value: ["$date_lower"])
+                               @filter(op_name: "<", value: ["$__paged_param_0"])
+                }
+            }""",
+            {
+                "date_lower": datetime.datetime(2050, 1, 1, 5, tzinfo=pytz.utc),
+                "__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),
+            },
+        )
+        expected_remainder_query = QueryStringWithParameters(
+            """{
+                Event {
+                    name @output(out_name: "event_name")
+                    event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
+                }
+            }""",
+            {"__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),},
+        )
+
+        # Check that the correct queries are generated
+        compare_graphql(self, expected_page_query.query_string, first.query_string)
+        self.assertEqual(expected_page_query.parameters, first.parameters)
+        self.assertEqual(1, len(remainder))
+        compare_graphql(self, expected_remainder_query.query_string, remainder[0].query_string)
+        self.assertEqual(expected_remainder_query.parameters, remainder[0].parameters)

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -273,6 +273,82 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_parameters, list(generated_parameters))
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_parameter_value_generation_int_existing_filters(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {"Species": 1000}
+        statistics = LocalStatistics(
+            class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
+        )
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields,
+        )
+
+        query = """{
+            Species {
+                name @output(out_name: "species_name")
+                limbs @filter(op_name: ">=", value: ["$limbs_lower"])
+            }
+        }"""
+        args = {
+            "limbs_lower": 26
+        }
+        query_ast = safe_parse_graphql(query)
+        vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
+        generated_parameters = generate_parameters_for_vertex_partition(
+            schema_info, query_ast, args, vertex_partition
+        )
+
+        expected_parameters = [51, 76]
+        self.assertEqual(expected_parameters, list(generated_parameters))
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_parameter_value_generation_int_existing_filters_2(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {"Species": 1000}
+        statistics = LocalStatistics(
+            class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
+        )
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields,
+        )
+
+        query = """{
+            Species {
+                name @output(out_name: "species_name")
+                limbs @filter(op_name: "<", value: ["$limbs_upper"])
+            }
+        }"""
+        args = {
+            "limbs_upper": 76
+        }
+        query_ast = safe_parse_graphql(query)
+        vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
+        generated_parameters = generate_parameters_for_vertex_partition(
+            schema_info, query_ast, args, vertex_partition
+        )
+
+        expected_parameters = [26, 51]
+        self.assertEqual(expected_parameters, list(generated_parameters))
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_parameter_value_generation_inline_fragment(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)


### PR DESCRIPTION
Wrote some tests, fixed some bugs. Notable bug fixes:
1. Timezone naive and aware datetimes are not comparable. There's 2 sources of input datetimes: input query args and quantile statistics. The easiest way to make them agree on a format is coerce input datetimes into the correct format.
2. Fixed assertion error message
3. Fix critical typo in parameter generator