### PR TITLE
Add edge constraints

### DIFF
--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -1,5 +1,8 @@
 # Copyright 2019-present Kensho Technologies, LLC.
+from typing import cast
+
 from graphql import GraphQLInt
+from graphql.type.definition import GraphQLObjectType
 
 from ..global_utils import is_same_type
 from ..schema import GraphQLDate, GraphQLDateTime
@@ -10,7 +13,9 @@ def is_datetime_field_type(
     schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
 ) -> bool:
     """Return whether the field is of type GraphQLDateTime."""
-    field_type = schema_info.schema.get_type(vertex_name).fields[field_name].type
+    field_type = (
+        cast(GraphQLObjectType, schema_info.schema.get_type(vertex_name)).fields[field_name].type
+    )
     return is_same_type(GraphQLDateTime, field_type)
 
 
@@ -18,7 +23,9 @@ def is_date_field_type(
     schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
 ) -> bool:
     """Return whether the field is of type GraphQLDate."""
-    field_type = schema_info.schema.get_type(vertex_name).fields[field_name].type
+    field_type = (
+        cast(GraphQLObjectType, schema_info.schema.get_type(vertex_name)).fields[field_name].type
+    )
     return is_same_type(GraphQLDate, field_type)
 
 
@@ -26,7 +33,9 @@ def is_int_field_type(
     schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
 ) -> bool:
     """Return whether the field is of type GraphQLInt."""
-    field_type = schema_info.schema.get_type(vertex_name).fields[field_name].type
+    field_type = (
+        cast(GraphQLObjectType, schema_info.schema.get_type(vertex_name)).fields[field_name].type
+    )
     return is_same_type(GraphQLInt, field_type)
 
 

--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -17,7 +17,7 @@ from ..schema.schema_info import QueryPlanningSchemaInfo
 def _get_field_type(
     schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
 ) -> Union[GraphQLList, GraphQLScalarType]:
