### PR TITLE
Fix revisit_count handling

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -1,9 +1,10 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 import bisect
 from dataclasses import dataclass
-from typing import Any, Dict, Set
+from typing import Any, Dict, Set, Union
 
 from cached_property import cached_property
+from graphql import GraphQLInterfaceType, GraphQLObjectType
 from graphql.language.printer import print_ast
 
 from ..ast_manipulation import safe_parse_graphql
@@ -54,7 +55,9 @@ def _convert_int_interval_to_field_value_interval(
     return Interval(lower_bound, upper_bound)
 
 
-def get_types(query_metadata: QueryMetadataTable,) -> Dict[VertexPath, str]:
+def get_types(
+    query_metadata: QueryMetadataTable,
+) -> Dict[VertexPath, Union[GraphQLObjectType, GraphQLInterfaceType]]:
     """Find the type at each VertexPath.
 
     Fold scopes are not considered.
@@ -69,7 +72,7 @@ def get_types(query_metadata: QueryMetadataTable,) -> Dict[VertexPath, str]:
     for location, location_info in query_metadata.registered_locations:
         if not isinstance(location, Location):
             continue
-        location_types[location.query_path] = location_info.type.name
+        location_types[location.query_path] = location_info.type
     return location_types
 
 
@@ -357,7 +360,7 @@ class QueryPlanningAnalysis:
         ).query_metadata_table
 
     @cached_property
-    def types(self) -> Dict[VertexPath, str]:
+    def types(self) -> Dict[VertexPath, Union[GraphQLObjectType, GraphQLInterfaceType]]:
         """Find the type at each VertexPath."""
         return get_types(self.metadata_table)
 

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -376,6 +376,7 @@ class QueryPlanningAnalysis:
 
     @cached_property
     def filters(self) -> Dict[VertexPath, Set[FilterInfo]]:
+        """Get the filters at each VertexPath."""
         return get_filters(self.schema_info, self.metadata_table)
 
     @cached_property

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -84,7 +84,7 @@ def _is_new_filter_stronger(
     Returns:
         whether the old filter can be removed with no change in query meaning.
     """
-    vertex_type = query_analysis.types[property_path.vertex_path]
+    vertex_type = query_analysis.types[property_path.vertex_path].name
     new_int_value = convert_field_value_to_int(
         query_analysis.schema_info, vertex_type, property_path.field_name, new_filter_value,
     )

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -324,3 +324,44 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             (("Animal", "in_Animal_ParentOf"), "birthday"),
         }
         self.assertEqual(expected_eligible_fields, eligible_fields)
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_distinct_result_set_estimates_with_revisit_counts(self):
+        schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
+        graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
+        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        uuid4_field_info = {
+            vertex_name: {"uuid": UUIDOrdering.LeftToRight}
+            for vertex_name in schema_graph.vertex_class_names
+        }
+        class_counts = {"Animal": 1000}
+        statistics = LocalStatistics(class_counts)
+        schema_info = QueryPlanningSchemaInfo(
+            schema=graphql_schema,
+            type_equivalence_hints=type_equivalence_hints,
+            schema_graph=schema_graph,
+            statistics=statistics,
+            pagination_keys=pagination_keys,
+            uuid4_field_info=uuid4_field_info,
+        )
+
+        query = QueryStringWithParameters("""{
+            Animal {
+                name @filter(op_name: "=", value: ["$animal_name"])
+                in_Animal_ParentOf @optional {
+                    name @output(out_name: "child_name")
+                    in_Animal_ParentOf {
+                        name @output(out_name: "grandchild_name")
+                    }
+                }
+            }
+        }""", {
+            "animal_name": "Joe",
+        })
+        estimates = analyze_query_string(schema_info, query).distinct_result_set_estimates
+        expected_estimates = {
+            ('Animal',): 1.0,
+            ('Animal', 'in_Animal_ParentOf'): 1000.0,
+            ('Animal', 'in_Animal_ParentOf', 'in_Animal_ParentOf'): 1000.0,
+        }
+        self.assertEqual(expected_estimates, estimates)

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -345,7 +345,8 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Animal {
                 name @filter(op_name: "=", value: ["$animal_name"])
                 in_Animal_ParentOf @optional {
@@ -355,13 +356,13 @@ class CostEstimationAnalysisTests(unittest.TestCase):
                     }
                 }
             }
-        }""", {
-            "animal_name": "Joe",
-        })
+        }""",
+            {"animal_name": "Joe",},
+        )
         estimates = analyze_query_string(schema_info, query).distinct_result_set_estimates
         expected_estimates = {
-            ('Animal',): 1.0,
-            ('Animal', 'in_Animal_ParentOf'): 1000.0,
-            ('Animal', 'in_Animal_ParentOf', 'in_Animal_ParentOf'): 1000.0,
+            ("Animal",): 1.0,
+            ("Animal", "in_Animal_ParentOf"): 1000.0,
+            ("Animal", "in_Animal_ParentOf", "in_Animal_ParentOf"): 1000.0,
         }
         self.assertEqual(expected_estimates, estimates)


### PR DESCRIPTION
The `revisit_count` field exists for gremlin, so any developer unfamiliar with the gremlin backend is not likely to think of it when dealing with `Location` objects. As one of those developers, I've written some buggy code that fails on queries with optionals.

Changes in this PR:
1. Add test that fails
2. Change the return type of `get_types` from string type name to grahpql type
3. Implement `get_filters` analysis pass that gets filters at a location across all revisits
4. Remove direct use of `Location` objects, resolving the bug 