### PR TITLE
Simplify cardinality estimation

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -226,7 +226,7 @@ class QueryPlanningAnalysis:
     def cardinality_estimate(self) -> float:
         """Return the cardinality estimate for this query."""
         return estimate_query_result_cardinality(
-            self.schema_info, self.query.query_string, self.query.parameters
+            self.schema_info, self.metadata_table, self.query.parameters
         )
 
     @cached_property

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -1,9 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from itertools import chain
-from typing import Dict, Any
+from typing import Any, Dict
 
-from ..compiler.metadata import QueryMetadataTable
-from ..compiler.compiler_frontend import graphql_to_ir
 from ..compiler.helpers import (
     INBOUND_EDGE_DIRECTION,
     OUTBOUND_EDGE_DIRECTION,
@@ -11,8 +9,9 @@ from ..compiler.helpers import (
     Location,
     get_edge_direction_and_name,
 )
-from .filter_selectivity_utils import adjust_counts_for_filters
+from ..compiler.metadata import QueryMetadataTable
 from ..schema.schema_info import QueryPlanningSchemaInfo
+from .filter_selectivity_utils import adjust_counts_for_filters
 
 
 def _is_subexpansion_optional(query_metadata, parent_location, child_location):
@@ -324,7 +323,7 @@ def _estimate_expansion_cardinality(schema_info, query_metadata, parameters, cur
 def estimate_query_result_cardinality(
     schema_info: QueryPlanningSchemaInfo,
     query_metadata: QueryMetadataTable,
-    parameters: Dict[str, Any]
+    parameters: Dict[str, Any],
 ) -> float:
     """Estimate the cardinality of a GraphQL query's result using database statistics.
 

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -321,10 +321,6 @@ def _estimate_expansion_cardinality(schema_info, query_metadata, parameters, cur
     return expansion_cardinality
 
 
-# XXX
-# 2. Move estimate_number_of_pages to pagination module
-# 3. Maybe use ast instead of query string in QueryPlanningAnalysis
-# 4. Propagate new api
 def estimate_query_result_cardinality(
     schema_info: QueryPlanningSchemaInfo,
     query_metadata: QueryMetadataTable,
@@ -362,48 +358,3 @@ def estimate_query_result_cardinality(
     expected_query_result_cardinality = root_counts * results_per_root
 
     return expected_query_result_cardinality
-
-
-def estimate_number_of_pages(schema_info, graphql_query, params, page_size):
-    """Estimate how many pages of results will be generated for a given query.
-
-    Using the cardinality estimator, we generate an estimate for the query result cardinality i.e.
-    the number of result rows, then divide (rounding up) by the page_size to get the approximate
-    number of pages that the query will produce.
-    For example, if a query were estimated to return 12000 result rows, and the desired page size is
-    5000, then the query can be divided into ceil(12000/5000)=3 pages, each with a result size below
-    (or equal to) 5000 results.
-
-    Args:
-        schema_info: QueryPlanningSchemaInfo
-        graphql_query: str, valid GraphQL query to be estimated.
-        params: dict, parameters for the given query.
-        page_size: int, desired number of result rows per page.
-
-    Returns:
-        int, estimated number of pages if the query were executed.
-
-    Raises:
-        ValueError if page_size is below 1.
-    """
-    if page_size < 1:
-        raise ValueError(
-            u"Could not estimate number of pages for query {}"
-            u" with page size lower than 1: {} {}".format(graphql_query, page_size, params)
-        )
-
-    result_size = estimate_query_result_cardinality(schema_info, graphql_query, params)
-    if result_size < 0.0:
-        raise AssertionError(
-            u"Received negative estimate {} for cardinality of query {}: {}".format(
-                result_size, graphql_query, params
-            )
-        )
-
-    # Since using a // b returns the fraction rounded down, we instead use (a + b - 1) // b, which
-    # returns the fraction value rounded up, which is the desired functionality.
-    num_pages = int((result_size + page_size - 1) // page_size)
-    if num_pages == 0:
-        num_pages = 1
-
-    return num_pages

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -13,14 +13,7 @@ from .typedefs import PageAndRemainder
 
 
 def _estimate_number_of_pages(query: ASTWithParameters, result_size: float, page_size: int) -> int:
-    """Estimate how many pages of results will be generated for a given query.
-
-    Using the cardinality estimator, we generate an estimate for the query result cardinality i.e.
-    the number of result rows, then divide (rounding up) by the page_size to get the approximate
-    number of pages that the query will produce.
-    For example, if a query were estimated to return 12000 result rows, and the desired page size is
-    5000, then the query can be divided into ceil(12000/5000)=3 pages, each with a result size below
-    (or equal to) 5000 results.
+    """Estimate how many pages of results we should generate to meet the desired result size.
 
     Args:
         query: ASTWithParameters

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -4,15 +4,15 @@ from typing import Tuple
 from graphql.language.printer import print_ast
 
 from ..ast_manipulation import safe_parse_graphql
-from ..global_utils import ASTWithParameters, QueryStringWithParameters
 from ..cost_estimation.analysis import QueryPlanningAnalysis
+from ..global_utils import ASTWithParameters, QueryStringWithParameters
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import PaginationAdvisory
 from .query_splitter import split_into_page_query_and_remainder_query
 from .typedefs import PageAndRemainder
 
 
-def _estimate_number_of_pages(result_size, page_size):
+def _estimate_number_of_pages(query, result_size, page_size):
     """Estimate how many pages of results will be generated for a given query.
 
     Using the cardinality estimator, we generate an estimate for the query result cardinality i.e.
@@ -23,10 +23,9 @@ def _estimate_number_of_pages(result_size, page_size):
     (or equal to) 5000 results.
 
     Args:
-        schema_info: QueryPlanningSchemaInfo
-        graphql_query: str, valid GraphQL query to be estimated.
-        params: dict, parameters for the given query.
-        page_size: int, desired number of result rows per page.
+        query: ASTWithParameters
+        result_size: The estimated result size of a query
+        page_size: The desired page size of a query
 
     Returns:
         int, estimated number of pages if the query were executed.
@@ -36,15 +35,13 @@ def _estimate_number_of_pages(result_size, page_size):
     """
     if page_size < 1:
         raise ValueError(
-            u"Could not estimate number of pages for query {}"
-            u" with page size lower than 1: {} {}".format(graphql_query, page_size, params)
+            f"Could not estimate number of pages for query {query}"
+            f" with page size lower than 1: {page_size}"
         )
 
     if result_size < 0.0:
         raise AssertionError(
-            u"Received negative estimate {} for cardinality of query {}: {}".format(
-                result_size, graphql_query, params
-            )
+            f"Received negative estimate {result_size} for cardinality of query {query}"
         )
 
     # Since using a // b returns the fraction rounded down, we instead use (a + b - 1) // b, which
@@ -83,7 +80,7 @@ def paginate_query_ast(
     """
     if page_size < 1:
         raise ValueError(
-            u"Could not page query {} with page size lower than 1: {}".format(query, page_size)
+            "Could not page query {} with page size lower than 1: {}".format(query, page_size)
         )
 
     # Initially, assume the query does not need to be paged i.e. will return one page of results.
@@ -94,10 +91,11 @@ def paginate_query_ast(
     # HACK(vlad): Since the current cost estimator expects GraphQL queries given as a string, we
     #             print the given AST and provide that to the cost estimator.
     graphql_query_string = print_ast(query.query_ast)
-    analysis = QueryPlanningAnalysis(schema_info,
-                                     QueryStringWithParameters(graphql_query_string, query.parameters))
+    analysis = QueryPlanningAnalysis(
+        schema_info, QueryStringWithParameters(graphql_query_string, query.parameters)
+    )
     result_size = analysis.cardinality_estimate
-    num_pages = _estimate_number_of_pages(result_size, page_size)
+    num_pages = _estimate_number_of_pages(query, result_size, page_size)
     if num_pages > 1:
         page_query, remainder_query, advisories = split_into_page_query_and_remainder_query(
             schema_info, query, num_pages

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -4,12 +4,56 @@ from typing import Tuple
 from graphql.language.printer import print_ast
 
 from ..ast_manipulation import safe_parse_graphql
-from ..cost_estimation.cardinality_estimator import estimate_number_of_pages
 from ..global_utils import ASTWithParameters, QueryStringWithParameters
+from ..cost_estimation.analysis import QueryPlanningAnalysis
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import PaginationAdvisory
 from .query_splitter import split_into_page_query_and_remainder_query
 from .typedefs import PageAndRemainder
+
+
+def _estimate_number_of_pages(result_size, page_size):
+    """Estimate how many pages of results will be generated for a given query.
+
+    Using the cardinality estimator, we generate an estimate for the query result cardinality i.e.
+    the number of result rows, then divide (rounding up) by the page_size to get the approximate
+    number of pages that the query will produce.
+    For example, if a query were estimated to return 12000 result rows, and the desired page size is
+    5000, then the query can be divided into ceil(12000/5000)=3 pages, each with a result size below
+    (or equal to) 5000 results.
+
+    Args:
+        schema_info: QueryPlanningSchemaInfo
+        graphql_query: str, valid GraphQL query to be estimated.
+        params: dict, parameters for the given query.
+        page_size: int, desired number of result rows per page.
+
+    Returns:
+        int, estimated number of pages if the query were executed.
+
+    Raises:
+        ValueError if page_size is below 1.
+    """
+    if page_size < 1:
+        raise ValueError(
+            u"Could not estimate number of pages for query {}"
+            u" with page size lower than 1: {} {}".format(graphql_query, page_size, params)
+        )
+
+    if result_size < 0.0:
+        raise AssertionError(
+            u"Received negative estimate {} for cardinality of query {}: {}".format(
+                result_size, graphql_query, params
+            )
+        )
+
+    # Since using a // b returns the fraction rounded down, we instead use (a + b - 1) // b, which
+    # returns the fraction value rounded up, which is the desired functionality.
+    num_pages = int((result_size + page_size - 1) // page_size)
+    if num_pages == 0:
+        num_pages = 1
+
+    return num_pages
 
 
 def paginate_query_ast(
@@ -50,9 +94,10 @@ def paginate_query_ast(
     # HACK(vlad): Since the current cost estimator expects GraphQL queries given as a string, we
     #             print the given AST and provide that to the cost estimator.
     graphql_query_string = print_ast(query.query_ast)
-    num_pages = estimate_number_of_pages(
-        schema_info, graphql_query_string, query.parameters, page_size
-    )
+    analysis = QueryPlanningAnalysis(schema_info,
+                                     QueryStringWithParameters(graphql_query_string, query.parameters))
+    result_size = analysis.cardinality_estimate
+    num_pages = _estimate_number_of_pages(result_size, page_size)
     if num_pages > 1:
         page_query, remainder_query, advisories = split_into_page_query_and_remainder_query(
             schema_info, query, num_pages

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -12,7 +12,7 @@ from .query_splitter import split_into_page_query_and_remainder_query
 from .typedefs import PageAndRemainder
 
 
-def _estimate_number_of_pages(query, result_size, page_size):
+def _estimate_number_of_pages(query: ASTWithParameters, result_size: float, page_size: int) -> int:
     """Estimate how many pages of results will be generated for a given query.
 
     Using the cardinality estimator, we generate an estimate for the query result cardinality i.e.

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -7,9 +7,8 @@ import pytest
 import pytz
 
 from .. import test_input_data
-from ...global_utils import ASTWithParameters, QueryStringWithParameters
 from ...compiler.metadata import FilterInfo
-from ...cost_estimation.cardinality_estimator import estimate_query_result_cardinality
+from ...cost_estimation.analysis import QueryPlanningAnalysis
 from ...cost_estimation.filter_selectivity_utils import (
     ABSOLUTE_SELECTIVITY,
     FRACTIONAL_SELECTIVITY,
@@ -24,7 +23,7 @@ from ...cost_estimation.int_value_conversion import (
 )
 from ...cost_estimation.interval import Interval, intersect_int_intervals
 from ...cost_estimation.statistics import LocalStatistics, Statistics
-from ...cost_estimation.analysis import QueryPlanningAnalysis
+from ...global_utils import QueryStringWithParameters
 from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ...schema_generation.schema_graph import SchemaGraph

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -7,6 +7,7 @@ import pytest
 import pytz
 
 from .. import test_input_data
+from ...global_utils import ASTWithParameters, QueryStringWithParameters
 from ...compiler.metadata import FilterInfo
 from ...cost_estimation.cardinality_estimator import estimate_query_result_cardinality
 from ...cost_estimation.filter_selectivity_utils import (
@@ -23,6 +24,7 @@ from ...cost_estimation.int_value_conversion import (
 )
 from ...cost_estimation.interval import Interval, intersect_int_intervals
 from ...cost_estimation.statistics import LocalStatistics, Statistics
+from ...cost_estimation.analysis import QueryPlanningAnalysis
 from ...schema.schema_info import QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ...schema_generation.schema_graph import SchemaGraph
@@ -43,7 +45,8 @@ def _make_schema_info_and_estimate_cardinality(
         pagination_keys=pagination_keys,
         uuid4_fields=uuid4_fields,
     )
-    return estimate_query_result_cardinality(schema_info, graphql_input, args)
+    analysis = QueryPlanningAnalysis(schema_info, QueryStringWithParameters(graphql_input, args))
+    return analysis.cardinality_estimate
 
 
 # The following TestCase class uses the 'snapshot_orientdb_client' fixture

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -8,8 +8,8 @@ import pytest
 import pytz
 
 from ...ast_manipulation import safe_parse_graphql
-from ...cost_estimation.cardinality_estimator import estimate_query_result_cardinality
 from ...cost_estimation.statistics import LocalStatistics
+from ...cost_estimation.analysis import QueryPlanningAnalysis
 from ...global_utils import ASTWithParameters, QueryStringWithParameters
 from ...query_pagination import paginate_query
 from ...query_pagination.pagination_planning import (
@@ -198,9 +198,7 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_remainder.parameters, remainder[0].parameters)
 
         # Check that the first page is estimated to fit into a page
-        first_page_cardinality_estimate = estimate_query_result_cardinality(
-            schema_info, first.query_string, first.parameters
-        )
+        first_page_cardinality_estimate = QueryPlanningAnalysis(schema_info, first).cardinality_estimate
         self.assertAlmostEqual(1, first_page_cardinality_estimate)
 
         # Get the second page
@@ -239,9 +237,7 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_remainder.parameters, remainder[0].parameters)
 
         # Check that the second page is estimated to fit into a page
-        second_page_cardinality_estimate = estimate_query_result_cardinality(
-            schema_info, second.query_string, second.parameters
-        )
+        second_page_cardinality_estimate = QueryPlanningAnalysis(schema_info, first).cardinality_estimate
         self.assertAlmostEqual(1, second_page_cardinality_estimate)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -8,8 +8,8 @@ import pytest
 import pytz
 
 from ...ast_manipulation import safe_parse_graphql
-from ...cost_estimation.statistics import LocalStatistics
 from ...cost_estimation.analysis import QueryPlanningAnalysis
+from ...cost_estimation.statistics import LocalStatistics
 from ...global_utils import ASTWithParameters, QueryStringWithParameters
 from ...query_pagination import paginate_query
 from ...query_pagination.pagination_planning import (
@@ -198,7 +198,9 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_remainder.parameters, remainder[0].parameters)
 
         # Check that the first page is estimated to fit into a page
-        first_page_cardinality_estimate = QueryPlanningAnalysis(schema_info, first).cardinality_estimate
+        first_page_cardinality_estimate = QueryPlanningAnalysis(
+            schema_info, first
+        ).cardinality_estimate
         self.assertAlmostEqual(1, first_page_cardinality_estimate)
 
         # Get the second page
@@ -237,7 +239,9 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_remainder.parameters, remainder[0].parameters)
 
         # Check that the second page is estimated to fit into a page
-        second_page_cardinality_estimate = QueryPlanningAnalysis(schema_info, first).cardinality_estimate
+        second_page_cardinality_estimate = QueryPlanningAnalysis(
+            schema_info, first
+        ).cardinality_estimate
         self.assertAlmostEqual(1, second_page_cardinality_estimate)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")


### PR DESCRIPTION
1. Remove `graphql_to_ir` call from `estimate_query_result_cardinality`. It doesn't belong there. During pagination the query metadata table is already available, and it's a waste to regenerate it.
2. Move `_estimate_number_of_pages` from cost estimation to pagination module, and remove unnecessary parameters from it.