### PR TITLE
Fix pagination timezone bug

### DIFF
--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -17,9 +17,6 @@ import datetime
 from typing import Any
 from uuid import UUID
 
-import pytz
-
-from ..exceptions import GraphQLError
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .helpers import is_date_field_type, is_datetime_field_type, is_int_field_type, is_uuid4_type
 

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -19,6 +19,7 @@ from uuid import UUID
 
 import pytz
 
+from ..exceptions import GraphQLError
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .helpers import is_date_field_type, is_datetime_field_type, is_int_field_type, is_uuid4_type
 
@@ -29,7 +30,7 @@ MIN_UUID_INT = 0
 MAX_UUID_INT = 2 ** 128 - 1
 
 
-DATETIME_EPOCH_UTC = datetime.datetime(1970, 1, 1, tzinfo=pytz.utc)
+DATETIME_EPOCH_TZ_NAIVE = datetime.datetime(1970, 1, 1)
 
 
 def field_supports_range_reasoning(
@@ -70,7 +71,7 @@ def convert_int_to_field_value(
     if is_int_field_type(schema_info, vertex_class, property_field):
         return int_value
     elif is_datetime_field_type(schema_info, vertex_class, property_field):
-        return DATETIME_EPOCH_UTC + datetime.timedelta(microseconds=int_value)
+        return DATETIME_EPOCH_TZ_NAIVE + datetime.timedelta(microseconds=int_value)
     elif is_date_field_type(schema_info, vertex_class, property_field):
         return datetime.date.fromordinal(int_value)
     elif is_uuid4_type(schema_info, vertex_class, property_field):
@@ -102,7 +103,7 @@ def convert_field_value_to_int(
     if is_int_field_type(schema_info, vertex_class, property_field):
         return value
     elif is_datetime_field_type(schema_info, vertex_class, property_field):
-        return (value.astimezone(pytz.utc) - DATETIME_EPOCH_UTC) // datetime.timedelta(
+        return (value.replace(tzinfo=None) - DATETIME_EPOCH_TZ_NAIVE) // datetime.timedelta(
             microseconds=1
         )
     elif is_date_field_type(schema_info, vertex_class, property_field):

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -1,5 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from abc import ABCMeta, abstractmethod
+import datetime
 
 import six
 
@@ -138,12 +139,18 @@ class LocalStatistics(Statistics):
             field_quantiles = dict()
 
         # Validate arguments
-        for vertex_name, quantile_list in six.iteritems(field_quantiles):
+        for (vertex_name, field_name), quantile_list in six.iteritems(field_quantiles):
             if len(quantile_list) < 2:
                 raise AssertionError(
-                    u"The number of quantiles should be at least 2. Vertex "
-                    u"{} has {}.".format(vertex_name, len(quantile_list))
+                    f"The number of quantiles should be at least 2. Field "
+                    f"{vertex_name}.{field_name} has {len(quantile_list)}."
                 )
+            for quantile in quantile_list:
+                if isinstance(quantile, datetime.datetime):
+                    if quantile.tzinfo is None:
+                        raise AssertionError(
+                            f"Quantile for {vertex_name}.{field_name} has no tzinfo."
+                        )
 
         self._class_counts = class_counts
         self._vertex_edge_vertex_counts = vertex_edge_vertex_counts
@@ -154,8 +161,8 @@ class LocalStatistics(Statistics):
         """See base class."""
         if class_name not in self._class_counts:
             raise AssertionError(
-                u"Class count statistic is required, but entry not found for: "
-                u"{}".format(class_name)
+                "Class count statistic is required, but entry not found for: "
+                "{}".format(class_name)
             )
         return self._class_counts[class_name]
 

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -147,9 +147,10 @@ class LocalStatistics(Statistics):
                 )
             for quantile in quantile_list:
                 if isinstance(quantile, datetime.datetime):
-                    if quantile.tzinfo is None:
-                        raise AssertionError(
-                            f"Quantile for {vertex_name}.{field_name} has no tzinfo."
+                    if quantile.tzinfo is not None:
+                        raise NotImplementedError(
+                            f"Range reasoning for tz-aware datetimes is not implemented. "
+                            f"found tz-aware quantiles for {vertex_name}.{field_name}."
                         )
 
         self._class_counts = class_counts

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -161,8 +161,7 @@ class LocalStatistics(Statistics):
         """See base class."""
         if class_name not in self._class_counts:
             raise AssertionError(
-                "Class count statistic is required, but entry not found for: "
-                "{}".format(class_name)
+                f"Class count statistic is required, but entry not found for {class_name}"
             )
         return self._class_counts[class_name]
 

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -1,5 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from copy import copy
+import datetime
 from typing import Any, Dict, Set, Tuple, cast
 
 from graphql import print_ast
@@ -15,6 +16,7 @@ from graphql.language.ast import (
     SelectionSetNode,
     StringValueNode,
 )
+import pytz
 
 from ..ast_manipulation import get_ast_field_name, get_only_query_definition
 from ..compiler.helpers import get_parameter_name
@@ -79,8 +81,12 @@ def _is_new_filter_stronger(operation: str, new_filter_value: Any, old_filter_va
         )
 
     if operation == "<":
+        if isinstance(new_filter_value, datetime.datetime):
+            return new_filter_value.astimezone(pytz.utc) <= old_filter_value.astimezone(pytz.utc)
         return new_filter_value <= old_filter_value
     elif operation == ">=":
+        if isinstance(new_filter_value, datetime.datetime):
+            return new_filter_value.astimezone(pytz.utc) >= old_filter_value.astimezone(pytz.utc)
         return new_filter_value >= old_filter_value
     else:
         raise AssertionError(f"Expected operation to be < or >=, got {operation}.")

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -16,7 +16,6 @@ from graphql.language.ast import (
     SelectionSetNode,
     StringValueNode,
 )
-import pytz
 
 from ..ast_manipulation import get_ast_field_name, get_only_query_definition
 from ..compiler.helpers import get_parameter_name
@@ -81,12 +80,12 @@ def _is_new_filter_stronger(operation: str, new_filter_value: Any, old_filter_va
         )
 
     if operation == "<":
-        if isinstance(new_filter_value, datetime.datetime):
-            return new_filter_value.astimezone(pytz.utc) <= old_filter_value.astimezone(pytz.utc)
+        if isinstance(old_filter_value, datetime.datetime):
+            return new_filter_value.replace(tzinfo=None) <= old_filter_value.replace(tzinfo=None)
         return new_filter_value <= old_filter_value
     elif operation == ">=":
-        if isinstance(new_filter_value, datetime.datetime):
-            return new_filter_value.astimezone(pytz.utc) >= old_filter_value.astimezone(pytz.utc)
+        if isinstance(old_filter_value, datetime.datetime):
+            return new_filter_value.replace(tzinfo=None) >= old_filter_value.replace(tzinfo=None)
         return new_filter_value >= old_filter_value
     else:
         raise AssertionError(f"Expected operation to be < or >=, got {operation}.")

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1501,7 +1501,6 @@ class IntegerIntervalTests(unittest.TestCase):
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.utc),
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("GMT")),
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("America/New_York")),
-            datetime(2000, 1, 1, tzinfo=pytz.utc),
         ]
         for datetime_value in datetime_values:
             int_value = convert_field_value_to_int(

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -1321,10 +1321,10 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
             dict(),
             field_quantiles={
                 ("Event", "event_date"): [
-                    datetime(2019, 3, 1, tzinfo=pytz.utc),
-                    datetime(2019, 6, 1, tzinfo=pytz.utc),
-                    datetime(2019, 8, 1, tzinfo=pytz.utc),
-                    datetime(2019, 9, 1, tzinfo=pytz.utc),
+                    datetime(2019, 3, 1),
+                    datetime(2019, 6, 1),
+                    datetime(2019, 8, 1),
+                    datetime(2019, 9, 1),
                 ],
             },
         )
