### PR TITLE
Test pagination with compiler tests

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -85,6 +85,8 @@ def get_field_value_intervals(
 
         # Find field_value_interval for each field
         for field_name, filters_on_field in single_field_filters.items():
+            # TODO add:
+            # if field_supports_range_reasoning(schema_info, location_name, field_name):
             integer_interval = get_integer_interval_for_filters_on_field(
                 schema_info, filters_on_field, vertex_type_name, field_name, parameters
             )

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -70,6 +70,9 @@ def get_field_value_intervals(
     """
     field_value_intervals = {}
     for location, location_info in query_metadata.registered_locations:
+        if not isinstance(location, Location):
+            continue  # We don't paginate inside folds.
+
         filter_infos = query_metadata.get_filter_infos(location)
         vertex_type_name = location_info.type.name
 

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -58,7 +58,10 @@ def get_field_value_intervals(
     query_metadata: QueryMetadataTable,
     parameters: Dict[str, Any],
 ) -> Dict[PropertyPath, Interval[Any]]:
-    """Map the PropertyPath of each field in the query with filters to its field value interval.
+    """Map the PropertyPath of each supported field with filters to its field value interval.
+
+    This method only considers fields on which we have range reasoning
+    (see field_supports_range_reasoning) that are not inside folds.
 
     Args:
         schema_info: QueryPlanningSchemaInfo

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -88,16 +88,15 @@ def get_field_value_intervals(
 
         # Find field_value_interval for each field
         for field_name, filters_on_field in single_field_filters.items():
-            # TODO add:
-            # if field_supports_range_reasoning(schema_info, location_name, field_name):
-            integer_interval = get_integer_interval_for_filters_on_field(
-                schema_info, filters_on_field, vertex_type_name, field_name, parameters
-            )
-            field_value_interval = _convert_int_interval_to_field_value_interval(
-                schema_info, vertex_type_name, field_name, integer_interval
-            )
-            property_path = PropertyPath(location.query_path, field_name)
-            field_value_intervals[property_path] = field_value_interval
+            if field_supports_range_reasoning(schema_info, vertex_type_name, field_name):
+                integer_interval = get_integer_interval_for_filters_on_field(
+                    schema_info, filters_on_field, vertex_type_name, field_name, parameters
+                )
+                field_value_interval = _convert_int_interval_to_field_value_interval(
+                    schema_info, vertex_type_name, field_name, integer_interval
+                )
+                property_path = PropertyPath(location.query_path, field_name)
+                field_value_intervals[property_path] = field_value_interval
     return field_value_intervals
 
 

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -301,9 +301,10 @@ def get_integer_interval_for_filters_on_field(
     """Get the interval of possible values on this field, constrained by its inequality filters."""
     interval = Interval[int](None, None)
     for filter_info in filters_on_field:
-        if not _filter_uses_only_runtime_parameters(filter_info):
-            continue  # We can't reason about tagged parameters
         if filter_info.op_name in INEQUALITY_OPERATORS:
+            if not _filter_uses_only_runtime_parameters(filter_info):
+                continue  # We can't reason about tagged parameters in inequality filters
+
             parameter_values = [
                 convert_field_value_to_int(
                     schema_info,
@@ -400,7 +401,7 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
         for filter_info in filters_on_field:
             if filter_info.op_name == "in_collection":
                 if not _filter_uses_only_runtime_parameters(filter_info):
-                    continue  # We can't reason about tagged parameters
+                    continue  # We can't reason about tagged parameters in in_collection filters
 
                 # TODO(bojanserafimov): Check if the filter values are in the interval selected
                 #                       by the inequality filters.

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -17,6 +17,7 @@ import datetime
 from typing import Any
 from uuid import UUID
 
+from ..schema import is_meta_field
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .helpers import is_date_field_type, is_datetime_field_type, is_int_field_type, is_uuid4_type
 
@@ -34,6 +35,8 @@ def field_supports_range_reasoning(
     schema_info: QueryPlanningSchemaInfo, vertex_class: str, property_field: str
 ) -> bool:
     """Return whether range reasoning is supported. See module docstring for definition."""
+    if is_meta_field(property_field):
+        return False
     return (
         is_uuid4_type(schema_info, vertex_class, property_field)
         or is_int_field_type(schema_info, vertex_class, property_field)

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1205,12 +1205,6 @@ class QueryPaginationTests(unittest.TestCase):
         from ..test_input_data import CommonTestData
 
         failing_tests = (
-            "complex_optional_variables",
-            "filter_count_with_tagged_optional_parameter_in_fold_scope",
-            "filter_count_with_tagged_parameter_in_fold_scope",
-            "filter_field_with_tagged_optional_parameter_in_fold_scope",
-            "in_collection_op_filter_with_optional_tag",
-            "in_collection_op_filter_with_tag",
         )
 
         for test_name in dir(test_input_data):

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -27,9 +27,8 @@ from ...query_pagination.parameter_generator import (
 from ...query_pagination.query_parameterizer import generate_parameterized_queries
 from ...schema.schema_info import EdgeConstraint, QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
-from ..test_helpers import compare_graphql, generate_schema_graph
+from ..test_helpers import compare_graphql, generate_schema_graph, get_function_names_from_module
 from ..test_input_data import CommonTestData
-from ..test_testing_invariants import get_function_names_from_module
 
 
 # The following TestCase class uses the 'snapshot_orientdb_client' fixture

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -7,6 +7,7 @@ from graphql import print_ast
 import pytest
 import pytz
 
+from .. import test_input_data
 from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.analysis import analyze_query_string
 from ...cost_estimation.statistics import LocalStatistics
@@ -27,6 +28,7 @@ from ...query_pagination.query_parameterizer import generate_parameterized_queri
 from ...schema.schema_info import EdgeConstraint, QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import compare_graphql, generate_schema_graph
+from ..test_input_data import CommonTestData
 
 
 # The following TestCase class uses the 'snapshot_orientdb_client' fixture
@@ -1185,6 +1187,7 @@ class QueryPaginationTests(unittest.TestCase):
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_with_compiler_tests(self):
+        """Test that pagination doesn't crash on any of the queries from the compiler tests."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
@@ -1201,10 +1204,7 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_fields=uuid4_fields,
         )
 
-        from .. import test_input_data
-        from ..test_input_data import CommonTestData
-
-        arg_value = {
+        arbitrary_value_for_type = {
             "String": "lol",
             "ID": "40000000-0000-0000-0000-000000000000",
             "Int": 5,
@@ -1222,7 +1222,7 @@ class QueryPaginationTests(unittest.TestCase):
                     test_data = method()
                     query = test_data.graphql_input
                     args = {
-                        arg_name: arg_value[str(arg_type)]
+                        arg_name: arbitrary_value_for_type[str(arg_type)]
                         for arg_name, arg_type in test_data.expected_input_metadata.items()
                     }
                     paginate_query(schema_info, QueryStringWithParameters(query, args), 10)

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1205,7 +1205,7 @@ class QueryPaginationTests(unittest.TestCase):
         )
 
         arbitrary_value_for_type = {
-            "String": "lol",
+            "String": "string_1",
             "ID": "40000000-0000-0000-0000-000000000000",
             "Int": 5,
             "Date": datetime.date(2000, 1, 1),

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1211,7 +1211,7 @@ class QueryPaginationTests(unittest.TestCase):
             "Date": datetime.date(2000, 1, 1),
             "DateTime": datetime.datetime(2000, 1, 1),
             "Decimal": 5.3,
-            "[String]": ["lol", "lel"],
+            "[String]": ["string_1", "string_2"],
         }
 
         for test_name in dir(test_input_data):

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -29,6 +29,7 @@ from ...schema.schema_info import EdgeConstraint, QueryPlanningSchemaInfo
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import compare_graphql, generate_schema_graph
 from ..test_input_data import CommonTestData
+from ..test_testing_invariants import get_function_names_from_module
 
 
 # The following TestCase class uses the 'snapshot_orientdb_client' fixture
@@ -1214,7 +1215,7 @@ class QueryPaginationTests(unittest.TestCase):
             "[String]": ["string_1", "string_2"],
         }
 
-        for test_name in dir(test_input_data):
+        for test_name in get_function_names_from_module(test_input_data):
             method = getattr(test_input_data, test_name)
             if hasattr(method, "__annotations__"):
                 output_type = method.__annotations__.get("return")

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1207,6 +1207,18 @@ class QueryPaginationTests(unittest.TestCase):
         failing_tests = (
         )
 
+        from graphql import GraphQLID, GraphQLInt, GraphQLList, GraphQLString
+        from ...schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal, GraphQLSchemaFieldType
+        arg_value = {
+            "String": "lol",
+            "ID": "40000000-0000-0000-0000-000000000000",
+            "Int": 5,
+            "Date": datetime.date(2000, 1, 1),
+            "DateTime": datetime.datetime(2000, 1, 1),
+            "Decimal": 5.3,
+            "[String]": ["lol", "lel"],
+        }
+
         for test_name in dir(test_input_data):
             if test_name in failing_tests:
                 continue
@@ -1216,7 +1228,9 @@ class QueryPaginationTests(unittest.TestCase):
                 if output_type == CommonTestData:
                     test_data = method()
                     query = test_data.graphql_input
-                    if test_data.expected_input_metadata == {}:
-                        args = {}
-                        paginate_query(schema_info, QueryStringWithParameters(query, args), 10)
+                    args = {
+                        arg_name: arg_value[str(arg_type)]
+                        for arg_name, arg_type in test_data.expected_input_metadata.items()
+                    }
+                    paginate_query(schema_info, QueryStringWithParameters(query, args), 10)
 

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1202,12 +1202,27 @@ class QueryPaginationTests(unittest.TestCase):
         )
 
         from .. import test_input_data
