### PR TITLE
Optimize SQL recurse with CTEs

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -758,7 +758,7 @@ class CompilationState(object):
         """Execute a Backtrack Block."""
         self._relocate(previous_location)
 
-    def traverse(self, vertex_field, optional):
+    def traverse(self, vertex_field: str, optional: bool) -> None:
         """Execute a Traverse Block."""
         self._recurse_needs_cte = True
 
@@ -887,7 +887,7 @@ class CompilationState(object):
             raise AssertionError("CompilationState is already in global scope.")
         self._current_location = None
 
-    def filter(self, predicate):
+    def filter(self, predicate: Expression) -> None:
         """Execute a Filter Block."""
         self._recurse_needs_cte = True
 

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -873,6 +873,9 @@ class CompilationState(object):
             .where(base.c[CTE_DEPTH_NAME] < literal_depth)
         )
 
+        # Instead of joining to the current _from_clause, we make this alias the _from_clause.
+        # If the existing _from_clause had any information in it, then the _current_alias would
+        # be a cte that contains all that information.
         self._from_clause = self._current_alias
 
     def start_global_operations(self):

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -808,10 +808,12 @@ class CompilationState(object):
 
         # Find which columns should be selected
         used_columns = sorted(self._used_columns[self._current_location.query_path])
+        import pdb; pdb.set_trace()
+        # TODO union the used columns of all locations so far
+        # used_columns.append('color')
+        # used_columns.append('name')
 
-        # Wrap the query so far into a cte. Make sure to select any fields used outside
-        # the cte.
-        # TODO Make sure all needed columns are selected
+        # Wrap the query so far into a cte. Make sure to select any fields used outside the cte.
         self._current_alias = self.get_query(
             [self._current_alias.c[col] for col in used_columns]
             + [self._current_alias.primary_key[0].label("primary_key")]

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -2,7 +2,7 @@
 """Transform a SqlNode tree into an executable SQLAlchemy query."""
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Dict, Set
+from typing import Dict, List, Optional, Set
 
 import six
 import sqlalchemy
@@ -12,8 +12,10 @@ from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.compiler import _CompileLabel
+from sqlalchemy.sql.elements import Label
 from sqlalchemy.sql.expression import BinaryExpression
 from sqlalchemy.sql.functions import func
+from sqlalchemy.sql.selectable import Select
 
 from . import blocks
 from ..global_utils import VertexPath
@@ -771,7 +773,7 @@ class CompilationState(object):
     def _wrap_into_cte(self) -> None:
         """Wrap the current query into a cte."""
         # Additional outputs the CTE needs to export for use elsewhere in the query
-        extra_outputs = []
+        extra_outputs: List[Label] = []
         # Mapping alias_key -> external_name -> internal_name
         column_mappings: Dict[str, Dict[str, str]] = {}
         for alias_key, alias in self._aliases.items():
@@ -1000,7 +1002,7 @@ class CompilationState(object):
             )
         )
 
-    def get_query(self, extra_outputs=None):
+    def get_query(self, extra_outputs: Optional[List[Label]] = None) -> Select:
         """After all IR Blocks are processed, return the resulting sqlalchemy query."""
         if not extra_outputs:
             extra_outputs = []

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -826,6 +826,8 @@ class CompilationState(object):
                 + [self._current_alias.primary_key[0].label("primary_key")]
             ).cte(recursive=False)
             self._from_clause = self._current_alias
+
+            # TODO more clever routing might be needed
             self._aliases = {
                 location: self._current_alias for location, alias in self._aliases.items()
             }

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -103,7 +103,8 @@ def _find_columns_used_outside_folds(sql_schema_info, ir):
         for recurse_info in ir.query_metadata_table.get_recurse_infos(location):
             traversal = "{}_{}".format(recurse_info.edge_direction, recurse_info.edge_name)
             used_columns[location.query_path] = used_columns.get(location.query_path, set()).union(
-                used_columns[location.query_path + (traversal,)])
+                used_columns[location.query_path + (traversal,)]
+            )
             used_columns.setdefault(location.query_path, set()).add(edge.from_column)
 
     # Find outputs used
