### PR TITLE
Traversals in folds for PostgreSQL

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -528,7 +528,9 @@ class SQLFoldObject(object):
         # Sort to make select order deterministic.
         return sorted(self._outputs, key=lambda column: column.name, reverse=True)
 
-    def visit_vertex(self, join_descriptor, from_table, to_table, current_fold_scope_location, all_folded_fields):
+    def visit_vertex(
+        self, join_descriptor, from_table, to_table, current_fold_scope_location, all_folded_fields
+    ):
         """Add a new traversal descriptor and add outputs, if visiting an output vertex."""
         if self._ended:
             raise AssertionError(
@@ -680,7 +682,7 @@ class CompilationState(object):
         if self._current_fold is not None and isinstance(new_location, FoldScopeLocation):
             alias_key = (
                 self._current_location.base_location.query_path,
-                self._current_location.fold_path
+                self._current_location.fold_path,
             )
         # Regardless of whether self._current_fold is None or not, if the new location is a
         # Location, relocation should occur based on a Location alias key.
@@ -760,9 +762,17 @@ class CompilationState(object):
         edge = self._sql_schema_info.join_descriptors[self._current_classname][vertex_field]
         self._relocate(self._current_location.navigate_to_subpath(vertex_field))
         if self._current_fold is not None:
-            self._current_fold.visit_vertex(edge, previous_alias, self._current_alias, self._current_location, self._all_folded_fields)
+            self._current_fold.visit_vertex(
+                edge,
+                previous_alias,
+                self._current_alias,
+                self._current_location,
+                self._all_folded_fields,
+            )
         else:
-            self._join_to_parent_location(previous_alias, edge.from_column, edge.to_column, optional)
+            self._join_to_parent_location(
+                previous_alias, edge.from_column, edge.to_column, optional
+            )
 
     def _get_current_primary_key_name(self, directive_name: str) -> str:
         """Return the name of the single-column primary key at the current location.
@@ -906,8 +916,13 @@ class CompilationState(object):
 
         # 4. Relocate to inside the fold scope and visit the first vertex.
         self._relocate(fold_scope_location)
-        self._current_fold.visit_vertex(join_descriptor, outer_alias, self._current_alias,
-                                        fold_scope_location, self._all_folded_fields)
+        self._current_fold.visit_vertex(
+            join_descriptor,
+            outer_alias,
+            self._current_alias,
+            fold_scope_location,
+            self._all_folded_fields,
+        )
 
     def unfold(self):
         """Complete the execution of a Fold Block."""
@@ -938,10 +953,7 @@ class CompilationState(object):
         # If the current location is the beginning of a fold, the current alias
         # will eventually be replaced by the resulting fold subquery during Unfold.
         self._aliases[
-            (
-                self._current_location.base_location.query_path,
-                self._current_location.fold_path,
-            )
+            (self._current_location.base_location.query_path, self._current_location.fold_path,)
             if self._current_fold is not None
             else (self._current_location.query_path, None)
         ] = self._current_alias

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -711,24 +711,19 @@ class CompilationState(object):
     def _relocate(self, new_location):
         """Move to a different location in the query, updating the _current_alias."""
         self._current_location = new_location
-        # Create appropriate alias key based on whether or not relocation is taking place in a fold
-        # or not. Note: during end_fold relocation to outside of the fold (i.e. to a Location rather
-        # than a FoldScopeLocation) occurs before self._current_fold is set to None. Therefore, it
-        # should be checked that the current fold is not None AND that the new location is a
-        # FoldScopeLocation.
-        if self._current_fold is not None and isinstance(new_location, FoldScopeLocation):
+        # Create appropriate alias key based on whether new_location is a FoldScopeLocation or a
+        # Location.
+        if isinstance(new_location, FoldScopeLocation):
             alias_key = (
                 self._current_location.base_location.query_path,
                 self._current_location.fold_path,
             )
-        # Regardless of whether self._current_fold is None or not, if the new location is a
-        # Location, relocation should occur based on a Location alias key.
         elif isinstance(new_location, Location):
             alias_key = (self._current_location.query_path, None)
         else:
             raise AssertionError(
-                f"Attempted an invalid relocation to {new_location} while the current fold was set"
-                f"to {self._current_fold}."
+                f"Attempted an invalid relocation to a {type(new_location)}. new_location must be "
+                f"either a Location or a FoldScopeLocation. new_location was {new_location}."
             )
 
         # Update the current alias.

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -83,8 +83,6 @@ def check_test_data(
         string_result = print_sqlalchemy_query_string(
             result.query, test_case.mssql_schema_info.dialect
         )
-        print("\n\n========MSSQL RESULT========")
-        print(string_result)
         compare_sql(test_case, expected_mssql, string_result)
         test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
         compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
@@ -100,8 +98,6 @@ def check_test_data(
         string_result = print_sqlalchemy_query_string(
             result.query, test_case.postgresql_schema_info.dialect
         )
-        print("\n\n========POSTGRESQL RESULT========")
-        print(string_result)
         compare_sql(test_case, expected_postgresql, string_result)
         test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
         compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
@@ -5867,7 +5863,7 @@ class CompilerTests(unittest.TestCase):
             JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
-                    array_agg("Animal_3".name) AS fold_output_name 
+                    array_agg("Animal_3".name) AS fold_output_name
                 FROM schema_1."Animal" AS "Animal_2"
                 JOIN schema_1."Animal" AS "Animal_4"
                 ON "Animal_2".parent = "Animal_4".uuid
@@ -5877,26 +5873,6 @@ class CompilerTests(unittest.TestCase):
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
         """
-        """
-            SELECT
-                "Animal_1".name AS animal_name, 
-                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) 
-                    AS sibling_and_self_names_list 
-            FROM 
-                schema_1."Animal" AS "Animal_1" 
-            JOIN (
-                SELECT 
-                    "Animal_1".uuid AS uuid, 
-                    array_agg("Animal_2".name) AS fold_output_name 
-                FROM schema_1."Animal" AS "Animal_1" 
-                JOIN schema_1."Animal" AS "Animal_3" 
-                ON "Animal_1".parent = "Animal_3".uuid 
-                JOIN schema_1."Animal" AS "Animal_2" 
-                ON "Animal_4".uuid = "Animal_2".parent 
-                GROUP BY "Animal_1".uuid
-            ) AS folded_subquery_1 
-            ON "Animal_1".uuid = folded_subquery_1.uuid
-"""
 
         check_test_data(
             self,

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -5833,7 +5833,7 @@ class CompilerTests(unittest.TestCase):
                     ))
             ])}
         """
-        # TODO: implement multiple traversals in a separate PR
+        # TODO: implement multiple traversals for MSSQL in a separate PR
         expected_mssql = NotImplementedError
         expected_cypher = """
             MATCH (Animal___1:Animal)

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -5787,55 +5787,7 @@ class CompilerTests(unittest.TestCase):
             ])}
         """
         # TODO: implement multiple traversals in a separate PR
-        expected_mssql = SKIP_TEST
-        #
-        #     SELECT
-        #         [Animal_1].name AS animal_name,
-        #         folded_subquery_1.fold_output_name AS sibling_and_self_species_list
-        #     FROM db_1.schema_1.[Animal] AS [Animal_1]
-        #     JOIN (
-        #         SELECT
-        #             [Animal_2].uuid AS uuid,
-        #             coalesce(
-        #                 (SELECT '|' + coalesce(
-        #                     REPLACE(
-        #                         REPLACE(
-        #                             REPLACE(
-        #                                 [Species_1].name, '^', '^e'
-        #                             ), '~', '^n'),
-        #                         '|', '^d'),
-        #                     '~')
-        #                 FROM db_1.schema_1.[Species] AS [Species_1]
-        #                 WHERE [Animal_3].species = [Species_1].uuid FOR XML PATH ('')
-        #                 ),
-        #             '') AS fold_output_name
-        #         FROM db_1.schema_1.[Animal] AS [Animal_2]
-        #         JOIN db_1.schema_1.[Animal] AS [Animal_4]
-        #         ON [Animal_2].parent = [Animal_4].uuid
-        #         JOIN db_1.schema_1.[Animal] AS [Animal_3]
-        #         ON [Animal_5].uuid = [Animal_3].parent
-        #     ) AS folded_subquery_1
-        #     ON [Animal_1].uuid = folded_subquery_1.uuid
-        # expected_sql = '''
-        #     SELECT
-        #         [Animal_1].name as animal_name,
-        #         coalesce(folded_subquery_1.fold_output_1, ARRAY[]::VARCHAR[])
-        #             AS sibling_and_self_names_list
-        #     FROM
-        #         db_1.schema_1.[Animal] AS [Animal_1]
-        #     LEFT JOIN (
-        #         SELECT
-        #             [Animal_2].uuid,
-        #             array_agg([Animal_4].name) as sibling_and_self_names_list
-        #         FROM db_1.schema_1.[Animal] AS [Animal_2]
-        #         JOIN db_1.schema_1.[Animal] AS [Animal_3]
-        #         ON [Animal_2].parent = [Animal_3].uuid
-        #         JOIN db_1.schema_1.[Animal] AS [Animal_4]
-        #         ON [Animal_3].uuid = [Animal_4].parent
-        #         GROUP BY [Animal_2].uuid
-        #     ) AS folded_subquery_1
-        #     ON [Animal_1].uuid = folded_subquery_1.uuid
-        # '''
+        expected_mssql = NotImplementedError
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -5926,7 +5878,7 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         """
-        expected_sql = NotImplementedError
+        expected_mssql = NotImplementedError
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -5977,7 +5929,7 @@ class CompilerTests(unittest.TestCase):
             test_data,
             expected_match,
             expected_gremlin,
-            expected_sql,
+            expected_mssql,
             expected_cypher,
             expected_postgresql,
         )


### PR DESCRIPTION
This PR implements traversals inside of folds for PostgreSQL. The `SQLFoldObject` methods `visit_traversed_vertex` and `visit_output_vertex` have been combined into a single method `visit_vertex`, which performs a traversal and checks if there are any outputs at the new location. Since outputs can only come from a single location within a fold, `visit_vertex` throws an error if the user attempts to output from multiple locations within the fold.