### PR TITLE
Remove first pipe character from folded MSSQL results as a part of postprocessing

### DIFF
--- a/graphql_compiler/post_processing/sql_post_processing.py
+++ b/graphql_compiler/post_processing/sql_post_processing.py
@@ -24,23 +24,32 @@ def _mssql_xml_path_string_to_list(
     if xml_path_result == "":
         return []
 
+    # Some of the special characters involved in XML path array aggregation.
+    delimiter = "|"
+    null = "~"
+
     # Remove the "|" from the first result in the string representation of the list.
+    if xml_path_result[0] != delimiter:
+        raise AssertionError(
+            f"Unexpected fold result. All XML path array aggregated lists must start with a '|'. "
+            f"Received a result beginging with a {xml_path_result[0]}: {xml_path_result}"
+        )
     xml_path_result = xml_path_result[1:]
 
     # Split the XML path result on "|".
-    list_result: Sequence[Optional[str]] = xml_path_result.split("|")
+    list_result: Sequence[Optional[str]] = xml_path_result.split(delimiter)
 
     # Convert "~" to None. Note that this must be done before "^n" -> "~".
-    list_result = [None if result == "~" else result for result in list_result]
+    list_result = [None if result == null else result for result in list_result]
 
     # Convert "^d" to "|".
     list_result = [
-        result.replace("^d", "|") if result is not None else None for result in list_result
+        result.replace("^d", delimiter) if result is not None else None for result in list_result
     ]
 
     # Convert "^n" to "~".
     list_result = [
-        result.replace("^n", "~") if result is not None else None for result in list_result
+        result.replace("^n", null) if result is not None else None for result in list_result
     ]
 
     # Convert "^e" to "^". Note that this must be done after the caret escaped characters i.e.

--- a/graphql_compiler/post_processing/sql_post_processing.py
+++ b/graphql_compiler/post_processing/sql_post_processing.py
@@ -31,8 +31,9 @@ def _mssql_xml_path_string_to_list(
     # Remove the "|" from the first result in the string representation of the list.
     if xml_path_result[0] != delimiter:
         raise AssertionError(
-            f"Unexpected fold result. All XML path array aggregated lists must start with a '|'. "
-            f"Received a result beginging with a {xml_path_result[0]}: {xml_path_result}"
+            f"Unexpected fold result. All XML path array aggregated lists must start with a "
+            f"'{delimiter}'. Received a result beginning with '{xml_path_result[0]}': "
+            f"{xml_path_result}"
         )
     xml_path_result = xml_path_result[1:]
 

--- a/graphql_compiler/post_processing/sql_post_processing.py
+++ b/graphql_compiler/post_processing/sql_post_processing.py
@@ -24,6 +24,9 @@ def _mssql_xml_path_string_to_list(
     if xml_path_result == "":
         return []
 
+    # Remove the "|" from the first result in the string representation of the list.
+    xml_path_result = xml_path_result[1:]
+
     # Split the XML path result on "|".
     list_result: Sequence[Optional[str]] = xml_path_result.split("|")
 

--- a/graphql_compiler/tests/test_post_processing.py
+++ b/graphql_compiler/tests/test_post_processing.py
@@ -344,15 +344,15 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_invalid_result(self):
         """Test invalid result throws error.
 
-                {
-                    Animal {
-                        in_Animal_ParentOf @fold{
-                            name @output(out_name: "child_names")
-                        }
-                    }
+        {
+            Animal {
+                in_Animal_ParentOf @fold{
+                    name @output(out_name: "child_names")
                 }
-                """
-        query_output = [{"child_names": "Animal 1|Animal 2||Animal 3|", }]
+            }
+        }
+        """
+        query_output = [{"child_names": "Animal 1|Animal 2||Animal 3|",}]
         output_metadata = {
             "child_names": OutputMetadata(
                 type=GraphQLList(GraphQLString), optional=False, folded=True

--- a/graphql_compiler/tests/test_post_processing.py
+++ b/graphql_compiler/tests/test_post_processing.py
@@ -340,3 +340,24 @@ class MssqlXmlPathTests(TestCase):
 
         post_process_mssql_folds(query_output, output_metadata)
         self.assertEqual(query_output, expected_result)
+
+    def test_convert_invalid_result(self):
+        """Test invalid result throws error.
+
+                {
+                    Animal {
+                        in_Animal_ParentOf @fold{
+                            name @output(out_name: "child_names")
+                        }
+                    }
+                }
+                """
+        query_output = [{"child_names": "Animal 1|Animal 2||Animal 3|", }]
+        output_metadata = {
+            "child_names": OutputMetadata(
+                type=GraphQLList(GraphQLString), optional=False, folded=True
+            ),
+        }
+
+        with self.assertRaises(AssertionError):
+            post_process_mssql_folds(query_output, output_metadata)

--- a/graphql_compiler/tests/test_post_processing.py
+++ b/graphql_compiler/tests/test_post_processing.py
@@ -49,7 +49,7 @@ class MssqlXmlPathTests(TestCase):
             }
         }
         """
-        query_output = [{"child_names": "Animal 1|Animal 2||Animal 3|",}]
+        query_output = [{"child_names": "|Animal 1|Animal 2||Animal 3|",}]
         output_metadata = {
             "child_names": OutputMetadata(
                 type=GraphQLList(GraphQLString), optional=False, folded=True
@@ -72,7 +72,7 @@ class MssqlXmlPathTests(TestCase):
             }
         }
         """
-        query_output = [{"child_names": "~|Animal 1|~",}]
+        query_output = [{"child_names": "|~|Animal 1|~",}]
         output_metadata = {
             "child_names": OutputMetadata(
                 type=GraphQLList(GraphQLString), optional=False, folded=True
@@ -97,7 +97,7 @@ class MssqlXmlPathTests(TestCase):
         """
         query_output = [
             {
-                "child_names": "name with a ^e (caret)|"
+                "child_names": "|name with a ^e (caret)|"
                 "name with a ^d (pipe)|"
                 "name with a ^n (tilde)|"
                 "^emany^e^dcaret^nescaped^n^n^dname^e",
@@ -136,7 +136,7 @@ class MssqlXmlPathTests(TestCase):
         """
         query_output = [
             {
-                "child_names": "name with a &amp; (ampersand)|"
+                "child_names": "|name with a &amp; (ampersand)|"
                 "name with a &gt; (greater than)|"
                 "name with a &lt; (less than)|"
                 "&amp;many&amp;&gt;ampersand&lt;escaped&lt;&lt;&gt;name&amp;",
@@ -175,7 +175,7 @@ class MssqlXmlPathTests(TestCase):
         """
         query_output = [
             {
-                "child_names": "name with a &#x06; (acknowledge)|"
+                "child_names": "|name with a &#x06; (acknowledge)|"
                 "&#x0B;many&#x06;hex&#x0F;&#x07;name&#x08;",
             }
         ]
@@ -203,7 +203,7 @@ class MssqlXmlPathTests(TestCase):
             }
         }
         """
-        query_output = [{"child_net_worths": "500|1000|400|~",}]
+        query_output = [{"child_net_worths": "|500|1000|400|~",}]
         output_metadata = {
             "child_net_worths": OutputMetadata(
                 type=GraphQLList(GraphQLDecimal), optional=False, folded=True
@@ -226,7 +226,7 @@ class MssqlXmlPathTests(TestCase):
             }
         }
         """
-        query_output = [{"child_birthdays": "2020-01-01|2000-02-29|~"}]
+        query_output = [{"child_birthdays": "|2020-01-01|2000-02-29|~"}]
         output_metadata = {
             "child_birthdays": OutputMetadata(
                 type=GraphQLList(GraphQLDate), optional=False, folded=True
@@ -252,7 +252,7 @@ class MssqlXmlPathTests(TestCase):
         }
         """
         query_output = [
-            {"child_datetime_fields": "2020-01-01T05:45:00+04:00|2000-02-29T13:02:27.0018349Z|~"}
+            {"child_datetime_fields": "|2020-01-01T05:45:00+04:00|2000-02-29T13:02:27.0018349Z|~"}
         ]
         output_metadata = {
             "child_datetime_fields": OutputMetadata(
@@ -298,9 +298,9 @@ class MssqlXmlPathTests(TestCase):
         """
         query_output = [
             {
-                "child_birthdays": "2020-01-01|2000-02-29|~",
-                "child_net_worths": "200|~|321",
-                "child_names": "^ecomplex&amp;^d^nname&#x06;|~|simple name",
+                "child_birthdays": "|2020-01-01|2000-02-29|~",
+                "child_net_worths": "|200|~|321",
+                "child_names": "|^ecomplex&amp;^d^nname&#x06;|~|simple name",
                 "parent_birthdays": "",
                 "parent_net_worths": "",
                 "parent_names": "",

--- a/graphql_compiler/tests/test_post_processing.py
+++ b/graphql_compiler/tests/test_post_processing.py
@@ -19,9 +19,10 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_empty_string(self):
         """Test empty list is correctly decoded.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     name @output(out_name: "child_names")
                 }
             }
@@ -43,7 +44,7 @@ class MssqlXmlPathTests(TestCase):
 
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     name @output(out_name: "child_names")
                 }
             }
@@ -64,9 +65,10 @@ class MssqlXmlPathTests(TestCase):
     def test_covert_none_result(self):
         """Test "~" is properly decoded to None.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     name @output(out_name: "child_names")
                 }
             }
@@ -87,9 +89,10 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_caret_encodings(self):
         """Test pipe, tilde, and carets are correctly decoded.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     name @output(out_name: "child_names")
                 }
             }
@@ -126,9 +129,10 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_ampersand_encodings(self):
         """Test ampersand, less than, and greater than are correctly decoded.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     name @output(out_name: "child_names")
                 }
             }
