### PR TITLE
Use many-to-one edges in pagination planning

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -8,7 +8,7 @@ from graphql.language.printer import print_ast
 
 from ..ast_manipulation import safe_parse_graphql
 from ..compiler.compiler_frontend import graphql_to_ir
-from ..compiler.helpers import get_edge_direction_and_name, Location
+from ..compiler.helpers import Location, get_edge_direction_and_name
 from ..compiler.metadata import FilterInfo, QueryMetadataTable
 from ..cost_estimation.cardinality_estimator import estimate_query_result_cardinality
 from ..cost_estimation.int_value_conversion import (
@@ -19,7 +19,7 @@ from ..cost_estimation.int_value_conversion import (
 from ..cost_estimation.interval import Interval
 from ..global_utils import ASTWithParameters, PropertyPath, QueryStringWithParameters, VertexPath
 from ..schema import is_meta_field
-from ..schema.schema_info import QueryPlanningSchemaInfo, EdgeConstraint
+from ..schema.schema_info import EdgeConstraint, QueryPlanningSchemaInfo
 from .filter_selectivity_utils import (
     adjust_counts_for_filters,
     get_integer_interval_for_filters_on_field,
@@ -142,8 +142,8 @@ def get_distinct_result_set_estimates(
             from_path = location.query_path[:-1]
             to_path = location.query_path
             edge_direction, edge_name = get_edge_direction_and_name(location.query_path[-1])
-            edge_constraints = schema_info.edge_constraints.get(edge_name, set())
-            if edge_direction == 'in':
+            edge_constraints = schema_info.edge_constraints.get(edge_name, EdgeConstraint(0))
+            if edge_direction == "in":
                 from_path, to_path = to_path, from_path
 
             if EdgeConstraint.AtMostOneDestination in edge_constraints:
@@ -153,8 +153,9 @@ def get_distinct_result_set_estimates(
 
     for _ in single_destination_traversals:  # This is on purpose (TODO explain why)
         for from_path, to_path in single_destination_traversals:
-            distinct_result_set_estimates[from_path] = min(distinct_result_set_estimates[from_path],
-                                                           distinct_result_set_estimates[to_path])
+            distinct_result_set_estimates[from_path] = min(
+                distinct_result_set_estimates[from_path], distinct_result_set_estimates[to_path]
+            )
 
     return distinct_result_set_estimates
 

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -144,8 +144,7 @@ def get_distinct_result_set_estimates(
             if EdgeConstraint.AtMostOneSource in edge_constraints:
                 single_destination_traversals.add((to_path, from_path))
 
-    # TODO 20
-    for i in range(20):
+    for _ in single_destination_traversals:  # This is on purpose (TODO explain why)
         for from_path, to_path in single_destination_traversals:
             distinct_result_set_estimates[from_path] = min(distinct_result_set_estimates[from_path],
                                                            distinct_result_set_estimates[to_path])

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -8,6 +8,7 @@ from graphql.language.printer import print_ast
 
 from ..ast_manipulation import safe_parse_graphql
 from ..compiler.compiler_frontend import graphql_to_ir
+from ..compiler.helpers import get_edge_direction_and_name
 from ..compiler.metadata import FilterInfo, QueryMetadataTable
 from ..cost_estimation.cardinality_estimator import estimate_query_result_cardinality
 from ..cost_estimation.int_value_conversion import (
@@ -18,7 +19,7 @@ from ..cost_estimation.int_value_conversion import (
 from ..cost_estimation.interval import Interval
 from ..global_utils import ASTWithParameters, PropertyPath, QueryStringWithParameters, VertexPath
 from ..schema import is_meta_field
-from ..schema.schema_info import QueryPlanningSchemaInfo
+from ..schema.schema_info import QueryPlanningSchemaInfo, EdgeConstraint
 from .filter_selectivity_utils import (
     adjust_counts_for_filters,
     get_integer_interval_for_filters_on_field,
@@ -125,10 +126,29 @@ def get_distinct_result_set_estimates(
             schema_info, filter_infos, parameters, vertex_type_name, class_count
         )
 
-    # TODO(bojanserafimov): If there's a many-to-one edge from A to B in the query, the
-    #                       distinct result set estimate for B cannot be greater than
-    #                       the one for A. Taking this into account would make the results
-    #                       more accurate.
+    single_destination_traversals = set()
+    for location, _ in query_metadata.registered_locations:
+        if len(location.query_path) > 1:
+            from_path = location.query_path[:-1]
+            to_path = location.query_path
+            # TODO(bojanserafimov): Make this work with FoldScope locations, and test analysis
+            #                       passes when query has folds. Also, a fold implies a single
+            #                       destination traversal.
+            edge_direction, edge_name = get_edge_direction_and_name(location.query_path[-1])
+            edge_constraints = schema_info.edge_constraints.get(edge_name, set())
+            if edge_direction == 'in':
+                from_path, to_path = to_path, from_path
+
+            if EdgeConstraint.AtMostOneDestination in edge_constraints:
+                single_destination_traversals.add((from_path, to_path))
+            if EdgeConstraint.AtMostOneSource in edge_constraints:
+                single_destination_traversals.add((to_path, from_path))
+
+    # TODO 20
+    for i in range(20):
+        for from_path, to_path in single_destination_traversals:
+            distinct_result_set_estimates[from_path] = min(distinct_result_set_estimates[from_path],
+                                                           distinct_result_set_estimates[to_path])
 
     return distinct_result_set_estimates
 

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -329,7 +329,7 @@ def make_sqlalchemy_schema_info(
 
 @unique
 class EdgeConstraint(Enum):
-    """An integrity constraint on a directed edge in the schema."""
+    """An integrity constraint on an edge in the schema."""
 
     AtLeastOneSource = auto()
     AtMostOneSource = auto()

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -24,7 +24,7 @@ from ...query_pagination.parameter_generator import (
     generate_parameters_for_vertex_partition,
 )
 from ...query_pagination.query_parameterizer import generate_parameterized_queries
-from ...schema.schema_info import QueryPlanningSchemaInfo, EdgeConstraint
+from ...schema.schema_info import EdgeConstraint, QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import compare_graphql, generate_schema_graph
 
@@ -116,9 +116,7 @@ class QueryPaginationTests(unittest.TestCase):
         uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
-        edge_constraints = {
-            'Animal_ParentOf': {EdgeConstraint.AtMostOneSource}
-        }
+        edge_constraints = {"Animal_ParentOf": EdgeConstraint.AtMostOneSource}
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
             type_equivalence_hints=type_equivalence_hints,
@@ -129,7 +127,8 @@ class QueryPaginationTests(unittest.TestCase):
             edge_constraints=edge_constraints,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Animal {
                 name @output(out_name: "animal_name")
                 in_Animal_ParentOf {

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -24,7 +24,7 @@ from ...query_pagination.parameter_generator import (
     generate_parameters_for_vertex_partition,
 )
 from ...query_pagination.query_parameterizer import generate_parameterized_queries
-from ...schema.schema_info import QueryPlanningSchemaInfo
+from ...schema.schema_info import QueryPlanningSchemaInfo, EdgeConstraint
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import compare_graphql, generate_schema_graph
 
@@ -103,6 +103,53 @@ class QueryPaginationTests(unittest.TestCase):
         # This is a white box test. We check that we don't paginate on the root when it has a
         # unique filter on it. A better plan is to paginate on a different vertex, but that is
         # not implemented.
+        expected_plan = PaginationPlan(tuple())
+        expected_warnings: Tuple[PaginationAdvisory, ...] = tuple()
+        self.assertEqual([w.message for w in expected_warnings], [w.message for w in warnings])
+        self.assertEqual(expected_plan, pagination_plan)
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_pagination_planning_unique_filter_on_many_to_one(self) -> None:
+        schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {"Animal": 1000}
+        statistics = LocalStatistics(class_counts)
+        edge_constraints = {
+            'Animal_ParentOf': {EdgeConstraint.AtMostOneSource}
+        }
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_fields=uuid4_fields,
+            edge_constraints=edge_constraints,
+        )
+
+        query = QueryStringWithParameters(
+            """{
+            Animal {
+                name @output(out_name: "animal_name")
+                in_Animal_ParentOf {
+                    uuid @filter(op_name: "=", value: ["$animal_uuid"])
+                }
+                out_Animal_ParentOf {
+                    name @output(out_name: "child_name")
+                }
+            }
+        }""",
+            {"animal_uuid": "40000000-0000-0000-0000-000000000000",},
+        )
+        number_of_pages = 10
+        analysis = analyze_query_string(schema_info, query)
+        pagination_plan, warnings = get_pagination_plan(analysis, number_of_pages)
+
+        # This is a white box test. We check that we don't paginate on the root when it has a
+        # unique filter on its many-to-one neighbor. A better plan is to paginate on a
+        # different vertex, but that is not implemented.
         expected_plan = PaginationPlan(tuple())
         expected_warnings: Tuple[PaginationAdvisory, ...] = tuple()
         self.assertEqual([w.message for w in expected_warnings], [w.message for w in warnings])


### PR DESCRIPTION
Make sure there is no unique filter on query nodes reachable from the pagination node by many-to-one edges.