### PR TITLE
Use less common ports in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,14 +20,14 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     ports:
-      - "127.0.0.1:3306:3306"
+      - "127.0.0.1:3307:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
   mariadb:
     image: mariadb:10.3.11
     restart: always
     ports:
-      - "127.0.0.1:3307:3306"
+      - "127.0.0.1:3308:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
   mssql:
@@ -42,8 +42,8 @@ services:
     image: neo4j:3.5.6
     restart: always
     ports:
-      - "127.0.0.1:7474:7474"
-      - "127.0.0.1:7687:7687"
+      - "127.0.0.1:7475:7474"
+      - "127.0.0.1:7688:7687"
     environment:
       NEO4J_AUTH: neo4j/root
   redisgraph:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: orientdb:2.2.30
     command: server.sh
     ports:
-      - "127.0.0.1:2480:2480"
-      - "127.0.0.1:2424:2424"
+      - "127.0.0.1:2481:2480"
+      - "127.0.0.1:2425:2424"
     environment:
       ORIENTDB_ROOT_PASSWORD: root
   postgres:
@@ -14,7 +14,7 @@ services:
     environment:
       POSTGRES_PASSWORD: root
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5433:5432"
   mysql:
     image: mysql:8.0.11
     command: --default-authentication-plugin=mysql_native_password
@@ -34,7 +34,7 @@ services:
     image: mcr.microsoft.com/mssql/server:2017-latest
     restart: always
     ports:
-      - "127.0.0.1:1433:1433"
+      - "127.0.0.1:1434:1433"
     environment:
       ACCEPT_EULA: "yes"
       MSSQL_SA_PASSWORD: Root-secure1  # password requirements are more stringent for MSSQL image
@@ -50,4 +50,4 @@ services:
     image: redislabs/redisgraph:1.2.2
     restart: always
     ports:
-      - "127.0.0.1:6379:6379"
+      - "127.0.0.1:6380:6379"