-    """Get the GraphQL type of the field on the specified."""
+    """Get the GraphQL type of the field on the specified vertex."""
     return (
         cast(
             Union[GraphQLObjectType, GraphQLInterfaceType], schema_info.schema.get_type(vertex_name)

--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -1,42 +1,50 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from typing import cast
+from typing import Union, cast
 
-from graphql import GraphQLInt
-from graphql.type.definition import GraphQLObjectType
+from graphql import (
+    GraphQLInt,
+    GraphQLInterfaceType,
+    GraphQLList,
+    GraphQLObjectType,
+    GraphQLScalarType,
+)
 
 from ..global_utils import is_same_type
 from ..schema import GraphQLDate, GraphQLDateTime
 from ..schema.schema_info import QueryPlanningSchemaInfo
 
 
+def _get_field_type(
+    schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
+) -> Union[GraphQLList, GraphQLScalarType]:
+    return (
+        cast(
+            Union[GraphQLObjectType, GraphQLInterfaceType], schema_info.schema.get_type(vertex_name)
+        )
+        .fields[field_name]
+        .type
+    )
+
+
 def is_datetime_field_type(
     schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
 ) -> bool:
     """Return whether the field is of type GraphQLDateTime."""
-    field_type = (
-        cast(GraphQLObjectType, schema_info.schema.get_type(vertex_name)).fields[field_name].type
-    )
-    return is_same_type(GraphQLDateTime, field_type)
+    return is_same_type(GraphQLDateTime, _get_field_type(schema_info, vertex_name, field_name))
 
 
 def is_date_field_type(
     schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
 ) -> bool:
     """Return whether the field is of type GraphQLDate."""
-    field_type = (
-        cast(GraphQLObjectType, schema_info.schema.get_type(vertex_name)).fields[field_name].type
-    )
-    return is_same_type(GraphQLDate, field_type)
+    return is_same_type(GraphQLDate, _get_field_type(schema_info, vertex_name, field_name))
 
 
 def is_int_field_type(
     schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
 ) -> bool:
     """Return whether the field is of type GraphQLInt."""
-    field_type = (
-        cast(GraphQLObjectType, schema_info.schema.get_type(vertex_name)).fields[field_name].type
-    )
-    return is_same_type(GraphQLInt, field_type)
+    return is_same_type(GraphQLInt, _get_field_type(schema_info, vertex_name, field_name))
 
 
 def is_uuid4_type(schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str) -> bool:

--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -17,6 +17,7 @@ from ..schema.schema_info import QueryPlanningSchemaInfo
 def _get_field_type(
     schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
 ) -> Union[GraphQLList, GraphQLScalarType]:
+    """Get the GraphQL type of the field on the specified."""
     return (
         cast(
             Union[GraphQLObjectType, GraphQLInterfaceType], schema_info.schema.get_type(vertex_name)

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -4,10 +4,10 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, auto, unique
 from functools import partial
-from typing import Dict, Optional, Set, Union
+from typing import Dict, Optional, Set
 
 from graphql.type import GraphQLSchema
-from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType, GraphQLUnionType
+from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType
 import six
 import sqlalchemy
 from sqlalchemy.dialects.mssql import dialect as mssql_dialect
@@ -15,7 +15,7 @@ from sqlalchemy.dialects.mysql import dialect as mysql_dialect
 from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
 from sqlalchemy.engine.interfaces import Dialect
 
-from . import is_vertex_field_name
+from . import TypeEquivalenceHintsType, is_vertex_field_name
 from ..cost_estimation.statistics import Statistics
 from ..schema_generation.schema_graph import SchemaGraph
 
@@ -359,7 +359,7 @@ class QueryPlanningSchemaInfo:
     # Be very careful with this option, as bad input here will
     # lead to incorrect output queries being generated.
     # *****
-    type_equivalence_hints: Dict[Union[GraphQLInterfaceType, GraphQLObjectType], GraphQLUnionType]
+    type_equivalence_hints: TypeEquivalenceHintsType
 
     # A SchemaGraph instance that corresponds to the GraphQLSchema, containing additional
     # information on unique indexes, subclass sets, and edge base connection classes.

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -333,8 +333,8 @@ class EdgeConstraint(Enum):
     AtMostOneSource = auto()
     AtLeastOneDestination = auto()
     AtMostOneDestination = auto()
-    NoParallelEdges = auto()
-    NoLoops = auto()
+    NoParallelEdges = auto()  # No pair of edges with matching sources and destinations
+    NoLoops = auto()  # No edge with source = destination
 
 
 @dataclass

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -1,12 +1,13 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from abc import ABCMeta
 from collections import namedtuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum, auto, unique
 from functools import partial
-from typing import Dict, Optional
+from typing import Dict, Optional, Set, Union
 
 from graphql.type import GraphQLSchema
-from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType
+from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType, GraphQLUnionType
 import six
 import sqlalchemy
 from sqlalchemy.dialects.mssql import dialect as mssql_dialect
@@ -15,6 +16,8 @@ from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
 from sqlalchemy.engine.interfaces import Dialect
 
 from . import is_vertex_field_name
+from ..cost_estimation.statistics import Statistics
+from ..schema_generation.schema_graph import SchemaGraph
 
 
 # Describes the intent to join two tables using the specified columns.
@@ -324,46 +327,62 @@ def make_sqlalchemy_schema_info(
     )
 
 
-# All schema information sufficient for query cost estimation and auto pagination
-QueryPlanningSchemaInfo = namedtuple(
-    "QueryPlanningSchemaInfo",
-    (
-        # GraphQLSchema
-        "schema",
-        # optional dict of GraphQL interface or type -> GraphQL union.
-        # Used as a workaround for GraphQL's lack of support for
-        # inheritance across "types" (i.e. non-interfaces), as well as a
-        # workaround for Gremlin's total lack of inheritance-awareness.
-        # The key-value pairs in the dict specify that the "key" type
-        # is equivalent to the "value" type, i.e. that the GraphQL type or
-        # interface in the key is the most-derived common supertype
-        # of every GraphQL type in the "value" GraphQL union.
-        # Recursive expansion of type equivalence hints is not performed,
-        # and only type-level correctness of this argument is enforced.
-        # See README.md for more details on everything this parameter does.
-        # *****
-        # Be very careful with this option, as bad input here will
-        # lead to incorrect output queries being generated.
-        # *****
-        "type_equivalence_hints",
-        # A SchemaGraph instance that corresponds to the GraphQLSchema, containing additional
-        # information on unique indexes, subclass sets, and edge base connection classes.
-        "schema_graph",
-        # A Statistics object giving statistical information about all objects in the schema.
-        "statistics",
-        # Dict mapping vertex names in the graphql schema to the Int or ID type property name
-        # to be used for pagination on that vertex. This property should be non-null and
-        # unique for all rows.  An easy choice for pagination key in most situations is the
-        # primary key. The pagination key for a vertex can be omitted making the vertex
-        # ineligible for pagination.
-        #
-        # NOTE(bojanserafimov): The type of this property might be different in the
-        #                       schema graph, due to the process of type overrides that happens
-        #                       during schema generation.
-        "pagination_keys",
-        # Dict mapping vertex names in the graphql schema to a set of property names that
-        # are known to contain uniformly distributed uppercase uuid values. The types of those
-        # fields are expected to be ID or String.
-        "uuid4_fields",
-    ),
-)
+@unique
+class EdgeConstraint(Enum):
+    AtLeastOneSource = auto()
+    AtMostOneSource = auto()
+    AtLeastOneDestination = auto()
+    AtMostOneDestination = auto()
+    NoParallelEdges = auto()
+    NoLoops = auto()
+
+
+@dataclass
+class QueryPlanningSchemaInfo:
+    """All schema information sufficient for query cost estimation and auto pagination."""
+
+    # The schema used for querying
+    schema: GraphQLSchema
+
+    # optional dict of GraphQL interface or type -> GraphQL union.
+    # Used as a workaround for GraphQL's lack of support for
+    # inheritance across "types" (i.e. non-interfaces), as well as a
+    # workaround for Gremlin's total lack of inheritance-awareness.
+    # The key-value pairs in the dict specify that the "key" type
+    # is equivalent to the "value" type, i.e. that the GraphQL type or
+    # interface in the key is the most-derived common supertype
+    # of every GraphQL type in the "value" GraphQL union.
+    # Recursive expansion of type equivalence hints is not performed,
+    # and only type-level correctness of this argument is enforced.
+    # See README.md for more details on everything this parameter does.
+    # *****
+    # Be very careful with this option, as bad input here will
+    # lead to incorrect output queries being generated.
+    # *****
+    type_equivalence_hints: Dict[Union[GraphQLInterfaceType, GraphQLObjectType], GraphQLUnionType]
+
+    # A SchemaGraph instance that corresponds to the GraphQLSchema, containing additional
+    # information on unique indexes, subclass sets, and edge base connection classes.
+    schema_graph: SchemaGraph
+
+    # A Statistics object giving statistical information about all objects in the schema.
+    statistics: Statistics
+
+    # Dict mapping vertex names in the graphql schema to the Int or ID type property name
+    # to be used for pagination on that vertex. This property should be non-null and
+    # unique for all rows.  An easy choice for pagination key in most situations is the
+    # primary key. The pagination key for a vertex can be omitted making the vertex
+    # ineligible for pagination.
+    #
+    # NOTE(bojanserafimov): The type of this property might be different in the
+    #                       schema graph, due to the process of type overrides that happens
+    #                       during schema generation.
+    pagination_keys: Dict[str, str]
+
+    # Dict mapping vertex names in the graphql schema to a set of property names that
+    # are known to contain uniformly distributed uppercase uuid values. The types of those
+    # fields are expected to be ID or String.
+    uuid4_fields: Dict[str, Set[str]]
+
+    # Map edge names to constraints inferred for them.
+    edge_constraints: Dict[str, Set[EdgeConstraint]] = field(default_factory=dict)

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -329,12 +329,12 @@ def make_sqlalchemy_schema_info(
 
 @unique
 class EdgeConstraint(Enum):
+    """An integrity constraint on a directed edge in the schema."""
+
     AtLeastOneSource = auto()
     AtMostOneSource = auto()
     AtLeastOneDestination = auto()
     AtMostOneDestination = auto()
-    NoParallelEdges = auto()  # No pair of edges with matching sources and destinations
-    NoLoops = auto()  # No edge with source = destination
 
 
 @dataclass


### PR DESCRIPTION
Needed for better pagination planning. It's not good to paginate on a vertex reachable by many-to-one edges from a uniquely filtered vertex. To prevent this we need many-to-one edge information