@@ -1501,6 +1501,7 @@ class IntegerIntervalTests(unittest.TestCase):
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.utc),
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("GMT")),
             datetime(2000, 1, 1, 20, 55, 40, 877633, tzinfo=pytz.timezone("America/New_York")),
+            datetime(2000, 1, 1, tzinfo=pytz.utc),
         ]
         for datetime_value in datetime_values:
             int_value = convert_field_value_to_int(
@@ -1509,9 +1510,7 @@ class IntegerIntervalTests(unittest.TestCase):
             recovered_datetime = convert_int_to_field_value(
                 schema_info, "Event", "event_date", int_value
             )
-            self.assertAlmostEqual(
-                0, (datetime_value.astimezone(pytz.utc) - recovered_datetime).total_seconds()
-            )
+            self.assertEqual(datetime_value.replace(tzinfo=None), recovered_datetime)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_int_value_conversion_date(self):

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -344,7 +344,12 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_remainder_query.parameters, remainder[0].parameters)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
-    def test_pagination_datetime_existing_filter(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="pagination with tz-naive filters not implemented yet",
+        raises=AssertionError,
+    )
+    def _test_pagination_datetime_existing_filter(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
@@ -354,7 +359,9 @@ class QueryPaginationTests(unittest.TestCase):
         statistics = LocalStatistics(
             class_counts,
             field_quantiles={
-                ("Event", "event_date"): [datetime.datetime(2000 + i, 1, 1) for i in range(101)],
+                ("Event", "event_date"): [
+                    datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)
+                ],
             },
         )
         schema_info = QueryPlanningSchemaInfo(
@@ -606,7 +613,9 @@ class QueryPaginationTests(unittest.TestCase):
         statistics = LocalStatistics(
             class_counts,
             field_quantiles={
-                ("Event", "event_date"): [datetime.datetime(2000 + i, 1, 1) for i in range(101)],
+                ("Event", "event_date"): [
+                    datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)
+                ],
             },
         )
         schema_info = QueryPlanningSchemaInfo(
@@ -631,9 +640,9 @@ class QueryPaginationTests(unittest.TestCase):
         )
 
         expected_parameters = [
-            datetime.datetime(2026, 1, 1, 0, 0),
-            datetime.datetime(2051, 1, 1, 0, 0),
-            datetime.datetime(2076, 1, 1, 0, 0),
+            datetime.datetime(2026, 1, 1, 0, 0, tzinfo=pytz.utc),
+            datetime.datetime(2051, 1, 1, 0, 0, tzinfo=pytz.utc),
+            datetime.datetime(2076, 1, 1, 0, 0, tzinfo=pytz.utc),
         ]
         self.assertEqual(expected_parameters, list(generated_parameters))
 

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -372,7 +372,11 @@ class QueryPaginationTests(unittest.TestCase):
         # We do this to make sure the test runs the same across local timezones.
         now = datetime.datetime.now()
         timedelta_from_utc = now.astimezone(pytz.utc) - now.replace(tzinfo=pytz.utc)