@@ -823,7 +824,6 @@ class CompilationState(object):
             def __init__(self):
                 self.c = {}
 
-        recursion_vertex_path = self._current_location.query_path + (vertex_field,)
         extra_outputs = []
         routers = {}
         for alias_key, alias in self._aliases.items():

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -826,7 +826,6 @@ class CompilationState(object):
                 label = "_".join(vertex_path) + "__" + used_column_name
                 extra_outputs.append(alias.c[used_column_name].label(label))
                 routers.setdefault(alias_key, AliasRouter()).c[used_column_name] = label
-        extra_outputs.append(self._current_alias.primary_key[0].label("primary_key"))
 
         # Wrap the query so far into a cte. Make sure to select any fields used outside the cte.
         if self._recurse_needs_cte:

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -991,9 +991,6 @@ class CompilationState(object):
 
     def construct_result(self, output_name, field):
         """Execute a ConstructResult Block."""
-        # self._outputs.append(
-        #     field.to_sql(self.dialect, self._aliases, self._current_alias).label(output_name)
-        # )
         self._outputs.append(
             {"from_alias": self._current_alias, "label": output_name, "field": field,}
         )

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -827,11 +827,11 @@ class CompilationState(object):
             self._from_clause = self._current_alias
             self._aliases = {location: self._current_alias for location, alias in self._aliases.items()}
 
-        # Redirect all outputs to come from the cte
-        self._outputs = [dict(o, from_alias=self._current_alias) for o in self._outputs]
+            # Redirect all outputs to come from the cte
+            self._outputs = [dict(o, from_alias=self._current_alias) for o in self._outputs]
 
-        # The filters are already included in the cte
-        self._filters = []
+            # The filters are already included in the cte
+            self._filters = []
 
         previous_alias = self._current_alias
         self._relocate(self._current_location.navigate_to_subpath(vertex_field))

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1,6 +1,8 @@
 # Copyright 2018-present Kensho Technologies, LLC.
 """Transform a SqlNode tree into an executable SQLAlchemy query."""
 from collections import namedtuple
+from dataclasses import dataclass
+from typing import Dict
 
 import six
 import sqlalchemy
@@ -651,6 +653,7 @@ class UniqueAliasGenerator(object):
         return alias
 
 
+@dataclass
 class ColumnRouter:
     """Container for columns selected from a variety of selectables.
 
@@ -663,8 +666,7 @@ class ColumnRouter:
     TODO(bojanserafimov): make an abstract class instead of duck-typing this.
     """
 
-    def __init__(self, columns):
-        self.c = columns
+    c: Dict[str, sqlalchemy.Column]
 
 
 class CompilationState(object):

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -97,7 +97,7 @@ def _find_columns_used_outside_folds(sql_schema_info, ir):
                 used_columns.setdefault(child_location.query_path, set()).add(edge.from_column)
 
     # Columns used in the base case of CTE recursions should be made available from parent scope
-    for location, location_info in ir.query_metadata_table.registered_locations:
+    for location in ir.query_metadata_table.registered_locations:
         if isinstance(location, FoldScopeLocation):
             continue
         for recurse_info in ir.query_metadata_table.get_recurse_infos(location):

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -702,7 +702,6 @@ class CompilationState(object):
         self._from_clause = self._current_alias  # the main sqlalchemy Selectable
         self._outputs = []  # sqlalchemy Columns labelled correctly for output
         self._filters = []  # sqlalchemy Expressions to be used in the where clause
-        self._filters_at_location = {}
 
         self._current_fold = None  # SQLFoldObject to collect fold info and guide output query
         self._fold_vertex_location = None  # location in the IR tree where the fold starts
@@ -786,8 +785,6 @@ class CompilationState(object):
 
     def recurse(self, vertex_field, depth):
         """Execute a Recurse Block."""
