### PR TITLE
Disable pagination with tags

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -87,7 +87,7 @@ def get_single_field_filters(
                     filter_info
                 )
             else:
-                pass  # We don't do anything for multi-field filters yet
+                pass
 
         for field_name, filters in single_field_filters_for_vertex.items():
             property_path = PropertyPath(location.query_path, field_name)

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -57,7 +57,18 @@ def _convert_int_interval_to_field_value_interval(
 def get_single_field_filters(
     schema_info: QueryPlanningSchemaInfo, query_metadata: QueryMetadataTable,
 ) -> Dict[PropertyPath, Set[FilterInfo]]:
-    """Find the single field filters for each field. Filters like name_or_alias are excluded."""
+    """Find the single field filters for each field.
+
+    Filters that apply to multiple fields, like name_or_alias, are ignored.
+    Filters inside fold scopes are not considered.
+
+    Args:
+        schema_info: QueryPlanningSchemaInfo
+        query_metadata: info on locations, inputs, outputs, and tags in the query
+
+    Returns:
+        A set of filters for each field.
+    """
     single_field_filters = {}
     for location, location_info in query_metadata.registered_locations:
         if not isinstance(location, Location):

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -154,6 +154,9 @@ def get_field_value_intervals(
         for field_name, _ in location_info.type.fields.items():
             property_path = PropertyPath(location.query_path, field_name)
             filters_on_field: Set[FilterInfo] = single_field_filters.get(property_path, set())
+            if not filters_on_field:
+                continue
+
             if field_supports_range_reasoning(schema_info, vertex_type_name, field_name):
                 integer_interval = get_integer_interval_for_filters_on_field(
                     schema_info, filters_on_field, vertex_type_name, field_name, parameters

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -4,7 +4,7 @@ from __future__ import division
 import bisect
 from collections import namedtuple
 import sys
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 import six
 
@@ -293,7 +293,7 @@ def filter_uses_only_runtime_parameters(filter_info: FilterInfo) -> bool:
 
 def get_integer_interval_for_filters_on_field(
     schema_info: QueryPlanningSchemaInfo,
-    filters_on_field: List[FilterInfo],
+    filters_on_field: Set[FilterInfo],
     location_name: str,
     field_name: str,
     parameters: Dict[str, Any],
@@ -336,12 +336,13 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
         Selectivity object
     """
     # Group filters by field
+    # TODO this is already computed in QueryPlanningAnalysis.single_field_filters
     single_field_filters = {}
     for filter_info in filter_infos:
         if len(filter_info.fields) == 0:
             raise AssertionError(u"Got filter on 0 fields {} {}".format(filter_info, location_name))
         elif len(filter_info.fields) == 1:
-            single_field_filters.setdefault(filter_info.fields[0], []).append(filter_info)
+            single_field_filters.setdefault(filter_info.fields[0], set()).add(filter_info)
         else:
             pass  # We don't do anything for multi-field filters yet
 

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -283,7 +283,7 @@ def _get_selectivity_fraction_of_interval(
     return float(interval_size) / domain_interval_size
 
 
-def _filter_uses_only_runtime_parameters(filter_info: FilterInfo) -> bool:
+def filter_uses_only_runtime_parameters(filter_info: FilterInfo) -> bool:
     """Return whether the filter uses only runtime parameters."""
     for filter_argument in filter_info.args:
         if not is_runtime_parameter(filter_argument):
@@ -302,7 +302,7 @@ def get_integer_interval_for_filters_on_field(
     interval = Interval[int](None, None)
     for filter_info in filters_on_field:
         if filter_info.op_name in INEQUALITY_OPERATORS:
-            if not _filter_uses_only_runtime_parameters(filter_info):
+            if not filter_uses_only_runtime_parameters(filter_info):
                 continue  # We can't reason about tagged parameters in inequality filters
 
             parameter_values = [
@@ -400,7 +400,7 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
         # Process in_collection filters
         for filter_info in filters_on_field:
             if filter_info.op_name == "in_collection":
-                if not _filter_uses_only_runtime_parameters(filter_info):
+                if not filter_uses_only_runtime_parameters(filter_info):
                     continue  # We can't reason about tagged parameters in in_collection filters
 
                 # TODO(bojanserafimov): Check if the filter values are in the interval selected

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -238,9 +238,9 @@ def generate_parameters_for_vertex_partition(
     query_location = Location(vertex_partition.query_path)
     vertex_type = query_metadata.get_location_info(query_location).type.name
     filter_infos = query_metadata.get_filter_infos(query_location)
-    filters_on_field = [
+    filters_on_field = {
         filter_info for filter_info in filter_infos if filter_info.fields == (pagination_field,)
-    ]
+    }
 
     # Get the value interval currently imposed by existing filters
     integer_interval = get_integer_interval_for_filters_on_field(

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1148,10 +1148,10 @@ class QueryPaginationTests(unittest.TestCase):
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_impossible_pagination(self):
-        """Ensure pagination is not done when not needed."""
+        """Ensure no unwanted error is raised when pagination is needed but stats are missing."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {}
+        pagination_keys = {}  # No pagination keys, so the planner has no options
         uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
         original_query = QueryStringWithParameters(
             """{


### PR DESCRIPTION
Currently we might paginate on a field that has an inequality filter using a tagged parameter. Our code is not smart enough to deal with that, so whatever output we produce is bound to be wrong in many ways. In this PR I disable pagination on such fields.

Breakdown of changes:
1. Add a `get_fields_eligible_for_pagination` analysis pass. The pass makes sure to exclude meta fields, fields inside `@fold`, and fields with tagged parameters in inequality filters.
2. Add a `get_single_field_filters` analysis. This is a refactor that materializes analysis that is currently used by cost estimation, pagination, and the new pagination field eligibility test.
3. Add a test for  `get_single_field_filters`
4. Use the new analysis passes in computation of pagination capacities.

There is no end-to-end test for this right now, since we only paginate on the root, and tagged parameters cannot appear on filters in the root since they have to be declared before they are used, and property fields come before vertex fields.