### PR TITLE
Fix pagination progress bug

### DIFF
--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -189,7 +189,7 @@ def _compute_parameters_for_non_uuid_field(
     min_quantile = 0
     max_quantile = len(proper_quantiles)
     if field_value_interval.lower_bound is not None:
-        min_quantile = bisect.bisect_left(proper_quantiles, field_value_interval.lower_bound)
+        min_quantile = bisect.bisect_right(proper_quantiles, field_value_interval.lower_bound)
     if field_value_interval.upper_bound is not None:
         max_quantile = bisect.bisect_left(proper_quantiles, field_value_interval.upper_bound)
     relevant_quantiles = proper_quantiles[min_quantile:max_quantile]

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -625,9 +625,7 @@ class QueryPaginationTests(unittest.TestCase):
                 limbs @filter(op_name: ">=", value: ["$limbs_lower"])
             }
         }"""
-        args = {
-            "limbs_lower": 10
-        }
+        args = {"limbs_lower": 10}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 10)
         generated_parameters = generate_parameters_for_vertex_partition(

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -383,7 +383,7 @@ class QueryPaginationTests(unittest.TestCase):
         remainder = first_page_and_remainder.remainder
 
         # There are 1000 dates uniformly spread out between year 2000 and 3000, so to get
-        # 100 results after 2050, we stop at 2058.
+        # 100 results after 2050, we stop at 2059.
         expected_page_query = QueryStringWithParameters(
             """{
                 Event {
@@ -392,7 +392,7 @@ class QueryPaginationTests(unittest.TestCase):
                                @filter(op_name: "<", value: ["$__paged_param_0"])
                 }
             }""",
-            {"date_lower": local_datetime, "__paged_param_0": datetime.datetime(2058, 1, 1, 0, 0),},
+            {"date_lower": local_datetime, "__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0),},
         )
         expected_remainder_query = QueryStringWithParameters(
             """{
@@ -401,7 +401,7 @@ class QueryPaginationTests(unittest.TestCase):
                     event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
                 }
             }""",
-            {"__paged_param_0": datetime.datetime(2058, 1, 1, 0, 0),},
+            {"__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0),},
         )
 
         # Check that the correct queries are generated
@@ -461,7 +461,7 @@ class QueryPaginationTests(unittest.TestCase):
             }""",
             {
                 "date_lower": datetime.datetime(2050, 1, 1, 0, 0, tzinfo=pytz.utc),
-                "__paged_param_0": datetime.datetime(2058, 1, 1, 0, 0),
+                "__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0),
             },
         )
         expected_remainder_query = QueryStringWithParameters(
@@ -471,7 +471,7 @@ class QueryPaginationTests(unittest.TestCase):
                     event_date @filter(op_name: ">=", value: ["$__paged_param_0"])
                 }
             }""",
-            {"__paged_param_0": datetime.datetime(2058, 1, 1, 0, 0),},
+            {"__paged_param_0": datetime.datetime(2059, 1, 1, 0, 0),},
         )
 
         # Check that the correct queries are generated
@@ -589,7 +589,7 @@ class QueryPaginationTests(unittest.TestCase):
                 limbs @filter(op_name: ">=", value: ["$limbs_lower"])
             }
         }"""
-        args = {"limbs_lower": 26}
+        args = {"limbs_lower": 25}
         query_ast = safe_parse_graphql(query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
         generated_parameters = generate_parameters_for_vertex_partition(


### PR DESCRIPTION
When an existing >= filter value is equal to a quantile value, and the number of pages is exactly the number of remaining quantiles, the parameter we generate is equal to the existing filter. This would generate an empty page if used in the query_splitter.