### PR TITLE
Make class count statistics optional

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -409,16 +409,17 @@ class QueryPlanningAnalysis:
         return get_types(self.metadata_table)
 
     @cached_property
-    def has_class_counts_data(self) -> bool:
+    def classes_with_missing_counts(self) -> Set[str]:
         """Return whether class counts are available for all vertices and edges used."""
+        classes_with_missing_counts = set()
         for vertex_path, vertex_type in self.types.items():
             if self.schema_info.statistics.get_class_count(vertex_type.name) is None:
-                return False
+                classes_with_missing_counts.add(vertex_type.name)
             if len(vertex_path) > 1:
                 _, edge_name = get_edge_direction_and_name(vertex_path[-1])
                 if self.schema_info.statistics.get_class_count(edge_name) is None:
-                    return False
-        return True
+                    classes_with_missing_counts.add(edge_name)
+        return classes_with_missing_counts
 
     @cached_property
     def cardinality_estimate(self) -> float:

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -409,6 +409,18 @@ class QueryPlanningAnalysis:
         return get_types(self.metadata_table)
 
     @cached_property
+    def has_class_counts_data(self) -> bool:
+        """Return whether class counts are available for all vertices and edges used."""
+        for vertex_path, vertex_type in self.types.items():
+            if self.schema_info.statistics.get_class_count(vertex_type.name) is None:
+                return False
+            if len(vertex_path) > 1:
+                _, edge_name = get_edge_direction_and_name(vertex_path[-1])
+                if self.schema_info.statistics.get_class_count(edge_name) is None:
+                    return False
+        return True
+
+    @cached_property
     def cardinality_estimate(self) -> float:
         """Return the cardinality estimate for this query."""
         # TODO use selectivity analysis pass instead of recomputing it

--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -410,7 +410,7 @@ class QueryPlanningAnalysis:
 
     @cached_property
     def classes_with_missing_counts(self) -> Set[str]:
-        """Return whether class counts are available for all vertices and edges used."""
+        """Return classes that don't have count statistics."""
         classes_with_missing_counts = set()
         for vertex_path, vertex_type in self.types.items():
             if self.schema_info.statistics.get_class_count(vertex_type.name) is None:

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -160,7 +160,6 @@ class LocalStatistics(Statistics):
 
     def get_class_count(self, class_name):
         """See base class."""
