### PR TITLE
Add selectivity analysis

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -66,7 +66,9 @@ def _convert_int_interval_to_field_value_interval(
 def _get_location_vertex_path(location: BaseLocation) -> VertexPath:
     """Get the VertexPath for a BaseLocation pointing at a vertex."""
     if location.field is not None:
-        raise AssertionError(f"Location {location} represents a field.")
+        raise AssertionError(
+            f"Location {location} represents a field. Expected a location pointing at a vertex."
+        )
 
     if isinstance(location, Location):
         return location.query_path
@@ -74,8 +76,7 @@ def _get_location_vertex_path(location: BaseLocation) -> VertexPath:
         return location.base_location.query_path + tuple(
             "{}_{}".format(direction, name) for direction, name in location.fold_path
         )
-    else:
-        raise AssertionError("Unexpected location encountered: {}".format(location))
+    raise AssertionError("Unexpected location encountered: {}".format(location))
 
 
 def get_types(
@@ -233,7 +234,7 @@ def get_selectivities(
     for vertex_path, vertex_type in types.items():
         vertex_type_name = vertex_type.name
         filter_infos = filters[vertex_path]
-        # TODO(bojanserafimov) use analysis.field_value_intervals
+        # TODO(bojanserafimov) use precomputed field_value_intervals
         #                      inside this method instead of recomputing it
         selectivity = get_selectivity_of_filters_at_vertex(
             schema_info, filter_infos, parameters, vertex_type_name

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -233,7 +233,8 @@ def get_selectivities(
     for vertex_path, vertex_type in types.items():
         vertex_type_name = vertex_type.name
         filter_infos = filters[vertex_path]
-        # TODO use analysis.field_value_intervals inside this method instead of recomputing it
+        # TODO(bojanserafimov) use analysis.field_value_intervals
+        #                      inside this method instead of recomputing it
         selectivity = get_selectivity_of_filters_at_vertex(
             schema_info, filter_infos, parameters, vertex_type_name
         )

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -267,7 +267,6 @@ def get_distinct_result_set_estimates(
     for vertex_path, vertex_type in types.items():
         vertex_type_name = vertex_type.name
         class_count = schema_info.statistics.get_class_count(vertex_type_name)
-        # TODO use analysis.selectivities instead of recomputing this
         distinct_result_set_estimates[vertex_path] = adjust_counts_with_selectivity(
             class_count, selectivities[vertex_path]
         )

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -451,6 +451,7 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
 
 
 def adjust_counts_with_selectivity(counts, selectivity):
+    """Apply the selectivity to the unfiltered vertex count and return the result."""
     adjusted_counts = counts
     if _is_absolute(selectivity):
         adjusted_counts = selectivity.value

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -450,9 +450,17 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
     return combined_selectivity
 
 
-def adjust_counts_with_selectivity(counts, selectivity):
-    """Apply the selectivity to the unfiltered vertex count and return the result."""
-    adjusted_counts = counts
+def adjust_counts_with_selectivity(result_counts: float, selectivity: Selectivity) -> float:
+    """Apply the selectivity to the unfiltered result count and return the result.
+
+    Args:
+        result_counts: estimated number of results before filters are applied
+        selectivity: combined selectivity of some filters
+
+    Returns:
+        estimated number of results after filters are applied.
+    """
+    adjusted_counts = result_counts
     if _is_absolute(selectivity):
         adjusted_counts = selectivity.value
     elif _is_fractional(selectivity):

--- a/graphql_compiler/cost_estimation/filter_selectivity_utils.py
+++ b/graphql_compiler/cost_estimation/filter_selectivity_utils.py
@@ -450,6 +450,15 @@ def get_selectivity_of_filters_at_vertex(schema_info, filter_infos, parameters, 
     return combined_selectivity
 
 
+def adjust_counts_with_selectivity(counts, selectivity):
+    adjusted_counts = counts
+    if _is_absolute(selectivity):
+        adjusted_counts = selectivity.value
+    elif _is_fractional(selectivity):
+        adjusted_counts *= selectivity.value
+    return adjusted_counts
+
+
 def adjust_counts_for_filters(schema_info, filter_infos, parameters, location_name, counts):
     """Adjust result counts for filters on a given location by calculating selectivities.
 
@@ -466,10 +475,4 @@ def adjust_counts_for_filters(schema_info, filter_infos, parameters, location_na
     combined_selectivity = get_selectivity_of_filters_at_vertex(
         schema_info, filter_infos, parameters, location_name
     )
-    adjusted_counts = counts
-    if _is_absolute(combined_selectivity):
-        adjusted_counts = combined_selectivity.value
-    elif _is_fractional(combined_selectivity):
-        adjusted_counts *= combined_selectivity.value
-
-    return adjusted_counts
+    return adjust_counts_with_selectivity(counts, combined_selectivity)


### PR DESCRIPTION
Computing the selectivity of all filters on a given vertex is currently a helper method used both in cost estimation and in pagination separately. I'm making it an analysis pass.

Working towards 3 goals:
- Making the cost estimation process transparent. Not quite like `EXPLAIN`, but if it's composed of independent thin analysis passes, printing out the results of the passes would be enough information to see what's going on without having to `pdb` into the library.
- Making cost estimation more granularly testable. Currently most of its tests are white-box end-to-end tests.
- Fixing rotation invariance: https://github.com/kensho-technologies/graphql-compiler/pull/593 When cost estimation is simpler, it's easier to make it rotation invariant.

In this PR:
- Make the `get_types` pass go into folded locations.
- Add a `get_fold_scope_roots` pass
- Make `get_fields_eligible_for_pagination` explicitly avoid folds, instead of relying on a limitation of `get_types`
- Add a `get_selectivities` pass
- Add some tests for new passes