### PR TITLE
Use ast for analysis

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -266,5 +266,6 @@ class QueryPlanningAnalysis:
 def analyze_query_string(
     schema_info: QueryPlanningSchemaInfo, query: QueryStringWithParameters
 ) -> QueryPlanningAnalysis:
+    """Create a QueryPlanningAnalysis object for the given query."""
     query_ast = safe_parse_graphql(query.query_string)
     return QueryPlanningAnalysis(schema_info, ASTWithParameters(query_ast, query.parameters))

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -217,7 +217,7 @@ class QueryPlanningAnalysis:
 
     @cached_property
     def query_string_with_parameters(self):
-        """Return the query in string form"""
+        """Return the query in string form."""
         query_string = print_ast(self.ast_with_parameters.query_ast)
         return QueryStringWithParameters(query_string, self.ast_with_parameters.parameters)
 

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -16,7 +16,7 @@ from ..cost_estimation.int_value_conversion import (
     is_uuid4_type,
 )
 from ..cost_estimation.interval import Interval
-from ..global_utils import PropertyPath, QueryStringWithParameters, VertexPath, ASTWithParameters
+from ..global_utils import ASTWithParameters, PropertyPath, QueryStringWithParameters, VertexPath
 from ..schema import is_meta_field
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .filter_selectivity_utils import (
@@ -259,10 +259,12 @@ class QueryPlanningAnalysis:
             self.field_value_intervals,
             self.distinct_result_set_estimates,
             self.metadata_table,
-            self.query_ast.parameters,
+            self.ast_with_parameters.parameters,
         )
 
 
-def analyze_query_string(schema_info: QueryPlanningSchemaInfo, query: QueryStringWithParameters) -> QueryPlanningAnalysis:
+def analyze_query_string(
+    schema_info: QueryPlanningSchemaInfo, query: QueryStringWithParameters
+) -> QueryPlanningAnalysis:
     query_ast = safe_parse_graphql(query.query_string)
     return QueryPlanningAnalysis(schema_info, ASTWithParameters(query_ast, query.parameters))

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -4,7 +4,7 @@ from typing import Tuple
 from graphql.language.printer import print_ast
 
 from ..ast_manipulation import safe_parse_graphql