-        # XXX TODO in this PR: document that class counts are not actually required
         return self._class_counts.get(class_name)
 
     def get_vertex_edge_vertex_count(

--- a/graphql_compiler/cost_estimation/statistics.py
+++ b/graphql_compiler/cost_estimation/statistics.py
@@ -160,11 +160,8 @@ class LocalStatistics(Statistics):
 
     def get_class_count(self, class_name):
         """See base class."""
-        if class_name not in self._class_counts:
-            raise AssertionError(
-                f"Class count statistic is required, but entry not found for {class_name}"
-            )
-        return self._class_counts[class_name]
+        # XXX TODO in this PR: document that class counts are not actually required
+        return self._class_counts.get(class_name)
 
     def get_vertex_edge_vertex_count(
         self, vertex_source_class_name, edge_class_name, vertex_target_class_name

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -6,7 +6,7 @@ from graphql.language.printer import print_ast
 from ..cost_estimation.analysis import QueryPlanningAnalysis, analyze_query_string
 from ..global_utils import ASTWithParameters, QueryStringWithParameters
 from ..schema.schema_info import QueryPlanningSchemaInfo
-from .pagination_planning import PaginationAdvisory, get_pagination_plan
+from .pagination_planning import MissingClassCount, PaginationAdvisory, get_pagination_plan
 from .parameter_generator import generate_parameters_for_vertex_partition
 from .query_parameterizer import generate_parameterized_queries
 from .typedefs import PageAndRemainder
@@ -85,7 +85,10 @@ def paginate_query_ast(
     # See if we can and should split the query
     num_pages = 1
     if query_analysis.classes_with_missing_counts:
-        advisories += tuple()  # TODO add advisory
+        advisories += tuple(
+            MissingClassCount(class_name)
+            for class_name in query_analysis.classes_with_missing_counts
+        )
     else:
         result_size = query_analysis.cardinality_estimate
         num_pages = _estimate_number_of_pages(

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -84,7 +84,9 @@ def paginate_query_ast(
 
     # See if we can and should split the query
     num_pages = 1
-    if query_analysis.has_class_counts_data:
+    if query_analysis.classes_with_missing_counts:
+        advisories += tuple()  # TODO add advisory
+    else:
         result_size = query_analysis.cardinality_estimate
         num_pages = _estimate_number_of_pages(
             query_analysis.query_string_with_parameters, result_size, page_size

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -82,11 +82,15 @@ def paginate_query_ast(
     remainder_queries: Tuple[ASTWithParameters, ...] = tuple()
     advisories: Tuple[PaginationAdvisory, ...] = tuple()
 
-    # Split the query if we should and we can
-    result_size = query_analysis.cardinality_estimate
-    num_pages = _estimate_number_of_pages(
-        query_analysis.query_string_with_parameters, result_size, page_size
-    )
+    # See if we can and should split the query
+    num_pages = 1
+    if query_analysis.has_class_counts_data:
+        result_size = query_analysis.cardinality_estimate
+        num_pages = _estimate_number_of_pages(
+            query_analysis.query_string_with_parameters, result_size, page_size
+        )
+
+    # Split the query if we can and should
     if num_pages > 1:
         pagination_plan, advisories = get_pagination_plan(query_analysis, num_pages)
         if len(pagination_plan.vertex_partitions) == 0:

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -15,6 +15,18 @@ class PaginationAdvisory(ABC):
 
 
 @dataclass
+class MissingClassCount(PaginationAdvisory):
+    class_name: str
+
+    def __post_init__(self):
+        """Initialize a human-readable message."""
+        self.message = (
+            f"Class count statistics for the vertices and edges mentioned in the queries "
+            f"are required for pagination. Class {self.class_name} had no counts."
+        )
+
+
+@dataclass
 class PaginationFieldNotSpecified(PaginationAdvisory):
     vertex_name: str
 

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -21,7 +21,7 @@ class MissingClassCount(PaginationAdvisory):
     def __post_init__(self):
         """Initialize a human-readable message."""
         self.message = (
-            f"Class count statistics for the vertices and edges mentioned in the queries "
+            f"Class count statistics for the vertices and edges mentioned in the query "
             f"are required for pagination. Class {self.class_name} had no counts."
         )
 

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -16,6 +16,7 @@ from ...global_utils import ASTWithParameters, QueryStringWithParameters
 from ...query_pagination import paginate_query
 from ...query_pagination.pagination_planning import (
     InsufficientQuantiles,
+    MissingClassCount,
     PaginationAdvisory,
     PaginationPlan,
     VertexPartitionPlan,
@@ -1674,10 +1675,8 @@ class QueryPaginationTests(unittest.TestCase):
             {},
         )
 
-        # No counts for Animal
-        count_data: Dict[str, int] = {}
-
-        statistics = LocalStatistics(count_data)
+        # No class counts provided
+        statistics = LocalStatistics({})
         schema_info = QueryPlanningSchemaInfo(
             schema=graphql_schema,
             type_equivalence_hints=type_equivalence_hints,
@@ -1687,9 +1686,9 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        first_page_and_remainder, _ = paginate_query(schema_info, query, 1)
+        first_page_and_remainder, advisories = paginate_query(schema_info, query, 1)
         self.assertTrue(first_page_and_remainder.remainder == tuple())
-        # TODO assert advisory is returned
+        self.assertEqual(advisories, (MissingClassCount("Animal"),))
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_pagination_missing_non_root_vertex_class_count(self) -> None:
@@ -1728,9 +1727,9 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        first_page_and_remainder, _ = paginate_query(schema_info, query, 1)
+        first_page_and_remainder, advisories = paginate_query(schema_info, query, 1)
         self.assertTrue(first_page_and_remainder.remainder == tuple())
-        # TODO assert advisory is returned
+        self.assertEqual(advisories, (MissingClassCount("Location"),))
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_pagination_missing_edge_class_count(self) -> None:
@@ -1769,6 +1768,6 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        first_page_and_remainder, _ = paginate_query(schema_info, query, 1)
+        first_page_and_remainder, advisories = paginate_query(schema_info, query, 1)
         self.assertTrue(first_page_and_remainder.remainder == tuple())
-        # TODO assert advisory is returned
+        self.assertEqual(advisories, (MissingClassCount("Animal_LivesIn"),))

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -1675,7 +1675,7 @@ class QueryPaginationTests(unittest.TestCase):
         )
 
         # No counts for Animal
-        count_data = {}
+        count_data: Dict[str, int] = {}
 
         statistics = LocalStatistics(count_data)
         schema_info = QueryPlanningSchemaInfo(
@@ -1688,7 +1688,8 @@ class QueryPaginationTests(unittest.TestCase):
         )
 
         first_page_and_remainder, _ = paginate_query(schema_info, query, 1)
-        # TODO assert no pagination happened (currently it crashes)
+        self.assertTrue(first_page_and_remainder.remainder == tuple())
+        # TODO assert advisory is returned
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_pagination_missing_non_root_vertex_class_count(self) -> None:
@@ -1728,7 +1729,8 @@ class QueryPaginationTests(unittest.TestCase):
         )
 
         first_page_and_remainder, _ = paginate_query(schema_info, query, 1)
-        # TODO assert no pagination happened (currently it crashes)
+        self.assertTrue(first_page_and_remainder.remainder == tuple())
+        # TODO assert advisory is returned
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_pagination_missing_edge_class_count(self) -> None:
@@ -1768,4 +1770,5 @@ class QueryPaginationTests(unittest.TestCase):
         )
 
         first_page_and_remainder, _ = paginate_query(schema_info, query, 1)
-        # TODO assert no pagination happened (currently it crashes)
+        self.assertTrue(first_page_and_remainder.remainder == tuple())
+        # TODO assert advisory is returned


### PR DESCRIPTION
Now that we have advisories it makes more sense to raise one for missing class counts than to raise an `AssertionError`.

Changes in this PR:
1. Add end-to-end pagination tests with class counts missing
2. Make class counts optional
3. Disable pagination completely if any relevant class count is missing
3. Return advisories for misssing class counts