+        from ..test_input_data import CommonTestData
+
+        failing_tests = (
+            "complex_optional_variables",
+            "filter_count_with_tagged_optional_parameter_in_fold_scope",
+            "filter_count_with_tagged_parameter_in_fold_scope",
+            "filter_field_with_tagged_optional_parameter_in_fold_scope",
+            "in_collection_op_filter_with_optional_tag",
+            "in_collection_op_filter_with_tag",
+        )
+
         for test_name in dir(test_input_data):
-            if test_name[0].islower():
-                method = getattr(test_input_data, test_name)
-                test_data = method()
-                query = test_data.graphql_input
-                if test_data.expected_input_metadata == {}:
-                    args = {}
-                    paginate_query(schema_info, QueryStringWithParameters(query, args), 10)
+            if test_name in failing_tests:
+                continue
+            method = getattr(test_input_data, test_name)
+            if hasattr(method, '__annotations__'):
+                output_type = method.__annotations__.get('return')
+                if output_type == CommonTestData:
+                    test_data = method()
+                    query = test_data.graphql_input
+                    if test_data.expected_input_metadata == {}:
+                        args = {}
+                        paginate_query(schema_info, QueryStringWithParameters(query, args), 10)
 

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1204,11 +1204,6 @@ class QueryPaginationTests(unittest.TestCase):
         from .. import test_input_data
         from ..test_input_data import CommonTestData
 