-        predicates_on_this_node = self._filters_at_location[self._current_location.query_path]
-
         if self._current_fold is not None:
             raise AssertionError("Recurse inside a fold is not allowed.")
 
@@ -898,9 +895,6 @@ class CompilationState(object):
                     sql_expression, self._came_from[self._current_alias].is_(None)
                 )
             self._filters.append(sql_expression)
-            self._filters_at_location.setdefault(self._current_location.query_path, []).append(
-                predicate
-            )
 
     def fold(self, fold_scope_location):
         """Begin execution of a Fold Block."""

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -97,7 +97,7 @@ def _find_columns_used_outside_folds(sql_schema_info, ir):
                 used_columns.setdefault(child_location.query_path, set()).add(edge.from_column)
 
     # Columns used in the base case of CTE recursions should be made available from parent scope
-    for location in ir.query_metadata_table.registered_locations:
+    for location, _ in ir.query_metadata_table.registered_locations:
         if isinstance(location, FoldScopeLocation):
             continue
         for recurse_info in ir.query_metadata_table.get_recurse_infos(location):

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -9355,8 +9355,8 @@ class CompilerTests(unittest.TestCase):
                 anon_2.name AS self_and_ancestor_name
             FROM anon_1, anon_2
         """
-        # TODO Add an integration test for this query to make sure the recurse preserves
-        #      left join misses from the parent optional traversal.
+        # TODO(bojanserafimov) Add an integration test for this query to make sure the recurse
+        #                      preserves left join misses from the parent optional traversal.
         expected_cypher = SKIP_TEST
         expected_postgresql = """
             WITH RECURSIVE anon_1 AS (

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -8045,6 +8045,7 @@ class CompilerTests(unittest.TestCase):
         # TODO why did the previous query have:
         # WHERE
         #     anon_1.__cte_key IS NOT NULL OR [Animal_1].uuid IS NULL
+        # TODO the name output in anon_1 should come from Animal_2
         expected_cypher = SKIP_TEST
 
         check_test_data(

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2003,8 +2003,7 @@ class CompilerTests(unittest.TestCase):
                 SELECT
                     [Animal_1].name AS [Animal__name],
                     [Animal_1].parent AS [Animal__parent],
-                    [Animal_1].uuid AS [Animal__uuid],
-                    [Animal_1].uuid AS primary_key
+                    [Animal_1].uuid AS [Animal__uuid]
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_1]
                 WHERE
@@ -8009,8 +8008,7 @@ class CompilerTests(unittest.TestCase):
                     [Animal_1].parent AS [Animal__parent],
                     [Animal_2].name AS [Animal_in_Animal_ParentOf__name],
                     [Animal_2].parent AS [Animal_in_Animal_ParentOf__parent],
-                    [Animal_2].uuid AS [Animal_in_Animal_ParentOf__uuid],
-                    [Animal_2].uuid AS primary_key
+                    [Animal_2].uuid AS [Animal_in_Animal_ParentOf__uuid]
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_1]
                     LEFT OUTER JOIN db_1.schema_1.[Animal] AS [Animal_2]

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2001,9 +2001,9 @@ class CompilerTests(unittest.TestCase):
         expected_sql = """
             WITH anon_2 AS (
                 SELECT
-                    [Animal_1].name AS name,
-                    [Animal_1].parent AS parent,
-                    [Animal_1].uuid AS uuid,
+                    [Animal_1].name AS [Animal__name],
+                    [Animal_1].parent AS [Animal__parent],
+                    [Animal_1].uuid AS [Animal__uuid],
                     [Animal_1].uuid AS primary_key
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_1]
@@ -2011,10 +2011,10 @@ class CompilerTests(unittest.TestCase):
                     [Animal_1].name = :animal_name),
             anon_1(name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    anon_2.name AS name,
-                    anon_2.parent AS parent,
-                    anon_2.uuid AS uuid,
-                    anon_2.uuid AS __cte_key,
+                    anon_2.[Animal__name] AS name,
+                    anon_2.[Animal__parent] AS parent,
+                    anon_2.[Animal__uuid] AS uuid,
+                    anon_2.[Animal__uuid] AS __cte_key,
                     0 AS __cte_depth
                 FROM
                     anon_2
@@ -8005,20 +8005,23 @@ class CompilerTests(unittest.TestCase):
         expected_sql = """
             WITH anon_1 AS (
                 SELECT
-                    [Animal_1].name AS name,
-                    [Animal_1].parent AS parent,
-                    [Animal_1].uuid AS uuid,
-                    [Animal_1].uuid AS primary_key
+                    [Animal_1].name AS [Animal__name],
+                    [Animal_1].parent AS [Animal__parent],
+                    [Animal_2].name AS [Animal_in_Animal_ParentOf__name],
+                    [Animal_2].parent AS [Animal_in_Animal_ParentOf__parent],
+                    [Animal_2].uuid AS [Animal_in_Animal_ParentOf__uuid],
+                    [Animal_2].uuid AS primary_key
                 FROM
-                    db_1.schema_1.[Animal] AS [Animal_2]
-                    LEFT OUTER JOIN db_1.schema_1.[Animal] AS [Animal_1]
-                        ON [Animal_2].parent = [Animal_1].uuid),
+                    db_1.schema_1.[Animal] AS [Animal_1]
+                    LEFT OUTER JOIN db_1.schema_1.[Animal] AS [Animal_2]
+                        ON [Animal_1].parent = [Animal_2].uuid
+            ),
             anon_2(name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    anon_1.name AS name,
-                    anon_1.parent AS parent,
-                    anon_1.uuid AS uuid,
-                    anon_1.uuid AS __cte_key,
+                    anon_1.[Animal_in_Animal_ParentOf__name] AS name,
+                    anon_1.[Animal_in_Animal_ParentOf__parent] AS parent,
+                    anon_1.[Animal_in_Animal_ParentOf__uuid] AS uuid,
+                    anon_1.[Animal_in_Animal_ParentOf__uuid] AS __cte_key,
                     0 AS __cte_depth
                 FROM
                     anon_1
@@ -8033,17 +8036,14 @@ class CompilerTests(unittest.TestCase):
                     anon_2
                     JOIN db_1.schema_1.[Animal] AS [Animal_3]
                         ON anon_2.uuid = [Animal_3].parent
-                WHERE anon_2.__cte_depth < 3
+                    WHERE anon_2.__cte_depth < 3
             )
             SELECT