-        local_datetime = datetime.datetime(2050, 1, 1, 0, 0) + timedelta_from_utc
+        local_datetime = datetime.datetime(2050, 1, 1, 0, 0) - timedelta_from_utc
+        self.assertEqual(
+            datetime.datetime(2050, 1, 1, 0, 0, tzinfo=pytz.utc),
+            local_datetime.astimezone(pytz.utc),
+        )
 
         query = QueryStringWithParameters(
             """{
@@ -389,7 +393,7 @@ class QueryPaginationTests(unittest.TestCase):
         remainder = first_page_and_remainder.remainder
 
         # There are 1000 dates uniformly spread out between year 2000 and 3000, so to get
-        # 100 results after 2050, we stop at 2061.
+        # 100 results after 2050, we stop at 2059.
         expected_page_query = QueryStringWithParameters(
             """{
                 Event {
@@ -400,7 +404,7 @@ class QueryPaginationTests(unittest.TestCase):
             }""",
             {
                 "date_lower": local_datetime,
-                "__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),
+                "__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0, tzinfo=pytz.utc),
             },
         )
         expected_remainder_query = QueryStringWithParameters(
@@ -410,7 +414,7 @@ class QueryPaginationTests(unittest.TestCase):
                     event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
                 }
             }""",
-            {"__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),},
+            {"__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0, tzinfo=pytz.utc),},
         )
 
         # Check that the correct queries are generated

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -344,12 +344,7 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_remainder_query.parameters, remainder[0].parameters)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
-    @pytest.mark.xfail(
-        strict=True,
-        reason="pagination with tz-naive filters not implemented yet",
-        raises=AssertionError,
-    )
-    def _test_pagination_datetime_existing_filter(self):
+    def test_pagination_datetime_existing_filter(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
@@ -388,7 +383,7 @@ class QueryPaginationTests(unittest.TestCase):
         remainder = first_page_and_remainder.remainder
 
         # There are 1000 dates uniformly spread out between year 2000 and 3000, so to get
-        # 100 results after 2050, we stop at 2059.
+        # 100 results after 2050, we stop at 2061.
         expected_page_query = QueryStringWithParameters(
             """{
                 Event {
@@ -398,8 +393,8 @@ class QueryPaginationTests(unittest.TestCase):
                 }
             }""",
             {
-                "date_lower": datetime.datetime(2050, 1, 1, 0, tzinfo=pytz.utc),
-                "__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0, tzinfo=pytz.utc),
+                "date_lower": datetime.datetime(2050, 1, 1, 0),
+                "__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),
             },
         )
         expected_remainder_query = QueryStringWithParameters(
@@ -409,7 +404,7 @@ class QueryPaginationTests(unittest.TestCase):
                     event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
                 }
             }""",
-            {"__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0, tzinfo=pytz.utc),},
+            {"__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),},
         )
 
         # Check that the correct queries are generated

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -368,6 +368,12 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_fields=uuid4_fields,
         )
 
+        # Construct a local datetime that corresponds to 2050-1-1 UTC.
+        # We do this to make sure the test runs the same across local timezones.
+        now = datetime.datetime.now()
+        timedelta_from_utc = now.astimezone(pytz.utc) - now.replace(tzinfo=pytz.utc)
+        local_datetime = datetime.datetime(2050, 1, 1, 0, 0) + timedelta_from_utc
+
         query = QueryStringWithParameters(
             """{
             Event {
@@ -375,7 +381,7 @@ class QueryPaginationTests(unittest.TestCase):
                 event_date @filter(op_name: ">=", value: ["$date_lower"])
             }
         }""",
-            {"date_lower": datetime.datetime(2050, 1, 1, 0, 0)},
+            {"date_lower": local_datetime},
         )
 
         first_page_and_remainder, _ = paginate_query(schema_info, query, 100)
@@ -393,7 +399,7 @@ class QueryPaginationTests(unittest.TestCase):
                 }
             }""",
             {
-                "date_lower": datetime.datetime(2050, 1, 1, 0),
+                "date_lower": local_datetime,
                 "__paged_param_0": datetime.datetime(2061, 1, 1, 0, 0, tzinfo=pytz.utc),
             },
         )

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -5,6 +5,7 @@ import unittest
 
 from graphql import print_ast
 import pytest
+import pytz
 
 from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.cardinality_estimator import estimate_query_result_cardinality
@@ -239,6 +240,177 @@ class QueryPaginationTests(unittest.TestCase):
             schema_info, second.query_string, second.parameters
         )
         self.assertAlmostEqual(1, second_page_cardinality_estimate)
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_pagination_datetime(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {"Event": 1000}
+        statistics = LocalStatistics(
+            class_counts,
+            field_quantiles={
+                ("Event", "event_date"): [
+                    datetime.datetime(2000 + i, 1, 1, tzinfo=pytz.utc) for i in range(101)
+                ],
+            },
+        )
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields,
+        )
+
+        query = QueryStringWithParameters(
+            """{
+            Event {
+                name @output(out_name: "event_name")
+            }
+        }""",
+            {},
+        )
+
+        first_page_and_remainder, _ = paginate_query(schema_info, query, 100)
+        first = first_page_and_remainder.one_page
+        remainder = first_page_and_remainder.remainder
+
+        # There are 1000 dates uniformly spread out between year 2000 and 3000, so to get
+        # 100 results, we stop at 2011.
+        expected_page_query = QueryStringWithParameters(
+            """{
+                Event {
+                    event_date @filter(op_name: "<", value: ["$__paged_param_0"])
+                    name @output(out_name: "event_name")
+                }
+            }""",
+            {"__paged_param_0": datetime.datetime(2011, 1, 1, 0, 0, tzinfo=pytz.utc),},
+        )
+        expected_remainder_query = QueryStringWithParameters(
+            """{
+                Event {
+                    event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
+                    name @output(out_name: "event_name")
+                }
+            }""",
+            {"__paged_param_0": datetime.datetime(2011, 1, 1, 0, 0, tzinfo=pytz.utc),},
+        )
+
+        # Check that the correct queries are generated
+        compare_graphql(self, expected_page_query.query_string, first.query_string)
+        self.assertEqual(expected_page_query.parameters, first.parameters)
+        self.assertEqual(1, len(remainder))
+        compare_graphql(self, expected_remainder_query.query_string, remainder[0].query_string)
+        self.assertEqual(expected_remainder_query.parameters, remainder[0].parameters)
+
+        # Get the second page
+        second_page_and_remainder, _ = paginate_query(schema_info, remainder[0], 100)
+        second = second_page_and_remainder.one_page
+        remainder = second_page_and_remainder.remainder
+
+        expected_page_query = QueryStringWithParameters(
+            """{
+                Event {
+                    event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
+                               @filter(op_name: "<", value: ["$__paged_param_1"])
+                    name @output(out_name: "event_name")
+                }
+            }""",
+            {
+                # TODO parameters seem wonky
+                "__paged_param_0": datetime.datetime(2011, 1, 1, 0, 0, tzinfo=pytz.utc),
+                "__paged_param_1": datetime.datetime(2021, 1, 1, 0, 0, tzinfo=pytz.utc),
+            },
+        )
+        expected_remainder_query = QueryStringWithParameters(
+            """{
+                Event {
+                    event_date @filter(op_name: ">=", value: ["$__paged_param_1"])
+                    name @output(out_name: "event_name")
+                }
+            }""",
+            {"__paged_param_1": datetime.datetime(2021, 1, 1, 0, 0, tzinfo=pytz.utc),},
+        )
+
+        # Check that the correct queries are generated
+        compare_graphql(self, expected_page_query.query_string, second.query_string)
+        self.assertEqual(expected_page_query.parameters, second.parameters)
+        self.assertEqual(1, len(remainder))
+        compare_graphql(self, expected_remainder_query.query_string, remainder[0].query_string)
+        self.assertEqual(expected_remainder_query.parameters, remainder[0].parameters)
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_pagination_datetime_existing_filter(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {"Event": 1000}
+        statistics = LocalStatistics(
+            class_counts,
+            field_quantiles={
+                ("Event", "event_date"): [datetime.datetime(2000 + i, 1, 1) for i in range(101)],
+            },
+        )
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields,
+        )
+
+        query = QueryStringWithParameters(
+            """{
+            Event {
+                name @output(out_name: "event_name")
+                event_date @filter(op_name: ">=", value: ["$date_lower"])
+            }
+        }""",
+            {"date_lower": datetime.datetime(2050, 1, 1, 0, 0)},
+        )
+
+        first_page_and_remainder, _ = paginate_query(schema_info, query, 100)
+        first = first_page_and_remainder.one_page
+        remainder = first_page_and_remainder.remainder
+
+        # There are 1000 dates uniformly spread out between year 2000 and 3000, so to get
+        # 100 results after 2050, we stop at 2059.
+        expected_page_query = QueryStringWithParameters(
+            """{
+                Event {
+                    name @output(out_name: "event_name")
+                    event_date @filter(op_name: ">=", value: ["$date_lower"])
+                               @filter(op_name: "<", value: ["$__paged_param_0"])
+                }
+            }""",
+            {
+                "date_lower": datetime.datetime(2050, 1, 1, 0, tzinfo=pytz.utc),
+                "__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0, tzinfo=pytz.utc),
+            },
+        )
+        expected_remainder_query = QueryStringWithParameters(
+            """{
+                Event {
+                    name @output(out_name: "event_name")
+                    event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
+                }
+            }""",
+            {"__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0, tzinfo=pytz.utc),},
+        )
+
+        # Check that the correct queries are generated
+        compare_graphql(self, expected_page_query.query_string, first.query_string)
+        self.assertEqual(expected_page_query.parameters, first.parameters)
+        self.assertEqual(1, len(remainder))
+        compare_graphql(self, expected_remainder_query.query_string, remainder[0].query_string)
+        self.assertEqual(expected_remainder_query.parameters, remainder[0].parameters)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_parameter_value_generation_int(self):


### PR DESCRIPTION
There's two situations in pagination where we deal with datetimes of different tz-awareness:
1. The quantile statistics are tz-aware, but an existing filter is tz-naive
2. The quantile statistics are tz-naive, but an existing filter is tz-aware

To simplify the problem, I disregard the first case now, since tz-aware database fields are not common. I disallow quantiles to be tz-aware.

For the second problem, no good solution exists. If a value is tz-naive, the user should not be able to use tz-aware filter, and the type system should communicate this. Since we don't do that yet, we have two options on what to do in this case:
1. Error on pagination
2. Somehow coerce the value into a tz-naive datetime on pagination

The first option is bad because we will have a query that compiles successfully but fails to paginate.

The second option is fine because the worst that can happen is we generate uneven page sizes.

In this PR i implement the second option:
- I assert that quantiles are tz-naive
- I coerce tz-naive to tz-aware datetimes by ignoring the tzinfo
- I add tests