-from ..cost_estimation.analysis import QueryPlanningAnalysis
+from ..cost_estimation.analysis import analyze_query_string
 from ..global_utils import ASTWithParameters, QueryStringWithParameters
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import PaginationAdvisory
@@ -84,7 +84,7 @@ def paginate_query_ast(
     # HACK(vlad): Since the current cost estimator expects GraphQL queries given as a string, we
     #             print the given AST and provide that to the cost estimator.
     graphql_query_string = print_ast(query.query_ast)
-    analysis = QueryPlanningAnalysis(
+    analysis = analyze_query_string(
         schema_info, QueryStringWithParameters(graphql_query_string, query.parameters)
     )
     result_size = analysis.cardinality_estimate

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -8,7 +8,7 @@ import pytz
 
 from .. import test_input_data
 from ...compiler.metadata import FilterInfo
-from ...cost_estimation.analysis import QueryPlanningAnalysis
+from ...cost_estimation.analysis import analyze_query_string
 from ...cost_estimation.filter_selectivity_utils import (
     ABSOLUTE_SELECTIVITY,
     FRACTIONAL_SELECTIVITY,
@@ -44,7 +44,7 @@ def _make_schema_info_and_estimate_cardinality(
         pagination_keys=pagination_keys,
         uuid4_fields=uuid4_fields,
     )
-    analysis = QueryPlanningAnalysis(schema_info, QueryStringWithParameters(graphql_input, args))
+    analysis = analyze_query_string(schema_info, QueryStringWithParameters(graphql_input, args))
     return analysis.cardinality_estimate
 
 

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from ...cost_estimation.analysis import QueryPlanningAnalysis
+from ...cost_estimation.analysis import analyze_query_string
 from ...cost_estimation.interval import Interval
 from ...cost_estimation.statistics import LocalStatistics
 from ...global_utils import QueryStringWithParameters
@@ -45,7 +45,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             }""",
             {"uuid_min": "80000000-0000-0000-0000-000000000000",},
         )
-        intervals = QueryPlanningAnalysis(schema_info, query).field_value_intervals
+        intervals = analyze_query_string(schema_info, query).field_value_intervals
         expected_intervals = {
             (("Animal",), "uuid"): Interval(
                 lower_bound="80000000-0000-0000-0000-000000000001", upper_bound=None
@@ -83,7 +83,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {"uuid": "80000000-0000-0000-0000-000000000000",},
         )
 
-        estimates = QueryPlanningAnalysis(schema_info, query).distinct_result_set_estimates
+        estimates = analyze_query_string(schema_info, query).distinct_result_set_estimates
         expected_estimates = {
             ("Animal",): 1,
             ("Animal", "out_Animal_ParentOf"): 1000,
@@ -117,7 +117,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {"uuid_min": "80000000-0000-0000-0000-000000000000",},
         )
 
-        capacities = QueryPlanningAnalysis(schema_info, query).pagination_capacities
+        capacities = analyze_query_string(schema_info, query).pagination_capacities
         expected_capacities = {(("Animal",), "uuid"): 500}
         self.assertEqual(expected_capacities, capacities)
 
@@ -148,7 +148,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {"uuid": "80000000-0000-0000-0000-000000000000",},
         )
 
-        capacities = QueryPlanningAnalysis(schema_info, query).pagination_capacities
+        capacities = analyze_query_string(schema_info, query).pagination_capacities
         expected_capacities = {(("Animal",), "uuid"): 1}
         self.assertEqual(expected_capacities, capacities)
 
@@ -181,7 +181,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {},
         )
 
-        capacities = QueryPlanningAnalysis(schema_info, query).pagination_capacities
+        capacities = analyze_query_string(schema_info, query).pagination_capacities
         expected_capacities = {
             (("Species",), "limbs"): 100,
             (("Species",), "uuid"): 1000,
@@ -218,7 +218,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {"limbs_min": 10,},
         )
 
-        capacities = QueryPlanningAnalysis(schema_info, query).pagination_capacities
+        capacities = analyze_query_string(schema_info, query).pagination_capacities
         expected_capacities = {
             (("Species",), "limbs"): 91,
             (("Species",), "uuid"): 905,

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -8,7 +8,7 @@ import pytest
 import pytz
 
 from ...ast_manipulation import safe_parse_graphql
-from ...cost_estimation.analysis import QueryPlanningAnalysis
+from ...cost_estimation.analysis import analyze_query_string
 from ...cost_estimation.statistics import LocalStatistics
 from ...global_utils import ASTWithParameters, QueryStringWithParameters
 from ...query_pagination import paginate_query
@@ -198,7 +198,7 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_remainder.parameters, remainder[0].parameters)
 
         # Check that the first page is estimated to fit into a page
-        first_page_cardinality_estimate = QueryPlanningAnalysis(
+        first_page_cardinality_estimate = analyze_query_string(
             schema_info, first
         ).cardinality_estimate
         self.assertAlmostEqual(1, first_page_cardinality_estimate)
@@ -239,7 +239,7 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_remainder.parameters, remainder[0].parameters)
 
         # Check that the second page is estimated to fit into a page
-        second_page_cardinality_estimate = QueryPlanningAnalysis(
+        second_page_cardinality_estimate = analyze_query_string(
             schema_info, first
         ).cardinality_estimate
         self.assertAlmostEqual(1, second_page_cardinality_estimate)


### PR DESCRIPTION
We have many passes that take a query ast and return a query ast because they are meant to be chained together, so returning and parsing a query string would be wasteful. Examples are macro expansion, and pagination.

Because of this, it makes more sense to use the AST as the starting point for analysis.