### PR TITLE
Refactor SQLFoldObject

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -996,9 +996,7 @@ class CompilationState(object):
             fold_subquery_alias,
             onclause=(
                 self._current_alias.c[outer_vertex_primary_key_name]
-                == fold_subquery_alias.c[
-                    outer_vertex_primary_key_name
-                ]
+                == fold_subquery_alias.c[outer_vertex_primary_key_name]
             ),
             isouter=False,
         )

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -278,6 +278,7 @@ SQLFoldTraversalDescriptor = namedtuple(
 )
 
 
+# TODO(bojanserafimov): Rename to FoldSubqueryBuilder and simplify usage and spec.
 class SQLFoldObject(object):
     """Object used to collect info for folds in order to ensure correct code emission."""
 

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -998,7 +998,7 @@ class CompilationState(object):
                 self._current_alias.c[outer_vertex_primary_key_name]
                 == fold_subquery_alias.c[
                     outer_vertex_primary_key_name
-                ]  # only support a single primary key field, no composite keys
+                ]
             ),
             isouter=False,
         )

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -2,7 +2,7 @@
 """Transform a SqlNode tree into an executable SQLAlchemy query."""
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 import six
 import sqlalchemy
@@ -278,17 +278,15 @@ SQLFoldTraversalDescriptor = namedtuple(
 )
 
 
-class FoldSubqueryBuilder(object):
-    """Class producing the SQL subquery that represents a fold scope."""
+class SQLFoldObject(object):
+    """Object used to collect info for folds in order to ensure correct code emission."""
 
-    # TODO(bojanserafimov): update docstring.
-    # A FoldSubqueryBuilder consists of information related to the SELECT clause of the fold
-    # subquery,
+    # A SQLFoldObject consists of information related to the SELECT clause of the fold subquery,
     # the GROUP BY clause, the WHERE clause (if applying filters) and the FROM clause which contains
     # one JOIN per vertex traversed in the fold, including the traversal from the vertex outside
     # the fold to the folded vertex itself.
     #
-    # The life cycle for the FoldSubqueryBuilder is:
+    # The life cycle for the SQLFoldObject is:
     #   1. initializing it with the information for the outer vertex (the one outside the fold)
     #   2. at least one traversal
     #   3. visiting the output vertex to collect the output columns
@@ -341,7 +339,7 @@ class FoldSubqueryBuilder(object):
     # JOIN VertexPrecedingOutput
     # ON ...
     def __init__(self, dialect, outer_vertex_table, primary_key_name):
-        """Create an FoldSubqueryBuilder with table, type, and join information supplied by the IR.
+        """Create an SQLFoldObject with table, type, and join information supplied by the IR.
 
         Args:
             dialect: SQLAlchemy compiler object passed in from the schema, representing
@@ -375,15 +373,14 @@ class FoldSubqueryBuilder(object):
     def __str__(self):
         """Produce string used to customize error messages."""
         if self._outer_vertex_alias is None:
-            return 'FoldSubqueryBuilder("Invalid fold: no vertex preceding fold.")'
+            return 'SQLFoldObject("Invalid fold: no vertex preceding fold.")'
         elif self._output_vertex_alias is None:
             return (
-                'FoldSubqueryBuilder("Vertex outside fold: {}.' 'Output vertex for fold: None.")'
+                'SQLFoldObject("Vertex outside fold: {}.' 'Output vertex for fold: None.")'
             ).format(self._outer_vertex_alias.original)
         else:
-            return (
-                'FoldSubqueryBuilder("Vertex outside fold: {}. Output vertex for fold: {}.")'
-                "".format(self._outer_vertex_alias.original, self._output_vertex_alias.original)
+            return 'SQLFoldObject("Vertex outside fold: {}. Output vertex for fold: {}.")'.format(
+                self._outer_vertex_alias.original, self._output_vertex_alias.original
             )
 
     def _construct_fold_joins(self):
@@ -531,7 +528,7 @@ class FoldSubqueryBuilder(object):
         )
 
     def _get_fold_outputs(self, fold_scope_location, all_folded_fields):
-        """Generate output columns for innermost fold scope and add them to this."""
+        """Generate output columns for innermost fold scope and add them to active SQLFoldObject."""
         # Find outputs for this fold in all_folded_fields and add to self._outputs.
         if fold_scope_location.fold_path in all_folded_fields:
             for fold_output in all_folded_fields[fold_scope_location.fold_path]:
@@ -579,7 +576,7 @@ class FoldSubqueryBuilder(object):
             self._outputs = self._get_fold_outputs(current_fold_scope_location, all_folded_fields)
 
     def add_filter(self, predicate, aliases):
-        """Add a new filter to the FoldSubqueryBuilder."""
+        """Add a new filter to the SQLFoldObject."""
         if self._ended:
             raise AssertionError(
                 "Cannot add a filter after end_fold has been called. Invalid "
@@ -593,8 +590,8 @@ class FoldSubqueryBuilder(object):
         sql_expression = predicate.to_sql(self._dialect, aliases, self._output_vertex_alias)
         self._filters.append(sql_expression)
 
-    def end_fold(self) -> Tuple[Select, FoldScopeLocation]:
-        """Return the fold subquery and the location its outputs come from."""
+    def end_fold(self):
+        """Produce the final subquery and join it onto the rest of the query."""
         if self._ended:
             raise AssertionError(
                 "Cannot call end_fold more than once. "
@@ -616,13 +613,17 @@ class FoldSubqueryBuilder(object):
                 "Folds containing multiple traversals are not implemented in MSSQL."
             )
 
+        # Join together all vertices traversed.
+        subquery_from_clause = self._construct_fold_joins()
+
+        # Produce full subquery.
+        fold_subquery = self._construct_fold_subquery(subquery_from_clause)
+
         # End the fold, preventing any more functions from being called on this fold.
         self._ended = True
 
-        # Produce the subquery.
-        subquery_from_clause = self._construct_fold_joins()
-        fold_subquery = self._construct_fold_subquery(subquery_from_clause)
         return fold_subquery, self._output_vertex_location
+
 
 
 class UniqueAliasGenerator(object):
@@ -672,7 +673,7 @@ class CompilationState(object):
         self._current_alias = None  # a sqlalchemy table Alias at the current location
 
         # Current folded subquery state.
-        self._current_fold = None  # FoldSubqueryBuilder to collect fold info and guide output query
+        self._current_fold = None  # SQLFoldObject to collect fold info and guide output query
         self._fold_vertex_location = None  # location in the IR tree where the fold starts
         self._outside_fold_location = None
 
@@ -962,7 +963,7 @@ class CompilationState(object):
         ]
 
         # 3. Initialize fold object.
-        self._current_fold = FoldSubqueryBuilder(
+        self._current_fold = SQLFoldObject(
             self._sql_schema_info.dialect, outer_alias, outer_vertex_primary_key_name
         )
 


### PR DESCRIPTION
The goal is to remove any reference to the `CompilationState` class in `SQLFoldObject`, rename it to `FoldSubqueryBuilder`, write a more tight specification for it, and write dedicated tests for it.

In this PR I move the code that joins the produced fold subquery to the main query into the `CompilationState` class so that `FoldSubqueryBuilder` would just need to do what it does (make the subquery) and not be concerned with how its results are used.