-                anon_1.name AS child_name,
-                anon_1.name AS name,
+                anon_1.[Animal_in_Animal_ParentOf__name] AS child_name,
+                anon_1.[Animal__name] AS name,
                 anon_2.name AS self_and_ancestor_name
-            FROM
-                anon_1, anon_2
+            FROM anon_1, anon_2
         """
-        # TODO This test shows the actual output, and not the desired output. The name output
-        #      in anon_1 should come from Animal_2. See todos in emit_sql.
         # TODO Add an integration test for this query to make sure the recurse preserves
         #      left join misses from the parent optional traversal.
         expected_cypher = SKIP_TEST

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2010,6 +2010,8 @@ class CompilerTests(unittest.TestCase):
                     0 AS __cte_depth
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_2]
+                WHERE
+                    [Animal_2].name = :animal_name
                 UNION ALL
                     SELECT
                         [Animal_3].name AS name,

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -1995,6 +1995,49 @@ class CompilerTests(unittest.TestCase):
             self, test_data, expected_match, expected_gremlin, expected_sql, expected_cypher
         )
 
+    def test_filter_then_recurse(self):
+        test_data = test_input_data.filter_then_recurse()
+
+        expected_match = SKIP_TEST
+        expected_gremlin = SKIP_TEST
+        expected_sql = """
+            WITH anon_1(name, parent, uuid, __cte_key, __cte_depth) AS (
+                SELECT
+                    [Animal_2].name AS name,
+                    [Animal_2].parent AS parent,
+                    [Animal_2].uuid AS uuid,
+                    [Animal_2].uuid AS __cte_key,
+                    0 AS __cte_depth
+                FROM
+                    db_1.schema_1.[Animal] AS [Animal_2]
+                UNION ALL
+                    SELECT
+                        [Animal_3].name AS name,
+                        [Animal_3].parent AS parent,
+                        [Animal_3].uuid AS uuid,
+                        anon_1.__cte_key AS __cte_key,
+                        anon_1.__cte_depth + 1 AS __cte_depth
+                    FROM
+                        anon_1
+                        JOIN db_1.schema_1.[Animal] AS [Animal_3]
+                            ON anon_1.uuid = [Animal_3].parent
+                    WHERE anon_1.__cte_depth < 1
+            )
+            SELECT
+                anon_1.name AS relation_name
+            FROM
+                db_1.schema_1.[Animal] AS [Animal_1]
+                JOIN anon_1
+                    ON [Animal_1].uuid = anon_1.__cte_key
+            WHERE
+                [Animal_1].name = :animal_name
+        """
+        expected_cypher = SKIP_TEST
+
+        check_test_data(
+            self, test_data, expected_match, expected_gremlin, expected_sql, expected_cypher
+        )
+
     def test_traverse_then_recurse(self):
         test_data = test_input_data.traverse_then_recurse()
 

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -8046,6 +8046,7 @@ class CompilerTests(unittest.TestCase):
         # WHERE
         #     anon_1.__cte_key IS NOT NULL OR [Animal_1].uuid IS NULL
         # TODO the name output in anon_1 should come from Animal_2
+        # TODO test with traverse after recurse
         expected_cypher = SKIP_TEST
 
         check_test_data(

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2001,38 +2001,40 @@ class CompilerTests(unittest.TestCase):
         expected_match = SKIP_TEST
         expected_gremlin = SKIP_TEST
         expected_sql = """
