### PR TITLE
Use db-agnostic uuids for pagination parameter generation

### DIFF
--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -98,7 +98,7 @@ def _convert_int_interval_to_field_value_interval(
     return Interval(lower_bound, upper_bound)
 
 
-def _make_uuid_mssql_compatible(uuid_value: str) -> str:
+def _get_nearest_db_agnostic_uuid(uuid_value: str) -> str:
     """Return the nearest db-agnostic uuid.
 
     Most databases compare uuids by considering the leftmost digist most significant.
@@ -166,7 +166,7 @@ def _compute_parameters_for_uuid_field(
         convert_int_to_field_value(schema_info, vertex_type, field, int_value)
         for int_value in int_value_splits
     )
-    return (_make_uuid_mssql_compatible(uuid_value) for uuid_value in uuid_value_splits)
+    return (_get_nearest_db_agnostic_uuid(uuid_value) for uuid_value in uuid_value_splits)
 
 
 def _compute_parameters_for_non_uuid_field(

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -98,6 +98,13 @@ def _convert_int_interval_to_field_value_interval(
     return Interval(lower_bound, upper_bound)
 
 
+def _make_uuid_mssql_compatible(uuid_value: str) -> str:
+    # TODO document
+    segments = uuid_value.split("-")
+    segments[4] = segments[0] + segments[1]
+    return "-".join(segments)
+
+
 def _compute_parameters_for_uuid_field(
     schema_info: QueryPlanningSchemaInfo,
     integer_interval: Interval[int],
@@ -135,9 +142,12 @@ def _compute_parameters_for_uuid_field(
         )
         for i in range(1, vertex_partition.number_of_splits)
     )
-    return (
+    uuid_value_splits = (
         convert_int_to_field_value(schema_info, vertex_type, field, int_value)
         for int_value in int_value_splits
+    )
+    return (
+        _make_uuid_mssql_compatible(uuid_value) for uuid_value in uuid_value_splits
     )
 
 

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -166,6 +166,9 @@ def _compute_parameters_for_uuid_field(
         convert_int_to_field_value(schema_info, vertex_type, field, int_value)
         for int_value in int_value_splits
     )
+
+    # There are 2^80 db-agnostic uuid values. Since we don't expect the number of pages
+    # to be even near that number, there shouldn't be any loss of precision from this.
     return (_get_nearest_db_agnostic_uuid(uuid_value) for uuid_value in uuid_value_splits)
 
 

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -271,7 +271,7 @@ class QueryPaginationTests(unittest.TestCase):
                     name @output(out_name: "animal")
                 }
             }""",
-            {"__paged_param_0": "40000000-0000-0000-0000-000000000000",},
+            {"__paged_param_0": "40000000-0000-0000-0000-400000000000",},
         )
 
         expected_remainder = QueryStringWithParameters(
@@ -281,7 +281,7 @@ class QueryPaginationTests(unittest.TestCase):
                     name @output(out_name: "animal")
                 }
             }""",
-            {"__paged_param_0": "40000000-0000-0000-0000-000000000000",},
+            {"__paged_param_0": "40000000-0000-0000-0000-400000000000",},
         )
 
         # Check that the correct first page and remainder are generated
@@ -311,8 +311,8 @@ class QueryPaginationTests(unittest.TestCase):
                 }
             }""",
             {
-                "__paged_param_0": "40000000-0000-0000-0000-000000000000",
-                "__paged_param_1": "80000000-0000-0000-0000-000000000000",
+                "__paged_param_0": "40000000-0000-0000-0000-400000000000",
+                "__paged_param_1": "80000000-0000-0000-0000-800000000000",
             },
         )
         expected_remainder = QueryStringWithParameters(
@@ -322,7 +322,7 @@ class QueryPaginationTests(unittest.TestCase):
                     name @output(out_name: "animal")
                 }
             }""",
-            {"__paged_param_1": "80000000-0000-0000-0000-000000000000",},
+            {"__paged_param_1": "80000000-0000-0000-0000-800000000000",},
         )
 
         # Check that the correct queries are generated
@@ -913,9 +913,9 @@ class QueryPaginationTests(unittest.TestCase):
         )
 
         expected_parameters = [
-            "40000000-0000-0000-0000-000000000000",
-            "80000000-0000-0000-0000-000000000000",
-            "c0000000-0000-0000-0000-000000000000",
+            "40000000-0000-0000-0000-400000000000",
+            "80000000-0000-0000-0000-800000000000",
+            "c0000000-0000-0000-0000-c00000000000",
         ]
         self.assertEqual(expected_parameters, list(generated_parameters))
 


### PR DESCRIPTION
MSSQL considers the last 6 bytes of the uuid most significant, which is different from what most databases do and what we expect https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values

This causes problems with paginating on uuid fields. To fix the problem, all uuid parameters we generate for pagination should have their first 6 bytes and last 6 bytes equal.