### PR TITLE
Make filtering inside a fold error message for MSSQL clearer

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -560,7 +560,9 @@ class SQLFoldObject(object):
                 "state encountered during fold {}".format(self)
             )
         if isinstance(self._dialect, MSDialect):
-            raise NotImplementedError("Filtering on fields is not implemented for MSSQL yet.")
+            raise NotImplementedError(
+                "Filtering on fields inside a fold is not implemented for MSSQL yet."
+            )
         # Filters are applied to output vertices, thus current_alias=self.output_vertex_alias.
         sql_expression = predicate.to_sql(self._dialect, aliases, self._output_vertex_alias)
         self._filters.append(sql_expression)


### PR DESCRIPTION
The previous error message was unclear because it did not specify that the user was trying to filter **inside a fold**. Filters outside of folds are implemented for MSSQL so this error message could lead to confusion.