### PR TITLE
Consider uuid comparison method during query planning

### DIFF
--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -54,7 +54,9 @@ def is_uuid4_type(schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_
     return field_name in schema_info.uuid4_field_info.get(vertex_name, {})
 
 
-def get_uuid_ordering(schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str) -> UUIDOrdering:
+def get_uuid_ordering(
+    schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str
+) -> UUIDOrdering:
     """Return the ordering of the uuid4 field."""
     ordering = schema_info.uuid4_field_info.get(vertex_name, {}).get(field_name)
     if ordering is None:

--- a/graphql_compiler/cost_estimation/helpers.py
+++ b/graphql_compiler/cost_estimation/helpers.py
@@ -11,7 +11,7 @@ from graphql import (
 
 from ..global_utils import is_same_type
 from ..schema import GraphQLDate, GraphQLDateTime
-from ..schema.schema_info import QueryPlanningSchemaInfo
+from ..schema.schema_info import QueryPlanningSchemaInfo, UUIDOrdering
 
 
 def _get_property_field_type(
@@ -51,4 +51,12 @@ def is_int_field_type(
 
 def is_uuid4_type(schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str) -> bool:
     """Return whether the field is a uniformly distributed uuid4 type."""
-    return field_name in schema_info.uuid4_fields.get(vertex_name, {})
+    return field_name in schema_info.uuid4_field_info.get(vertex_name, {})
+
+
+def get_uuid_ordering(schema_info: QueryPlanningSchemaInfo, vertex_name: str, field_name: str) -> UUIDOrdering:
+    """Return the ordering of the uuid4 field."""
+    ordering = schema_info.uuid4_field_info.get(vertex_name, {}).get(field_name)
+    if ordering is None:
+        raise AssertionError(f"{vertex_name}.{field_name} is not a uniform uuid4 field.")
+    return ordering

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -38,6 +38,7 @@ DATETIME_EPOCH_TZ_NAIVE = datetime.datetime(1970, 1, 1)
 
 
 def _flip_uuid(uuid_string):
+    """Swap the first 12 and last 12 hex digits of a uuid string."""
     segments = uuid_string.split("-")
     segment_lengths = tuple(len(segment) for segment in segments)
     expected_segment_lengths = (8, 4, 4, 4, 12)

--- a/graphql_compiler/cost_estimation/int_value_conversion.py
+++ b/graphql_compiler/cost_estimation/int_value_conversion.py
@@ -19,7 +19,13 @@ from uuid import UUID
 
 from ..schema import is_meta_field
 from ..schema.schema_info import QueryPlanningSchemaInfo, UUIDOrdering
-from .helpers import is_date_field_type, is_datetime_field_type, is_int_field_type, is_uuid4_type, get_uuid_ordering
+from .helpers import (
+    get_uuid_ordering,
+    is_date_field_type,
+    is_datetime_field_type,
+    is_int_field_type,
+    is_uuid4_type,
+)
 
 
 # UUIDs are defined in RFC-4122 as a 128-bit identifier. This means that the minimum UUID value
@@ -36,7 +42,7 @@ def _flip_uuid(uuid_string):
     segment_lengths = tuple(len(segment) for segment in segments)
     expected_segment_lengths = (8, 4, 4, 4, 12)
     if expected_segment_lengths != segment_lengths:
-        raise AssertionError(f"Unexpected segment lengths {segment_lengths} in {uuid_value}")
+        raise AssertionError(f"Unexpected segment lengths {segment_lengths} in {uuid_string}")
 
     new_segments = [
         segments[4][:8],
@@ -94,8 +100,8 @@ def convert_int_to_field_value(
     elif is_uuid4_type(schema_info, vertex_class, property_field):
         if not MIN_UUID_INT <= int_value <= MAX_UUID_INT:
             raise AssertionError(
-                u"Integer value {} could not be converted to UUID, as it "
-                u"is not in the range of valid UUIDs {} - {}: {} {}".format(
+                "Integer value {} could not be converted to UUID, as it "
+                "is not in the range of valid UUIDs {} - {}: {} {}".format(
                     int_value, MIN_UUID_INT, MAX_UUID_INT, vertex_class, property_field
                 )
             )
@@ -107,16 +113,18 @@ def convert_int_to_field_value(
         elif ordering == UUIDOrdering.LastSixBytesFirst:
             return _flip_uuid(uuid_string)
         else:
-            raise AssertionError(f"Unexpected ordering for {vertex_class}.{property_field}: {ordering}")
+            raise AssertionError(
+                f"Unexpected ordering for {vertex_class}.{property_field}: {ordering}"
+            )
     elif field_supports_range_reasoning(schema_info, vertex_class, property_field):
         raise AssertionError(
-            u"Could not represent int {} as {} {}, but should be able to.".format(
+            "Could not represent int {} as {} {}, but should be able to.".format(
                 int_value, vertex_class, property_field
             )
         )
     else:
         raise NotImplementedError(
-            u"Could not represent int {} as {} {}.".format(int_value, vertex_class, property_field)
+            "Could not represent int {} as {} {}.".format(int_value, vertex_class, property_field)
         )
 
 
@@ -139,16 +147,16 @@ def convert_field_value_to_int(
         elif ordering == UUIDOrdering.LastSixBytesFirst:
             return UUID(_flip_uuid(value)).int
         else:
-            raise AssertionError(f"Unexpected ordering for {vertex_class}.{property_field}: {ordering}")
+            raise AssertionError(
+                f"Unexpected ordering for {vertex_class}.{property_field}: {ordering}"
+            )
     elif field_supports_range_reasoning(schema_info, vertex_class, property_field):
         raise AssertionError(
-            u"Could not represent {} {} value {} as int, but should be able to".format(
+            "Could not represent {} {} value {} as int, but should be able to".format(
                 vertex_class, property_field, value
             )
         )
     else:
         raise NotImplementedError(
-            u"Could not represent {} {} value {} as int.".format(
-                vertex_class, property_field, value
-            )
+            "Could not represent {} {} value {} as int.".format(vertex_class, property_field, value)
         )

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, Flag, auto, unique
 from functools import partial
-from typing import Dict, Optional, Set
+from typing import Dict, Optional
 
 from graphql.type import GraphQLSchema
 from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -392,10 +392,9 @@ class QueryPlanningSchemaInfo:
     #                       during schema generation.
     pagination_keys: Dict[str, str]
 
-    # Dict mapping vertex names in the graphql schema to a set of property names that
-    # are known to contain uniformly distributed uppercase uuid values. The types of those
-    # fields are expected to be ID or String.
-    # TODO update docstring
+    # Dict mapping vertex names in the graphql schema to a dict mapping property names that
+    # are known to contain uniformly distributed uuid values to the ordering method used for
+    # them in the database. The types of these fields are expected to be ID or String.
     uuid4_field_info: Dict[str, Dict[str, UUIDOrdering]]
 
     # Map edge names to constraints inferred for them.

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -2,7 +2,7 @@
 from abc import ABCMeta
 from collections import namedtuple
 from dataclasses import dataclass, field
-from enum import Flag, auto, unique
+from enum import Enum, Flag, auto, unique
 from functools import partial
 from typing import Dict, Optional, Set
 
@@ -337,6 +337,19 @@ class EdgeConstraint(Flag):
     AtMostOneDestination = auto()
 
 
+@unique
+class UUIDOrdering(Enum):
+    """Specifies how the database would compare two uuid values."""
+
+    # Leftmost digits are most significant. This is the usual comparison method in
+    # Postgres, Orientdb, and likely many other databases.
+    LeftToRight = auto()
+
+    # The most significant digits are the last 12 hex digits (6 bytes), followed
+    # by the first digits, left to right. This is the comparison method in MSSQL.
+    LastSixBytesFirst = auto()
+
+
 @dataclass
 class QueryPlanningSchemaInfo:
     """All schema information sufficient for query cost estimation and auto pagination."""
@@ -382,7 +395,8 @@ class QueryPlanningSchemaInfo:
     # Dict mapping vertex names in the graphql schema to a set of property names that
     # are known to contain uniformly distributed uppercase uuid values. The types of those
     # fields are expected to be ID or String.
-    uuid4_fields: Dict[str, Set[str]]
+    # TODO update docstring
+    uuid4_field_info: Dict[str, Dict[str, UUIDOrdering]]
 
     # Map edge names to constraints inferred for them.
     edge_constraints: Dict[str, EdgeConstraint] = field(default_factory=dict)

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -35,7 +35,10 @@ def _make_schema_info_and_estimate_cardinality(
 ) -> float:
     graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
     pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-    uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+    uuid4_field_info = {
+        vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+        for vertex_name in schema_graph.vertex_class_names
+    }
     schema_info = QueryPlanningSchemaInfo(
         schema=graphql_schema,
         type_equivalence_hints=type_equivalence_hints,
@@ -900,7 +903,10 @@ def _make_schema_info_and_get_filter_selectivity(
 ) -> Selectivity:
     graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
     pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-    uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+    uuid4_field_info = {
+        vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+        for vertex_name in schema_graph.vertex_class_names
+    }
     schema_info = QueryPlanningSchemaInfo(
         schema=graphql_schema,
         type_equivalence_hints=type_equivalence_hints,
@@ -1109,7 +1115,10 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         classname = "Animal"
         between_filter = FilterInfo(
             fields=("uuid",), op_name="between", args=("$uuid_lower", "$uuid_upper",)
@@ -1190,7 +1199,10 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         statistics = LocalStatistics(
             dict(), field_quantiles={("Species", "limbs"): [3, 6, 7, 9, 11, 55, 80],}
         )
@@ -1318,7 +1330,10 @@ class FilterSelectivityUtilsTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         statistics = LocalStatistics(
             dict(),
             field_quantiles={
@@ -1450,7 +1465,10 @@ class IntegerIntervalTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         statistics = LocalStatistics({})
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
@@ -1484,7 +1502,10 @@ class IntegerIntervalTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         statistics = LocalStatistics({})
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
@@ -1518,7 +1539,10 @@ class IntegerIntervalTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         statistics = LocalStatistics({})
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
@@ -1552,7 +1576,10 @@ class IntegerIntervalTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         statistics = LocalStatistics({})
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -7,7 +7,7 @@ from ...cost_estimation.analysis import analyze_query_string
 from ...cost_estimation.interval import Interval
 from ...cost_estimation.statistics import LocalStatistics
 from ...global_utils import QueryStringWithParameters
-from ...schema.schema_info import QueryPlanningSchemaInfo
+from ...schema.schema_info import QueryPlanningSchemaInfo, UUIDOrdering
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import generate_schema_graph
 
@@ -24,7 +24,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -33,7 +33,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -58,7 +58,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -67,7 +67,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -95,7 +95,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -104,7 +104,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -126,7 +126,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -135,7 +135,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -157,7 +157,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
@@ -169,7 +169,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -193,7 +193,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
@@ -205,7 +205,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -230,7 +230,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -239,7 +239,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -265,7 +265,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -274,7 +274,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -24,7 +24,10 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -58,7 +61,10 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -95,7 +101,10 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -126,7 +135,10 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -157,7 +169,10 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
@@ -193,7 +208,10 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
@@ -230,7 +248,10 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -265,7 +286,10 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -25,7 +25,7 @@ from ...query_pagination.parameter_generator import (
     generate_parameters_for_vertex_partition,
 )
 from ...query_pagination.query_parameterizer import generate_parameterized_queries
-from ...schema.schema_info import EdgeConstraint, QueryPlanningSchemaInfo
+from ...schema.schema_info import EdgeConstraint, QueryPlanningSchemaInfo, UUIDOrdering
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import compare_graphql, generate_schema_graph, get_function_names_from_module
 from ..test_input_data import CommonTestData
@@ -43,7 +43,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -52,7 +52,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         # Check that the correct plan is generated when it's obvious (page the root)
@@ -77,7 +77,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -86,7 +86,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -115,7 +115,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         edge_constraints = {"Animal_ParentOf": EdgeConstraint.AtMostOneSource}
@@ -125,7 +125,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
             edge_constraints=edge_constraints,
         )
 
@@ -160,7 +160,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
@@ -172,7 +172,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         # Check that the paginator generates a plan paginating on an int field
@@ -199,7 +199,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(class_counts)
@@ -209,7 +209,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         # Check that the paginator detects a lack of quantile data for Species.limbs
@@ -236,7 +236,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         query = QueryStringWithParameters(
             """{
             Animal {
@@ -257,7 +257,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         first_page_and_remainder, _ = paginate_query(schema_info, query, 1)
@@ -344,7 +344,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Event": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -358,7 +358,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -444,7 +444,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Event": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -458,7 +458,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         local_datetime = datetime.datetime(2050, 1, 1, 0, 0)
@@ -511,7 +511,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Event": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -525,7 +525,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = QueryStringWithParameters(
@@ -581,7 +581,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
@@ -592,7 +592,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -616,7 +616,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 10000000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [0, 10, 20, 30,],}
@@ -627,7 +627,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -663,7 +663,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
@@ -674,7 +674,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -699,7 +699,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): list(range(0, 101, 10))},
@@ -710,7 +710,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -735,7 +735,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
@@ -746,7 +746,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -771,7 +771,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
@@ -782,7 +782,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -810,7 +810,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): list(range(0, 1001, 10))}
@@ -821,7 +821,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -847,7 +847,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Event": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -861,7 +861,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -888,7 +888,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -897,7 +897,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -920,12 +920,48 @@ class QueryPaginationTests(unittest.TestCase):
         self.assertEqual(expected_parameters, list(generated_parameters))
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_parameter_value_generation_mssql_uuid(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst} for vertex_name in schema_graph.vertex_class_names}
+        class_counts = {"Animal": 1000}
+        statistics = LocalStatistics(class_counts)
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_field_info=uuid4_field_info,
+        )
+
+        query = """{
+            Animal {
+                name @output(out_name: "animal_name")
+            }
+        }"""
+        args = {}
+        query_ast = safe_parse_graphql(query)
+        vertex_partition = VertexPartitionPlan(("Animal",), "uuid", 4)
+        generated_parameters = generate_parameters_for_vertex_partition(
+            schema_info, ASTWithParameters(query_ast, args), vertex_partition
+        )
+
+        expected_parameters = [
+            "00000000-0000-0000-0000-400000000000",
+            "00000000-0000-0000-0000-800000000000",
+            "00000000-0000-0000-0000-c00000000000",
+        ]
+        self.assertEqual(expected_parameters, list(generated_parameters))
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_parameter_value_generation_consecutive(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -937,7 +973,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -962,7 +998,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -974,7 +1010,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -1010,7 +1046,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -1022,7 +1058,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -1061,7 +1097,7 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -1073,7 +1109,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         query = """{
@@ -1113,7 +1149,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         original_query = QueryStringWithParameters(
             """{
             Animal {
@@ -1134,7 +1170,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         first_page_and_remainder, _ = paginate_query(schema_info, original_query, 10)
@@ -1152,7 +1188,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {}  # No pagination keys, so the planner has no options
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         original_query = QueryStringWithParameters(
             """{
             Animal {
@@ -1173,7 +1209,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         first_page_and_remainder, _ = paginate_query(schema_info, original_query, 10)
@@ -1191,7 +1227,7 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_fields = {vertex_name: {"uuid"} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
         count_data = {vertex_name: 100 for vertex_name in schema_graph.vertex_class_names}
         count_data.update({edge_name: 100 for edge_name in schema_graph.edge_class_names})
         statistics = LocalStatistics(count_data)
@@ -1201,7 +1237,7 @@ class QueryPaginationTests(unittest.TestCase):
             schema_graph=schema_graph,
             statistics=statistics,
             pagination_keys=pagination_keys,
-            uuid4_fields=uuid4_fields,
+            uuid4_field_info=uuid4_field_info,
         )
 
         arbitrary_value_for_type = {

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -43,7 +43,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -77,7 +80,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -115,7 +121,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         edge_constraints = {"Animal_ParentOf": EdgeConstraint.AtMostOneSource}
@@ -160,7 +169,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
@@ -199,7 +211,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(class_counts)
@@ -236,7 +251,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         query = QueryStringWithParameters(
             """{
             Animal {
@@ -344,7 +362,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Event": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -444,7 +465,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Event": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -511,7 +535,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Event": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -581,7 +608,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
@@ -616,7 +646,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 10000000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [0, 10, 20, 30,],}
@@ -663,7 +696,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
@@ -699,7 +735,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): list(range(0, 101, 10))},
@@ -735,7 +774,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
@@ -771,7 +813,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): [i for i in range(101)],}
@@ -810,7 +855,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): list(range(0, 1001, 10))}
@@ -847,7 +895,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Event": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -888,7 +939,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -924,7 +978,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Animal": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -961,7 +1018,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -998,7 +1058,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -1046,7 +1109,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -1097,7 +1163,10 @@ class QueryPaginationTests(unittest.TestCase):
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
         pagination_keys["Species"] = "limbs"  # Force pagination on int field
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts,
@@ -1149,7 +1218,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         original_query = QueryStringWithParameters(
             """{
             Animal {
@@ -1188,7 +1260,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {}  # No pagination keys, so the planner has no options
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         original_query = QueryStringWithParameters(
             """{
             Animal {
@@ -1227,7 +1302,10 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        uuid4_field_info = {vertex_name: {"uuid": UUIDOrdering.LeftToRight} for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
         count_data = {vertex_name: 100 for vertex_name in schema_graph.vertex_class_names}
         count_data.update({edge_name: 100 for edge_name in schema_graph.edge_class_names})
         statistics = LocalStatistics(count_data)


### PR DESCRIPTION
MSSQL considers the last 6 bytes of the uuid most significant, which is different from what most databases do and what we expect https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values

This causes problems with cost estimation and pagination on uuid fields. To fix the problem, I make the `QueryPlanningSchemaInfo` aware of the uuid comparison method used by the database.

This approach is different and likely better than https://github.com/kensho-technologies/graphql-compiler/pull/765 (see Pedro's comment that points out some flaws).