### PR TITLE
Add multiple output fold test

### DIFF
--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -514,12 +514,12 @@ class IntegrationTests(TestCase):
                 {"starting_animal_name": "Animal 1",},
                 [
                     {
-                        "child_names": ['Animal 1', 'Animal 2', 'Animal 3'],
+                        "child_names": ["Animal 1", "Animal 2", "Animal 3"],
                         "child_uuids": [
-                            'cfc6e625-8594-0927-468f-f53d864a7a51',
-                            'cfc6e625-8594-0927-468f-f53d864a7a52',
-                            'cfc6e625-8594-0927-468f-f53d864a7a53'
-                        ]
+                            "cfc6e625-8594-0927-468f-f53d864a7a51",
+                            "cfc6e625-8594-0927-468f-f53d864a7a52",
+                            "cfc6e625-8594-0927-468f-f53d864a7a53",
+                        ],
                     },
                 ],
             ),

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -499,6 +499,30 @@ class IntegrationTests(TestCase):
                 {"starting_animal_name": "Animal 4",},
                 [{"child_names": []},],
             ),
+            # Query 5: Multiple outputs in a fold scope.
+            (
+                """
+            {
+                Animal {
+                    name @filter(op_name: "=", value: ["$starting_animal_name"])
+                    out_Animal_ParentOf @fold {
+                        name @output(out_name: "child_names")
+                        uuid @output(out_name: "child_uuids")
+                    }
+                }
+            }""",
+                {"starting_animal_name": "Animal 1",},
+                [
+                    {
+                        "child_names": ['Animal 1', 'Animal 2', 'Animal 3'],
+                        "child_uuids": [
+                            'cfc6e625-8594-0927-468f-f53d864a7a51',
+                            'cfc6e625-8594-0927-468f-f53d864a7a52',
+                            'cfc6e625-8594-0927-468f-f53d864a7a53'
+                        ]
+                    },
+                ],
+            ),
         ]
 
         for graphql_query, parameters, expected_results in queries:


### PR DESCRIPTION
This adds a test for multiple fold outputs within the same fold scope. Note that the way we sort outputs for comparison should be updated. See #787 