--- a/graphql_compiler/tests/integration_tests/integration_backend_config.py
+++ b/graphql_compiler/tests/integration_tests/integration_backend_config.py
@@ -57,9 +57,9 @@ SQL_BACKEND_TO_CONNECTION_STRING = {
     # test_backend.POSTGRES:
     #     u'postgresql://postgres:{password}@localhost:5433'.format(password=DEFAULT_ROOT_PASSWORD),
     # test_backend.MYSQL:
-    #     u'mysql://root:{password}@127.0.0.1:3306'.format(password=DEFAULT_ROOT_PASSWORD),
-    # test_backend.MARIADB:
     #     u'mysql://root:{password}@127.0.0.1:3307'.format(password=DEFAULT_ROOT_PASSWORD),
+    # test_backend.MARIADB:
+    #     u'mysql://root:{password}@127.0.0.1:3308'.format(password=DEFAULT_ROOT_PASSWORD),
     test_backend.MSSQL: "mssql+pyodbc:///?odbc_connect={}".format(escaped_pyodbc_parameter_string),
     # test_backend.SQLITE:
     #     u'sqlite:///:memory:',

--- a/graphql_compiler/tests/integration_tests/integration_backend_config.py
+++ b/graphql_compiler/tests/integration_tests/integration_backend_config.py
@@ -39,7 +39,8 @@ REDISGRAPH_BACKENDS = {
 
 pyodbc_parameter_string = "DRIVER={driver};SERVER={server};UID={uid};PWD={pwd}".format(  # nosec
     driver="{ODBC Driver 17 for SQL SERVER}",
-    server="127.0.0.1",  # Do not change to 'localhost'. You won't be able to connect with the db.
+    server="127.0.0.1,1434",  # Do not change to 'localhost'.
+                              # You won't be able to connect with the db.
     uid="SA",  # System Administrator.
     pwd="Root-secure1",
 )

--- a/graphql_compiler/tests/integration_tests/integration_backend_config.py
+++ b/graphql_compiler/tests/integration_tests/integration_backend_config.py
@@ -54,7 +54,7 @@ SQL_BACKEND_TO_CONNECTION_STRING = {
     #                       string formats.
     #
     # test_backend.POSTGRES:
-    #     u'postgresql://postgres:{password}@localhost:5432'.format(password=DEFAULT_ROOT_PASSWORD),
+    #     u'postgresql://postgres:{password}@localhost:5433'.format(password=DEFAULT_ROOT_PASSWORD),
     # test_backend.MYSQL:
     #     u'mysql://root:{password}@127.0.0.1:3306'.format(password=DEFAULT_ROOT_PASSWORD),
     # test_backend.MARIADB:

--- a/graphql_compiler/tests/integration_tests/integration_backend_config.py
+++ b/graphql_compiler/tests/integration_tests/integration_backend_config.py
@@ -40,7 +40,7 @@ REDISGRAPH_BACKENDS = {
 pyodbc_parameter_string = "DRIVER={driver};SERVER={server};UID={uid};PWD={pwd}".format(  # nosec
     driver="{ODBC Driver 17 for SQL SERVER}",
     server="127.0.0.1,1434",  # Do not change to 'localhost'.
-                              # You won't be able to connect with the db.
+    # You won't be able to connect with the db.
     uid="SA",  # System Administrator.
     pwd="Root-secure1",
 )

--- a/graphql_compiler/tests/test_data_tools/neo4j_graph.py
+++ b/graphql_compiler/tests/test_data_tools/neo4j_graph.py
@@ -19,8 +19,8 @@ class Neo4jClient(object):
 
 def get_neo4j_url(database_name: str) -> str:
     """Return an Neo4j path for the specified database on the NEO4J_SERVER."""
-    template = "bolt://{}/{}"
-    return template.format(NEO4J_SERVER, database_name)
+    template = "bolt://{}:{}/{}"
+    return template.format(NEO4J_SERVER, NEO4J_PORT, database_name)
 
 
 def get_test_neo4j_graph(

--- a/graphql_compiler/tests/test_data_tools/neo4j_graph.py
+++ b/graphql_compiler/tests/test_data_tools/neo4j_graph.py
@@ -5,7 +5,7 @@ from neo4j import GraphDatabase
 
 
 NEO4J_SERVER = "localhost"
-NEO4J_PORT = 7687
+NEO4J_PORT = 7688
 NEO4J_USER = "neo4j"
 NEO4J_PASSWORD = "root"  # nosec
 

--- a/graphql_compiler/tests/test_data_tools/orientdb_graph.py
+++ b/graphql_compiler/tests/test_data_tools/orientdb_graph.py
@@ -14,8 +14,8 @@ ORIENTDB_PASSWORD = "root"  # nosec
 
 def get_orientdb_url(database_name: str) -> str:
     """Return an OrientDB path for the specified database on the ORIENTDB_SERVER."""
-    template = "memory://{}/{}"
-    return template.format(ORIENTDB_SERVER, database_name)
+    template = "memory://{}:{}/{}"
+    return template.format(ORIENTDB_SERVER, ORIENTDB_PORT, database_name)
 
 
 def get_test_orientdb_graph(
@@ -28,7 +28,7 @@ def get_test_orientdb_graph(
     config = Config.from_url(url, ORIENTDB_USER, ORIENTDB_PASSWORD, initial_drop=True)
     Graph(config, strict=True)
 
-    client = OrientDB("localhost", ORIENTDB_PORT)
+    client = OrientDB(host="localhost", port=ORIENTDB_PORT)
     client.connect(ORIENTDB_USER, ORIENTDB_PASSWORD)
     client.db_open(graph_name, ORIENTDB_USER, ORIENTDB_PASSWORD, db_type=DB_TYPE_GRAPH)
 

--- a/graphql_compiler/tests/test_data_tools/orientdb_graph.py
+++ b/graphql_compiler/tests/test_data_tools/orientdb_graph.py
@@ -7,7 +7,7 @@ from pyorient.ogm import Config, Graph
 
 
 ORIENTDB_SERVER = "localhost"
-ORIENTDB_PORT = 2424
+ORIENTDB_PORT = 2425
 ORIENTDB_USER = "root"
 ORIENTDB_PASSWORD = "root"  # nosec
 

--- a/graphql_compiler/tests/test_data_tools/redisgraph_graph.py
+++ b/graphql_compiler/tests/test_data_tools/redisgraph_graph.py
@@ -6,7 +6,7 @@ from redisgraph import Graph
 
 
 REDISGRAPH_SERVER = "localhost"
-REDISGRAPH_PORT = 6379
+REDISGRAPH_PORT = 6380
 
 
 def get_test_redisgraph_graph(


### PR DESCRIPTION
To prevent collisions and debugging when the developers are working on other projects simultaneously.