### PR TITLE
Fix bug with impossible pagination

### DIFF
--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -13,15 +13,9 @@ def split_into_page_query_and_remainder_query(
 ) -> Tuple[ASTWithParameters, ASTWithParameters]:
     """Split a query into two equivalent queries, one of which will return roughly a page of data.
 
-    First, two parameterized queries are generated that contain filters usable for pagination i.e.
-    filters with which the number of results can be constrained. Parameters for these filters are
-    then generated such that one of the new queries will return roughly a page of results, while the
-    other query will generate the rest of the results. This ensures that the two new queries' result
-    data is equivalent to the original query's result data.
-
     Args:
         query_analysis: the query with any query analysis needed for pagination
-        pagination_plan: plan on how to split the query
+        pagination_plan: plan on how to split the query. The plan defines what is considered a page
 
     Returns:
         tuple containing three elements:
@@ -30,7 +24,6 @@ def split_into_page_query_and_remainder_query(
             - ASTWithParameters or None, describing a query that returns the rest of the
               result data of the original query. If the original query is expected to return only a
               page or less of results, then this element will have value None.
-            - Tuple of PaginationAdvisories that communicate what can be done to improve pagination
     """
     if len(pagination_plan.vertex_partitions) != 1:
         raise NotImplementedError(

--- a/graphql_compiler/query_pagination/query_splitter.py
+++ b/graphql_compiler/query_pagination/query_splitter.py
@@ -3,14 +3,14 @@ from typing import Tuple
 
 from ..cost_estimation.analysis import QueryPlanningAnalysis
 from ..global_utils import ASTWithParameters
-from .pagination_planning import PaginationAdvisory, PaginationPlan, get_pagination_plan
+from .pagination_planning import PaginationPlan
 from .parameter_generator import generate_parameters_for_vertex_partition
 from .query_parameterizer import generate_parameterized_queries
 
 
 def split_into_page_query_and_remainder_query(
     query_analysis: QueryPlanningAnalysis, pagination_plan: PaginationPlan
-) -> Tuple[ASTWithParameters, ASTWithParameters, Tuple[PaginationAdvisory, ...]]:
+) -> Tuple[ASTWithParameters, ASTWithParameters]:
     """Split a query into two equivalent queries, one of which will return roughly a page of data.
 
     First, two parameterized queries are generated that contain filters usable for pagination i.e.

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1178,7 +1178,7 @@ class QueryPaginationTests(unittest.TestCase):
         first = first_page_and_remainder.one_page
         remainder = first_page_and_remainder.remainder
 
-        # No pagination necessary
+        # Query should be split, but there's no viable pagination method.
         compare_graphql(self, original_query.query_string, first.query_string)
         self.assertEqual(original_query.parameters, first.parameters)
         self.assertEqual(0, len(remainder))


### PR DESCRIPTION
When pagination is needed but not possible we get an `AssertionError`. Instead we should return a non-paginated query.

In this diff I fix that bug, and resolve an unrelated TODO (advisory plumbing) on the way.