### PR TITLE
Create codecov.yml slightly relaxing patch coverage rule

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 0.03%
+        base: auto


### PR DESCRIPTION
Inspired by the situation of #803, where the addition of thoroughly-tested code caused a negative coverage result because of a coverage change in an unrelated module.

Our project coverage is already very high, to the point where a single line missing coverage will currently make the coverage check fail. However, while our coverage is high, we don't have a high coverage _depth_ — any given line is covered relatively few times. This makes it somewhat likely that an unrelated change may cause some line to transition from covered to uncovered. Due to our high coverage, this makes it very likely that the newly-uncovered line will cause Codecov to report a negative coverage result, even though the code change may have been only distantly related to the coverage change.

The 0.03% threshold allows a few lines (1 < N < 10) to transition from covered to uncovered, without reporting a negative patch coverage result. If this PR is merged, I think #803 would get a positive patch coverage result.