-        failing_tests = (
-        )
-
-        from graphql import GraphQLID, GraphQLInt, GraphQLList, GraphQLString
-        from ...schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal, GraphQLSchemaFieldType
         arg_value = {
             "String": "lol",
             "ID": "40000000-0000-0000-0000-000000000000",
@@ -1220,11 +1215,9 @@ class QueryPaginationTests(unittest.TestCase):
         }
 
         for test_name in dir(test_input_data):
-            if test_name in failing_tests:
-                continue
             method = getattr(test_input_data, test_name)
-            if hasattr(method, '__annotations__'):
-                output_type = method.__annotations__.get('return')
+            if hasattr(method, "__annotations__"):
+                output_type = method.__annotations__.get("return")
                 if output_type == CommonTestData:
                     test_data = method()
                     query = test_data.graphql_input
@@ -1233,4 +1226,3 @@ class QueryPaginationTests(unittest.TestCase):
                         for arg_name, arg_type in test_data.expected_input_metadata.items()
                     }
                     paginate_query(schema_info, QueryStringWithParameters(query, args), 10)
-

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -1,6 +1,7 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Common test data and helper functions."""
 from collections import namedtuple
+from inspect import getmembers, isfunction
 from pprint import pformat
 import re
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -443,6 +444,23 @@ BackendTester = namedtuple(
         "setup_data",
     ),
 )
+
+
+def get_function_names_from_module(module):
+    """Return a set of function names present in a given module."""
+    return {member for member, member_type in getmembers(module) if isfunction(member_type)}
+
+
+def get_test_function_names_from_class(test_class):
+    """Return a set of test function names present in a given TestCase class."""
+    if not issubclass(test_class, unittest.TestCase):
+        raise AssertionError(u"Received non-test class {} as input.".format(test_class))
+    member_dict = test_class.__dict__
+    return {
+        member
+        for member in member_dict
+        if isfunction(member_dict[member]) and member[:5] == "test_"
+    }
 
 
 def transform(emitted_output: str) -> str:

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -453,7 +453,7 @@ def get_function_names_from_module(module):
 
 def get_test_function_names_from_class(test_class):
     """Return a set of test function names present in a given TestCase class."""
-    if not issubclass(test_class, unittest.TestCase):
+    if not issubclass(test_class, TestCase):
         raise AssertionError(u"Received non-test class {} as input.".format(test_class))
     member_dict = test_class.__dict__
     return {

--- a/graphql_compiler/tests/test_testing_invariants.py
+++ b/graphql_compiler/tests/test_testing_invariants.py
@@ -1,26 +1,9 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Common GraphQL test inputs and expected outputs."""
-from inspect import getmembers, isfunction
 import unittest
 
-import graphql_compiler.tests.test_input_data as test_input_data
-
-
-def get_function_names_from_module(module):
-    """Return a set of function names present in a given module."""
-    return {member for member, member_type in getmembers(module) if isfunction(member_type)}
-
-
-def get_test_function_names_from_class(test_class):
-    """Return a set of test function names present in a given TestCase class."""
-    if not issubclass(test_class, unittest.TestCase):
-        raise AssertionError(u"Received non-test class {} as input.".format(test_class))
-    member_dict = test_class.__dict__
-    return {
-        member
-        for member in member_dict
-        if isfunction(member_dict[member]) and member[:5] == "test_"
-    }
+from . import test_input_data as test_input_data
+from .test_helpers import get_function_names_from_module, get_test_function_names_from_class
 
 
 # The namedtuple function is imported from test_input_data,


### PR DESCRIPTION
Checking that pagination does not raise errors on any of the 140 compiler input data tests. The implementation of this with `dir` and `getattr` is not great, but I'll address that after I address the bugs.

Bugs discovered and addressed:
1. Attempting to do range reasoning on fields that don't support it
2. Attempting to reason about the range of tagged parameters as if they were runtime parameters
3. FoldScopeLocation not expected
4. Attempting range reasoning on meta field

Remaining limitations:
1. Bad things will happen if we paginate on a field that has an inequality filter with a tagged parameter. Not sure what yet, will address in separate PR.