-            WITH anon_1(name, parent, uuid, __cte_key, __cte_depth) AS (
+            WITH anon_2 AS (
                 SELECT
-                    [Animal_2].name AS name,
-                    [Animal_2].parent AS parent,
-                    [Animal_2].uuid AS uuid,
-                    [Animal_2].uuid AS __cte_key,
+                    [Animal_1].name AS name,
+                    [Animal_1].uuid AS uuid,
+                    [Animal_1].uuid AS primary_key
+                FROM
+                    db_1.schema_1.[Animal] AS [Animal_1]
+                WHERE
+                    [Animal_1].name = :animal_name),
+            anon_1(name, uuid, __cte_key, __cte_depth) AS (
+                SELECT
+                    anon_2.name AS name,
+                    anon_2.uuid AS uuid,
+                    anon_2.uuid AS __cte_key,
                     0 AS __cte_depth
                 FROM
-                    db_1.schema_1.[Animal] AS [Animal_2]
-                WHERE
-                    [Animal_2].name = :animal_name
+                    anon_2
                 UNION ALL
-                    SELECT
-                        [Animal_3].name AS name,
-                        [Animal_3].parent AS parent,
-                        [Animal_3].uuid AS uuid,
-                        anon_1.__cte_key AS __cte_key,
-                        anon_1.__cte_depth + 1 AS __cte_depth
-                    FROM
-                        anon_1
-                        JOIN db_1.schema_1.[Animal] AS [Animal_3]
-                            ON anon_1.uuid = [Animal_3].parent
-                    WHERE anon_1.__cte_depth < 1
+                SELECT
+                    [Animal_2].name AS name,
+                    [Animal_2].uuid AS uuid,
+                    anon_1.__cte_key AS __cte_key,
+                    anon_1.__cte_depth + 1 AS __cte_depth
+                FROM
+                    anon_1 JOIN db_1.schema_1.[Animal] AS [Animal_2]
+                        ON anon_1.uuid = [Animal_2].parent
+                WHERE
+                    anon_1.__cte_depth < 1
             )
             SELECT
                 anon_1.name AS relation_name
             FROM
-                db_1.schema_1.[Animal] AS [Animal_1]
-                JOIN anon_1
-                    ON [Animal_1].uuid = anon_1.__cte_key
-            WHERE
-                [Animal_1].name = :animal_name
+                anon_1,
+                anon_2
         """
         expected_cypher = SKIP_TEST
 

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -8042,9 +8042,10 @@ class CompilerTests(unittest.TestCase):
             FROM
                 anon_1, anon_2
         """
+        # TODO This test shows the actual output, and not the desired output. The name output
+        #      in anon_1 should come from Animal_2. See todos in emit_sql.
         # TODO Add an integration test for this query to make sure the recurse preserves
         #      left join misses from the parent optional traversal.
-        # TODO the name output in anon_1 should come from Animal_2. See todos in emit_sql.
         expected_cypher = SKIP_TEST
 
         check_test_data(

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -8042,11 +8042,9 @@ class CompilerTests(unittest.TestCase):
             FROM
                 anon_1, anon_2
         """
-        # TODO why did the previous query have:
-        # WHERE
-        #     anon_1.__cte_key IS NOT NULL OR [Animal_1].uuid IS NULL
-        # TODO the name output in anon_1 should come from Animal_2
-        # TODO test with traverse after recurse
+        # TODO Add an integration test for this query to make sure the recurse preserves
+        #      left join misses from the parent optional traversal.
+        # TODO the name output in anon_1 should come from Animal_2. See todos in emit_sql.
         expected_cypher = SKIP_TEST
 
         check_test_data(

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -908,6 +908,28 @@ def simple_recurse() -> CommonTestData:  # noqa: D103
     )
 
 
+def filter_then_recurse() -> CommonTestData:  # noqa: D103
+    graphql_input = """{
+        Animal {
+            name @filter(op_name: "=", value: ["$animal_name"])
+            out_Animal_ParentOf @recurse(depth: 1) {
+                name @output(out_name: "relation_name")
+            }
+        }
+    }"""
+    expected_output_metadata = {
+        "relation_name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+    }
+    expected_input_metadata = {"animal_name": GraphQLString}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None,
+    )
+
+
 def traverse_then_recurse() -> CommonTestData:  # noqa: D103
     graphql_input = """{
         Animal {

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -1805,6 +1805,41 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
+    def test_filter_then_recurse(self):
+        test_data = test_input_data.filter_then_recurse()
+
+        base_location = helpers.Location(("Animal",))
+        child_location = base_location.navigate_to_subpath("out_Animal_ParentOf")
+
+        expected_blocks = [
+            blocks.QueryRoot({"Animal"}),
+            blocks.Filter(
+                expressions.BinaryComposition(
+                    u"=",
+                    expressions.LocalField("name", GraphQLString),
+                    expressions.Variable("$animal_name", GraphQLString),
+                )
+            ),
+            blocks.MarkLocation(base_location),
+            blocks.Recurse("out", "Animal_ParentOf", 1),
+            blocks.MarkLocation(child_location),
+            blocks.Backtrack(base_location),
+            blocks.GlobalOperationsStart(),
+            blocks.ConstructResult(
+                {
+                    "relation_name": expressions.OutputContextField(
+                        child_location.navigate_to_field("name"), GraphQLString
+                    ),
+                }
+            ),
+        ]
+        expected_location_types = {
+            base_location: "Animal",
+            child_location: "Animal",
+        }
+
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
+
     def test_traverse_then_recurse(self):
         test_data = test_input_data.traverse_then_recurse()
 


### PR DESCRIPTION
In some cases Postgres and MSSQL compute the recurrence before they compute the base case, which can be millions of times slower. To force the backend to compute the base case first, it can be wrapped in a cte.

In this PR I wrap the query contents before the recurse (as seen in the IR) into a cte if they are complicated enough (contain at least one traversal or filter).