### PR TITLE
Propagate analysis

### DIFF
--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -4,7 +4,7 @@ from typing import Tuple
 from graphql.language.printer import print_ast
 
 from ..ast_manipulation import safe_parse_graphql
-from ..cost_estimation.analysis import analyze_query_string
+from ..cost_estimation.analysis import analyze_query_string, QueryPlanningAnalysis
 from ..global_utils import ASTWithParameters, QueryStringWithParameters
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import PaginationAdvisory
@@ -47,7 +47,7 @@ def _estimate_number_of_pages(query: ASTWithParameters, result_size: float, page
 
 
 def paginate_query_ast(
-    schema_info: QueryPlanningSchemaInfo, query: ASTWithParameters, page_size: int
+    query_analysis: QueryPlanningAnalysis, page_size: int
 ) -> Tuple[PageAndRemainder[ASTWithParameters], Tuple[PaginationAdvisory, ...]]:
     """Generate a query fetching a page of results and the remainder queries for a query AST.
 
@@ -56,8 +56,7 @@ def paginate_query_ast(
     magnitude of the estimate.
 
     Args:
-        schema_info: QueryPlanningSchemaInfo
-        query: ASTWithParameters
+        query_analysis: the query with any query analysis needed for pagination
         page_size: int, describes the desired number of result rows per page.
 
     Returns:
@@ -77,26 +76,22 @@ def paginate_query_ast(
         )
 
     # Initially, assume the query does not need to be paged i.e. will return one page of results.
-    page_query = query
+    page_query = query_analysis.ast_with_parameters
     remainder_queries: Tuple[ASTWithParameters, ...] = tuple()
     advisories: Tuple[PaginationAdvisory, ...] = tuple()
 
-    # HACK(vlad): Since the current cost estimator expects GraphQL queries given as a string, we
-    #             print the given AST and provide that to the cost estimator.
-    graphql_query_string = print_ast(query.query_ast)
-    analysis = analyze_query_string(
-        schema_info, QueryStringWithParameters(graphql_query_string, query.parameters)
-    )
-    result_size = analysis.cardinality_estimate
-    num_pages = _estimate_number_of_pages(query, result_size, page_size)
+    result_size = query_analysis.cardinality_estimate
+    num_pages = _estimate_number_of_pages(
+        query_analysis.query_string_with_parameters, result_size, page_size)
     if num_pages > 1:
         page_query, remainder_query, advisories = split_into_page_query_and_remainder_query(
-            schema_info, query, num_pages
+            query_analysis, num_pages
         )
         remainder_queries = (remainder_query,)
 
     return (
-        PageAndRemainder[ASTWithParameters](query, page_size, page_query, remainder_queries),
+        PageAndRemainder[ASTWithParameters](
+            query_analysis.ast_with_parameters, page_size, page_query, remainder_queries),
         advisories,
     )
 
@@ -126,9 +121,8 @@ def paginate_query(
     """
     query_ast = safe_parse_graphql(query.query_string)
 
-    ast_page_and_remainder, advisories = paginate_query_ast(
-        schema_info, ASTWithParameters(query_ast, query.parameters), page_size
-    )
+    query_analysis = analyze_query_string(schema_info, query)
+    ast_page_and_remainder, advisories = paginate_query_ast(query_analysis, page_size)
 
     page_query_with_parameters = QueryStringWithParameters(
         print_ast(ast_page_and_remainder.one_page.query_ast),

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -3,10 +3,8 @@ from abc import ABC
 from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
-from graphql import DocumentNode
-
-from ..cost_estimation.analysis import QueryPlanningAnalysis
 from ..ast_manipulation import get_only_query_definition, get_only_selection_from_ast
+from ..cost_estimation.analysis import QueryPlanningAnalysis
 from ..cost_estimation.helpers import is_uuid4_type
 from ..cost_estimation.int_value_conversion import field_supports_range_reasoning
 from ..exceptions import GraphQLError
@@ -174,11 +172,9 @@ def get_pagination_plan(
         tuple including a best-effort pagination plan together with a tuple of advisories describing
         any ways in which the pagination plan was less than ideal and how to resolve them
     """
-    # TODO propagate analysis?
-    schema_info = query_analysis.schema_info
-    query_ast = query_analysis.ast_with_parameters.query_ast
-
-    definition_ast = get_only_query_definition(query_ast, GraphQLError)
+    definition_ast = get_only_query_definition(
+        query_analysis.ast_with_parameters.query_ast, GraphQLError
+    )
 
     if number_of_pages <= 0:
         raise AssertionError(
@@ -200,7 +196,7 @@ def get_pagination_plan(
     root_node = get_only_selection_from_ast(definition_ast, GraphQLError).name.value
     pagination_node = root_node
     vertex_partition_plan, advisories = get_best_vertex_partition_plan(
-        schema_info, pagination_node, number_of_pages
+        query_analysis.schema_info, pagination_node, number_of_pages
     )
 
     if vertex_partition_plan is None:

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -16,6 +16,7 @@ from ..cost_estimation.int_value_conversion import (
     convert_int_to_field_value,
 )
 from ..cost_estimation.interval import Interval, intersect_int_intervals, measure_int_interval
+from ..global_utils import ASTWithParameters
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import VertexPartitionPlan
 
@@ -199,8 +200,7 @@ def _compute_parameters_for_non_uuid_field(
 
 def generate_parameters_for_vertex_partition(
     schema_info: QueryPlanningSchemaInfo,
-    query_ast: DocumentNode,
-    parameters: Dict[str, Any],
+    query: ASTWithParameters,
     vertex_partition: VertexPartitionPlan,
 ) -> Iterator[Any]:
     """Return a generator of parameter values that realize the vertex partition.
@@ -212,8 +212,7 @@ def generate_parameters_for_vertex_partition(
 
     Args:
         schema_info: contains statistics and relevant schema information
-        query_ast: the query for which we are generating parameters
-        parameters: parameters for the query
+        query: the query for which we are generating parameters
         vertex_partition: the pagination plan we are working on
 
     Returns:
@@ -231,7 +230,7 @@ def generate_parameters_for_vertex_partition(
         raise AssertionError("Invalid number of splits {}".format(vertex_partition))
 
     # Find the FilterInfos on the pagination field
-    graphql_query_string = print_ast(query_ast)
+    graphql_query_string = print_ast(query.query_ast)
     query_metadata = graphql_to_ir(
         schema_info.schema,
         graphql_query_string,
@@ -246,7 +245,7 @@ def generate_parameters_for_vertex_partition(
 
     # Get the value interval currently imposed by existing filters
     integer_interval = get_integer_interval_for_filters_on_field(
-        schema_info, filters_on_field, vertex_type, pagination_field, parameters
+        schema_info, filters_on_field, vertex_type, pagination_field, query.parameters
     )
     field_value_interval = _convert_int_interval_to_field_value_interval(
         schema_info, vertex_type, pagination_field, integer_interval

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -1,9 +1,8 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 import bisect
 import itertools
-from typing import Any, Dict, Iterator, List, cast
+from typing import Any, Iterator, List, cast
 
-from graphql import DocumentNode
 from graphql.language.printer import print_ast
 
 from ..compiler.compiler_frontend import graphql_to_ir

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -1,9 +1,8 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from typing import Tuple
 
-from ..global_utils import ASTWithParameters
-from ..schema.schema_info import QueryPlanningSchemaInfo
 from ..cost_estimation.analysis import QueryPlanningAnalysis
+from ..global_utils import ASTWithParameters
 from .pagination_planning import PaginationAdvisory, get_pagination_plan
 from .parameter_generator import generate_parameters_for_vertex_partition
 from .query_parameterizer import generate_parameterized_queries
@@ -36,14 +35,10 @@ def split_into_page_query_and_remainder_query(
     if num_pages <= 1:
         raise AssertionError(
             u"Could not split query {} into pagination queries for the next page"
-            u" of results, as the number of pages {} must be greater than 1: {}".format(
-                query.query_ast, num_pages, query.parameters
+            u" of results, as the number of pages {} must be greater than 1".format(
+                query_analysis.ast_with_parameters, num_pages
             )
         )
-
-    # TODO propagate analysis?
-    schema_info = query_analysis.schema_info
-    query = query_analysis.ast_with_parameters
 
     # TODO propagate advisories to top-level
     pagination_plan, advisories = get_pagination_plan(query_analysis, num_pages)
@@ -54,11 +49,16 @@ def split_into_page_query_and_remainder_query(
         )
 
     parameter_generator = generate_parameters_for_vertex_partition(
-        schema_info, query.query_ast, query.parameters, pagination_plan.vertex_partitions[0]
+        query_analysis.schema_info,
+        query_analysis.ast_with_parameters,
+        pagination_plan.vertex_partitions[0],
     )
     first_param = next(parameter_generator)
 
     page_query, remainder_query = generate_parameterized_queries(
-        schema_info, query, pagination_plan.vertex_partitions[0], first_param
+        query_analysis.schema_info,
+        query_analysis.ast_with_parameters,
+        pagination_plan.vertex_partitions[0],
+        first_param,
     )
     return page_query, remainder_query, advisories


### PR DESCRIPTION
Propagate a `QueryPlanningAnalysis` object from `paginate_query` to `get_query_plan`, removing hacks along the way. Refactor only.