@@ -165,9 +169,10 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_hex_encodings(self):
         """Test HTML hex encodings are properly decoded.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     name @output(out_name: "child_names")
                 }
             }
@@ -195,9 +200,10 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_basic_decimal(self):
         """Test basic XML path encoding for decimals is correctly decoded.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     net_worth @output(out_name: "child_net_worths")
                 }
             }
@@ -218,9 +224,10 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_basic_date(self):
         """Test basic XML path encoding for dates is correctly decoded.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     birthday @output(out_name: "child_birthdays")
                 }
             }
@@ -243,9 +250,10 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_basic_datetime(self):
         """Test basic XML path encoding for datetimes is correctly decoded.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     datetime_field @output(out_name: "child_datetime_fields")
                 }
             }
@@ -280,15 +288,16 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_complex(self):
         """Test multiple folds, outputs, and types are correctly decoded.
 
-        Note that multiple outputs inside a fold are not yet implemented.
+        Example query for the given results:
+            - Note that multiple outputs inside a fold are not yet implemented.
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     birthday @output(out_name: "child_birthdays")
                     net_worth @output(out_name: "child_net_worths")
                     name @output(out_name: "child_names")
                 }
-                out_Animal_ParentOf @fold{
+                out_Animal_ParentOf @fold {
                     birthday @output(out_name: "parent_birthdays")
                     net_worth @output(out_name: "parent_net_worths")
                     name @output(out_name: "parent_names")
@@ -344,9 +353,10 @@ class MssqlXmlPathTests(TestCase):
     def test_convert_invalid_result(self):
         """Test invalid result throws error.
 
+        Example query for the given results:
         {
             Animal {
-                in_Animal_ParentOf @fold{
+                in_Animal_ParentOf @fold {
                     name @output(out_name: "child_names")
                 }
             }


### PR DESCRIPTION
XML path base array aggregation for MSSQL folds places a `|` before every result in the list. This PR removes the `|` from the first element of the string representation of the list so that every result does not have "" as the first element of the list after postprocessing.