### PR TITLE
Add missing type hints to query_formatting module

### DIFF
--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -2,7 +2,7 @@
 """Safely insert runtime arguments into compiled GraphQL queries."""
 import datetime
 import decimal
-from typing import Any, Mapping, Union
+from typing import Any, Dict, Mapping, Union
 
 import arrow
 from graphql import (
@@ -18,11 +18,18 @@ from graphql import (
 )
 import six
 
-from ..compiler import CYPHER_LANGUAGE, GREMLIN_LANGUAGE, MATCH_LANGUAGE, SQL_LANGUAGE
+from ..compiler import (
+    CYPHER_LANGUAGE,
+    GREMLIN_LANGUAGE,
+    MATCH_LANGUAGE,
+    SQL_LANGUAGE,
+    CompilationResult,
+)
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..global_utils import is_same_type
 from ..schema import CUSTOM_SCALAR_TYPES, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+from ..typedefs import GraphQLQueryArgumentType
 from .cypher_formatting import insert_arguments_into_cypher_query_redisgraph
 from .gremlin_formatting import insert_arguments_into_gremlin_query
 from .match_formatting import insert_arguments_into_match_query
@@ -34,7 +41,7 @@ from .sql_formatting import insert_arguments_into_sql_query
 ######
 
 
-def _raise_invalid_type_error(name, expected_python_type_name, value):
+def _raise_invalid_type_error(name: str, expected_python_type_name: str, value: Any):
     """Raise a GraphQLInvalidArgumentError that states that the argument type is invalid."""
     raise GraphQLInvalidArgumentError(
         "Invalid type for argument {}. Expected {}. Got value {} of "
@@ -179,7 +186,7 @@ def deserialize_multiple_json_arguments(
     }
 
 
-def validate_argument_type(name, expected_type, value):
+def validate_argument_type(name: str, expected_type: GraphQLQueryArgumentType, value: Any):
     """Ensure the value has the expected type and is usable in any of our backends, or raise errors.
 
     Backends are the database languages we have the ability to compile to, like OrientDB MATCH,
@@ -268,7 +275,7 @@ def ensure_arguments_are_provided(
 
 
 def validate_arguments(
-    expected_types: Mapping[str, GraphQLType], arguments: Mapping[str, Any]
+    expected_types: Mapping[str, GraphQLQueryArgumentType], arguments: Mapping[str, Any]
 ) -> None:
     """Ensure that all arguments are provided and that they are of the expected type."""
     ensure_arguments_are_provided(expected_types, arguments)
@@ -276,7 +283,7 @@ def validate_arguments(
         validate_argument_type(name, expected_types[name], arguments[name])
 
 
-def insert_arguments_into_query(compilation_result, arguments):
+def insert_arguments_into_query(compilation_result: CompilationResult, arguments: Dict[str, Any]):
     """Insert the arguments into the compiled GraphQL query to form a complete query.
 
     Args:

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -29,7 +29,7 @@ from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
 from ..global_utils import is_same_type
 from ..schema import CUSTOM_SCALAR_TYPES, GraphQLDate, GraphQLDateTime, GraphQLDecimal
-from ..typedefs import GraphQLQueryArgumentType
+from ..typedefs import QueryArgumentGraphQLType
 from .cypher_formatting import insert_arguments_into_cypher_query_redisgraph
 from .gremlin_formatting import insert_arguments_into_gremlin_query
 from .match_formatting import insert_arguments_into_match_query
@@ -186,7 +186,7 @@ def deserialize_multiple_json_arguments(
     }
 
 
-def validate_argument_type(name: str, expected_type: GraphQLQueryArgumentType, value: Any):
+def validate_argument_type(name: str, expected_type: QueryArgumentGraphQLType, value: Any):
     """Ensure the value has the expected type and is usable in any of our backends, or raise errors.
 
     Backends are the database languages we have the ability to compile to, like OrientDB MATCH,
@@ -275,7 +275,7 @@ def ensure_arguments_are_provided(
 
 
 def validate_arguments(
-    expected_types: Mapping[str, GraphQLQueryArgumentType], arguments: Mapping[str, Any]
+    expected_types: Mapping[str, QueryArgumentGraphQLType], arguments: Mapping[str, Any]
 ) -> None:
     """Ensure that all arguments are provided and that they are of the expected type."""
     ensure_arguments_are_provided(expected_types, arguments)

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -28,7 +28,7 @@ from ..query_formatting.common import (
 )
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal, GraphQLSchemaFieldType
 from ..schema.schema_info import CommonSchemaInfo
-from ..typedefs import GraphQLQueryArgumentType
+from ..typedefs import QueryArgumentGraphQLType
 from .test_helpers import compare_gremlin, compare_match, get_schema
 
 
@@ -232,7 +232,7 @@ class QueryFormattingTests(unittest.TestCase):
                     validate_argument_type(arbitrary_argument_name, graphql_type, invalid_value)
 
     def test_non_null_types_pass_validation(self) -> None:
-        type_and_value: List[Tuple[GraphQLQueryArgumentType, Any]] = [
+        type_and_value: List[Tuple[QueryArgumentGraphQLType, Any]] = [
             (GraphQLString, "abc"),  # sanity check
             (GraphQLNonNull(GraphQLString), "abc"),
             (GraphQLList(GraphQLString), ["a", "b", "c"]),  # sanity check

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -28,6 +28,7 @@ from ..query_formatting.common import (
 )
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal, GraphQLSchemaFieldType
 from ..schema.schema_info import CommonSchemaInfo
+from ..typedefs import GraphQLQueryArgumentType
 from .test_helpers import compare_gremlin, compare_match, get_schema
 
 
@@ -231,7 +232,7 @@ class QueryFormattingTests(unittest.TestCase):
                     validate_argument_type(arbitrary_argument_name, graphql_type, invalid_value)
 
     def test_non_null_types_pass_validation(self) -> None:
-        type_and_value = [
+        type_and_value: List[Tuple[GraphQLQueryArgumentType, Any]] = [
             (GraphQLString, "abc"),  # sanity check
             (GraphQLNonNull(GraphQLString), "abc"),
             (GraphQLList(GraphQLString), ["a", "b", "c"]),  # sanity check

--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -1,0 +1,17 @@
+# Copyright 2020-present Kensho Technologies, LLC.
+from typing import Union
+
+from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
+
+
+# The compiler's supported GraphQL types for query arguments. The GraphQL type of a query argument
+# is the type of the field that the argument references. Not to be confused with the GraphQLArgument
+# class in the GraphQL core library.
+GraphQLQueryArgumentType = Union[
+    GraphQLScalarType,
+    GraphQLList[GraphQLScalarType],
+    GraphQLList[GraphQLNonNull[GraphQLScalarType]],
+    GraphQLNonNull[GraphQLScalarType],
+    GraphQLNonNull[GraphQLList[GraphQLScalarType]],
+    GraphQLNonNull[GraphQLList[GraphQLNonNull[GraphQLScalarType]]],
+]

--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -7,7 +7,7 @@ from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
 # The compiler's supported GraphQL types for query arguments. The GraphQL type of a query argument
 # is the type of the field that the argument references. Not to be confused with the GraphQLArgument
 # class in the GraphQL core library.
-GraphQLQueryArgumentType = Union[
+QueryArgumentGraphQLType = Union[
     GraphQLScalarType,
     GraphQLList[GraphQLScalarType],
     GraphQLList[GraphQLNonNull[GraphQLScalarType]],


### PR DESCRIPTION
I am adding type hints to `query_formatting/common.py` to reduce the size of this PR.
https://github.com/kensho-technologies/graphql-compiler/pull/804