### PR TITLE
Update emit_sql with typehints, fstrings, NamedTuples

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -740,7 +740,7 @@ class CompilationState(object):
         self._outputs: List[Label] = []  # SQLAlchemy Columns labelled correctly for output.
         self._filters: List[
             BinaryExpression
-        ] = []  # SQLAlchemy Expressions to be used in the where clause.
+        ] = []  # SQLAlchemy Expressions to be used in the WHERE clause.
 
         # Generates aliases for fold subqueries.
         self._alias_generator: UniqueAliasGenerator = UniqueAliasGenerator()

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -528,7 +528,9 @@ class SQLFoldObject(object):
         # Sort to make select order deterministic.
         return sorted(self._outputs, key=lambda column: column.name, reverse=True)
 
-    def visit_vertex(self, join_descriptor, from_table, to_table, current_fold_scope_location, all_folded_fields):
+    def visit_vertex(
+        self, join_descriptor, from_table, to_table, current_fold_scope_location, all_folded_fields
+    ):
         """Add a new traversal descriptor and add outputs, if visiting an output vertex."""
         if self._ended:
             raise AssertionError(
@@ -680,7 +682,7 @@ class CompilationState(object):
         if self._current_fold is not None and isinstance(new_location, FoldScopeLocation):
             alias_key = (
                 self._current_location.base_location.query_path,
-                self._current_location.fold_path
+                self._current_location.fold_path,
             )
         # Regardless of whether self._current_fold is None or not, if the new location is a
         # Location, relocation should occur based on a Location alias key.
@@ -760,9 +762,17 @@ class CompilationState(object):
         edge = self._sql_schema_info.join_descriptors[self._current_classname][vertex_field]
         self._relocate(self._current_location.navigate_to_subpath(vertex_field))
         if self._current_fold is not None:
-            self._current_fold.visit_vertex(edge, previous_alias, self._current_alias, self._current_location, self._all_folded_fields)
+            self._current_fold.visit_vertex(
+                edge,
+                previous_alias,
+                self._current_alias,
+                self._current_location,
+                self._all_folded_fields,
+            )
         else:
-            self._join_to_parent_location(previous_alias, edge.from_column, edge.to_column, optional)
+            self._join_to_parent_location(
+                previous_alias, edge.from_column, edge.to_column, optional
+            )
 
     def _get_current_primary_key_name(self, directive_name: str) -> str:
         """Return the name of the single-column primary key at the current location.
@@ -906,8 +916,13 @@ class CompilationState(object):
 
         # 4. Relocate to inside the fold scope and visit the first vertex.
         self._relocate(fold_scope_location)
-        self._current_fold.visit_vertex(join_descriptor, outer_alias, self._current_alias,
-                                        fold_scope_location, self._all_folded_fields)
+        self._current_fold.visit_vertex(
+            join_descriptor,
+            outer_alias,
+            self._current_alias,
+            fold_scope_location,
+            self._all_folded_fields,
+        )
 
     def unfold(self):
         """Complete the execution of a Fold Block."""
@@ -938,10 +953,7 @@ class CompilationState(object):
         # If the current location is the beginning of a fold, the current alias
         # will eventually be replaced by the resulting fold subquery during Unfold.
         self._aliases[
-            (
-                self._current_location.base_location.query_path,
-                self._current_location.fold_path,
-            )
+            (self._current_location.base_location.query_path, self._current_location.fold_path,)
             if self._current_fold is not None
             else (self._current_location.query_path, None)
         ] = self._current_alias

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1,14 +1,14 @@
 # Copyright 2018-present Kensho Technologies, LLC.
 """Transform a SqlNode tree into an executable SQLAlchemy query."""
-from collections import namedtuple
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterator, List, NamedTuple, Optional, Set, Tuple
 
 import six
 import sqlalchemy
 from sqlalchemy import select
 from sqlalchemy.dialects.mssql.base import MSDialect
 from sqlalchemy.dialects.postgresql.base import PGDialect
+from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import expression
 from sqlalchemy.sql.compiler import _CompileLabel
@@ -16,15 +16,24 @@ from sqlalchemy.sql.elements import Label
 from sqlalchemy.sql.expression import Alias, BinaryExpression
 from sqlalchemy.sql.functions import func
 from sqlalchemy.sql.schema import Column
-from sqlalchemy.sql.selectable import FromClause, Select
+from sqlalchemy.sql.selectable import FromClause, Join, Select
 
 from . import blocks
 from ..global_utils import VertexPath
 from ..schema import COUNT_META_FIELD_NAME
-from ..schema.schema_info import SQLSchemaInfo, SQLAlchemySchemaInfo
+from ..schema.schema_info import DirectJoinDescriptor, SQLAlchemySchemaInfo
+from .compiler_entities import BasicBlock
 from .compiler_frontend import IrAndMetadata
 from .expressions import ContextField, Expression
-from .helpers import BaseLocation, FoldPath, FoldScopeLocation, Location, QueryPath, get_edge_direction_and_name
+from .helpers import (
+    BaseLocation,
+    FoldPath,
+    FoldScopeLocation,
+    Location,
+    QueryPath,
+    get_edge_direction_and_name,
+)
+from .metadata import LocationInfo
 
 
 # Some reserved column names used in emitted SQL queries
@@ -36,7 +45,7 @@ FOLD_OUTPUT_FORMAT_STRING = "fold_output_{}"
 FOLD_SUBQUERY_FORMAT_STRING = "folded_subquery_{}"
 
 
-def _traverse_and_validate_blocks(ir: IrAndMetadata):
+def _traverse_and_validate_blocks(ir: IrAndMetadata) -> Iterator[BasicBlock]:
     """Yield all blocks, while validating consistency."""
     found_query_root = False
     found_global_operations_block = False
@@ -49,29 +58,24 @@ def _traverse_and_validate_blocks(ir: IrAndMetadata):
             found_query_root = True
         else:
             if not found_query_root:
-                raise AssertionError(
-                    "Found block {} before QueryRoot: {}".format(block, ir.ir_blocks)
-                )
+                raise AssertionError(f"Found block {block} before QueryRoot: {ir.ir_blocks}.")
 
         if isinstance(block, blocks.GlobalOperationsStart):
             if found_global_operations_block:
-                raise AssertionError(
-                    "Found duplicate GlobalOperationsStart: {}".format(ir.ir_blocks)
-                )
+                raise AssertionError(f"Found duplicate GlobalOperationsStart: {ir.ir_blocks}.")
             found_global_operations_block = True
         else:
             if found_global_operations_block:
                 if not isinstance(block, globally_allowed_blocks):
                     raise AssertionError(
-                        "Only {} are allowed after GlobalOperationsBlock. "
-                        "Found {} in {}.".format(globally_allowed_blocks, block, ir.ir_blocks)
+                        f"Only {globally_allowed_blocks} are allowed after GlobalOperationsBlock. "
+                        f"Found {block} in {ir.ir_blocks}."
                     )
             else:
                 if isinstance(block, global_only_blocks):
                     raise AssertionError(
-                        "Block {} is only allowed after GlobalOperationsBlock: {}".format(
-                            block, ir.ir_blocks
-                        )
+                        f"Block {block} is only allowed after GlobalOperationsBlock: "
+                        f"{ir.ir_blocks}."
                     )
         yield block
 
@@ -96,7 +100,7 @@ def _find_columns_used_outside_folds(
             if isinstance(child_location, FoldScopeLocation):
                 continue
             edge_direction, edge_name = get_edge_direction_and_name(child_location.query_path[-1])
-            vertex_field_name = "{}_{}".format(edge_direction, edge_name)
+            vertex_field_name = f"{edge_direction}_{edge_name}"
             edge = sql_schema_info.join_descriptors[location_info.type.name][vertex_field_name]
             used_columns.setdefault(location.query_path, set()).add(edge.from_column)
             used_columns.setdefault(child_location.query_path, set()).add(edge.to_column)
@@ -125,7 +129,7 @@ def _find_columns_used_outside_folds(
         if isinstance(location, FoldScopeLocation):
             continue
         for recurse_info in ir.query_metadata_table.get_recurse_infos(location):
-            traversal = "{}_{}".format(recurse_info.edge_direction, recurse_info.edge_name)
+            traversal = f"{recurse_info.edge_direction}_{recurse_info.edge_name}"
             used_columns[location.query_path] = used_columns.get(location.query_path, set()).union(
                 used_columns[location.query_path + (traversal,)]
             )
@@ -206,7 +210,7 @@ def compile_xmlpath(element, compiler, **kw):
     return compiler.visit_label(element, **kw)
 
 
-def _get_xml_path_clause(output_column, predicate_expression):
+def _get_xml_path_clause(output_column: Column, predicate_expression: BinaryExpression):
     """Produce an MSSQL-style XML PATH-based aggregation subquery.
 
     XML PATH clause aggregates the values of the output_column from the output vertex
@@ -240,25 +244,25 @@ def _get_xml_path_clause(output_column, predicate_expression):
     """
     delimiter = expression.literal_column("'|'")
     null = expression.literal_column("'~'")
-    encoded_column = func.REPLACE(  # replace all occurrences of '^' in the original with '^e'
+    encoded_column = func.REPLACE(  # Replace all occurrences of '^' in the original with '^e'.
         output_column, expression.literal_column("'^'"), expression.literal_column("'^e'")
     )
-    encoded_column = func.REPLACE(  # replace all occurrences of '~' in the original with '^n'
+    encoded_column = func.REPLACE(  # Replace all occurrences of '~' in the original with '^n'.
         encoded_column, null, expression.literal_column("'^n'")
     )
-    encoded_column = func.REPLACE(  # replace all occurrences of '|' in the original with '^d'
+    encoded_column = func.REPLACE(  # Replace all occurrences of '|' in the original with '^d'.
         encoded_column, delimiter, expression.literal_column("'^d'")
     )
 
-    # delimit elements in the array using '|'and mark nulls with `~`
-    xml_column = delimiter + func.COALESCE(  # denote null values with '~'
-        encoded_column, null
-    )  # allow unambiguously distinguishing (nullable) array elements using scheme above
+    # Delimit elements in the array using '|'and replace nulls in the original with `~`.
+    xml_column = delimiter + func.COALESCE(encoded_column, null)
 
-    # use constructor: you can't directly construct an XMLPathBinaryExpression from plain text
+    # Use constructor because it is not possible to directly construct an XMLPathBinaryExpression
+    # from plain text
     xml_column = XMLPathBinaryExpression(xml_column.left, xml_column.right, xml_column.operator)
 
-    return func.COALESCE(  # coalesce to represent empty arrays as ''
+    # Coalesce to represent empty arrays as '' and return the XML PATH aggregated data.
+    return func.COALESCE(
         select([xml_column])
         .where(predicate_expression)
         .suffix_with("FOR XML PATH ('')")
@@ -267,23 +271,19 @@ def _get_xml_path_clause(output_column, predicate_expression):
     )
 
 
-# 3-tuple describing the join information for each traversal in a fold.
-#
-# Contains DirectJoinDescriptor naming the columns used in the join predicate,
-# the source/from table, and the destination/to table
-SQLFoldTraversalDescriptor = namedtuple(
-    "SQLFoldJoinInfo",
-    (
-        # DirectJoinDescriptor giving columns used to join from_table/to_table
-        "join_descriptor",
-        # SQLAlchemy table corresponding to corresponding to the outside vertex of the traversal,
-        # appears on the left side of the join.
-        "from_table",
-        # SQLAlchemy table corresponding to corresponding to the inside vertex of the traversal,
-        # appears on the right side of the join.
-        "to_table",
-    ),
-)
+class SQLFoldTraversalDescriptor(NamedTuple):
+    """Describes the join information for traversals inside a fold."""
+
+    # DirectJoinDescriptor giving columns used to join from_table/to_table.
+    join_descriptor: DirectJoinDescriptor
+
+    # SQLAlchemy table corresponding to corresponding to the outside vertex of the traversal,
+    # appears on the left side of the join.
+    from_table: Alias
+
+    # SQLAlchemy table corresponding to corresponding to the inside vertex of the traversal,
+    # appears on the right side of the join.
+    to_table: Alias
 
 
 class SQLFoldObject(object):
@@ -346,12 +346,11 @@ class SQLFoldObject(object):
     #          ...
     # JOIN VertexPrecedingOutput
     # ON ...
-    def __init__(self, dialect, outer_vertex_table, primary_key_name):
+    def __init__(self, dialect: DefaultDialect, outer_vertex_table: Alias, primary_key_name: str):
         """Create an SQLFoldObject with table, type, and join information supplied by the IR.
 
         Args:
-            dialect: SQLAlchemy compiler object passed in from the schema, representing
-                     the dialect to which the query will be compiled.
+            dialect: dialect to which the query will be compiled.
             outer_vertex_table: SQLAlchemy table alias for vertex outside of fold.
             primary_key_name: name of the primary key of the vertex immediately outside the
                               fold. Used to set the group by as well as join the fold subquery
@@ -359,24 +358,26 @@ class SQLFoldObject(object):
         """
         # Table and FoldScopeLocation containing output columns are initialized to None because
         # the output table is unknown until one is found during visit_vertex.
-        self._output_vertex_alias = None
-        self._output_vertex_location = None
+        self._output_vertex_alias: Optional[Alias] = None
+        self._output_vertex_location: Optional[FoldScopeLocation] = None
 
         # Table for vertex immediately outside fold.
-        self._outer_vertex_alias = outer_vertex_table
-        self._outer_vertex_primary_key = primary_key_name
+        self._outer_vertex_alias: Alias = outer_vertex_table
+        self._outer_vertex_primary_key: str = primary_key_name
 
-        # List of SQLFoldTraversalDescriptor namedtuples describing each traversal in the fold
+        # List of SQLFoldTraversalDescriptors describing each traversal in the fold
         # starting with the join from the vertex immediately outside the fold to the folded vertex.
-        self._traversal_descriptors = []
-        self._outputs = []  # Output columns for folded subquery.
-        self._filters = []  # SQLAlchemy Expressions to be used in the where clause.
+        self._traversal_descriptors: List[SQLFoldTraversalDescriptor] = []
+        self._outputs: List[Label] = []  # Output columns for folded subquery.
+        self._filters: List[
+            BinaryExpression
+        ] = []  # SQLAlchemy Expressions to be used in the where clause.
 
         # SQLAlchemy compiler object determining which dialect to target.
-        self._dialect = dialect
+        self._dialect: DefaultDialect = dialect
 
         # Whether this fold has been ended by calling the end_fold function.
-        self._ended = False
+        self._ended: bool = False
 
     def __str__(self):
         """Produce string used to customize error messages."""
@@ -384,14 +385,16 @@ class SQLFoldObject(object):
             return 'SQLFoldObject("Invalid fold: no vertex preceding fold.")'
         elif self._output_vertex_alias is None:
             return (
-                'SQLFoldObject("Vertex outside fold: {}.' 'Output vertex for fold: None.")'
-            ).format(self._outer_vertex_alias.original)
+                f'SQLFoldObject("Vertex outside fold: {self._outer_vertex_alias.original}. '
+                'Output vertex for fold: None.")'
+            )
         else:
-            return 'SQLFoldObject("Vertex outside fold: {}. Output vertex for fold: {}.")'.format(
-                self._outer_vertex_alias.original, self._output_vertex_alias.original
+            return (
+                f'SQLFoldObject("Vertex outside fold: {self._outer_vertex_alias.original}. '
+                f'Output vertex for fold: {self._output_vertex_alias.original}.")'
             )
 
-    def _construct_fold_joins(self):
+    def _construct_fold_joins(self) -> Join:
         """Use the traversal descriptors to create the join clause for the tables in the fold."""
         # Start the join clause with the from_table of the first traversal descriptor,
         # which is the vertex immediately preceding the fold.
@@ -406,7 +409,7 @@ class SQLFoldObject(object):
         else:
             raise NotImplementedError(
                 "Fold only supported for MSSQL and "
-                "PostgreSQL, dialect was set to {}".format(self._dialect.name)
+                f"PostgreSQL, dialect was set to {self._dialect.name}."
             )
 
         traversal_descriptors = self._traversal_descriptors[:terminating_index]
@@ -430,7 +433,7 @@ class SQLFoldObject(object):
 
         return join_clause
 
-    def _construct_fold_subquery(self, subquery_from_clause):
+    def _construct_fold_subquery(self, subquery_from_clause: Join) -> Select:
         """Combine all parts of the fold object to produce the complete fold subquery."""
         select_statement = (
             sqlalchemy.select(self._outputs)
@@ -448,18 +451,28 @@ class SQLFoldObject(object):
         else:
             raise NotImplementedError(
                 "Fold only supported for MSSQL and "
-                "PostgreSQL, dialect was set to {}".format(self._dialect.name)
+                "PostgreSQL, dialect was set to {self._dialect.name}."
             )
 
-    def _get_array_agg_column(self, intermediate_fold_output_name, fold_output_field):
+    def _get_array_agg_column(
+        self, intermediate_fold_output_name: str, fold_output_field: str
+    ) -> Label:
         """Select an array_agg of the fold output field, labeled as requested."""
+        if self._output_vertex_alias is None:
+            raise AssertionError(
+                "Attempted to perform array aggregation while the "
+                "_output_vertex_alias was set to None."
+            )
         return sqlalchemy.func.array_agg(self._output_vertex_alias.c[fold_output_field]).label(
             intermediate_fold_output_name
         )
 
     def _get_mssql_xml_path_column(
-        self, intermediate_fold_output_name, fold_output_field, last_traversal
-    ):
+        self,
+        intermediate_fold_output_name: str,
+        fold_output_field: str,
+        last_traversal: SQLFoldTraversalDescriptor,
+    ) -> Label:
         """Select the MSSQL XML PATH aggregation of the fold output field, labeled as requested.
 
         The MSSQL equivalent of array aggregation is performed using an XML PATH subquery that has
@@ -485,8 +498,7 @@ class SQLFoldObject(object):
         direction of the edge connecting VertexPrecedingOutput to OutputVertex.
 
         Args:
-            intermediate_fold_output_name: string label to give to the resulting XML PATH
-                                            subquery built
+            intermediate_fold_output_name: string label to give to the resulting XML PATH subquery.
             fold_output_field: string name of the column requested from the output vertex.
             last_traversal: SQLFoldTraversalDescriptor describing tables/WHERE predicate
                             used in subquery.
@@ -494,7 +506,12 @@ class SQLFoldObject(object):
         Returns:
             Selectable for XML PATH aggregation subquery
         """
-        # use join info tuple for most recent traversal to set WHERE clause for XML PATH subquery
+        if self._output_vertex_alias is None:
+            raise AssertionError(
+                "Attempted to aggregate with XML PATH before an _output_vertex_alias had been "
+                "found."
+            )
+        # Use join info tuple for most recent traversal to set WHERE clause for XML PATH subquery.
         edge, from_alias, to_alias = last_traversal
 
         return _get_xml_path_clause(
@@ -502,19 +519,18 @@ class SQLFoldObject(object):
             (from_alias.c[edge.from_column] == to_alias.c[edge.to_column]),
         ).label(intermediate_fold_output_name)
 
-    def _get_fold_output_column_clause(self, fold_output_field):
+    def _get_fold_output_column_clause(self, fold_output_field: str) -> Label:
         """Get the SQLAlchemy column expression corresponding to the fold output field."""
         if fold_output_field == COUNT_META_FIELD_NAME:
             return sqlalchemy.func.coalesce(
                 sqlalchemy.func.count(), sqlalchemy.literal_column("0")
             ).label(FOLD_OUTPUT_FORMAT_STRING.format(COUNT_META_FIELD_NAME))
         else:
-            # force column to have explicit label as opposed to anon_label
+            # Force column to have explicit label as opposed to anon_label.
             intermediate_fold_output_name = FOLD_OUTPUT_FORMAT_STRING.format(fold_output_field)
-            # add array aggregated output column to self._outputs
-            # add aggregated output column to self._outputs
+            # Add aggregated output column to self._outputs.
             if isinstance(self._dialect, MSDialect):
-                # MSSQL uses XML PATH aggregation
+                # MSSQL uses XML PATH aggregation.
                 return self._get_mssql_xml_path_column(
                     intermediate_fold_output_name,
                     fold_output_field,
@@ -522,21 +538,24 @@ class SQLFoldObject(object):
                     self._traversal_descriptors[-1],
                 )
             elif isinstance(self._dialect, PGDialect):
-                # PostgreSQL uses ARRAY_AGG
+                # PostgreSQL uses ARRAY_AGG.
                 return self._get_array_agg_column(intermediate_fold_output_name, fold_output_field)
             else:
                 raise NotImplementedError(
                     "Fold only supported for MSSQL and PostgreSQL, "
-                    "dialect set to {}".format(self._dialect.name)
+                    f"dialect set to {self._dialect.name}."
                 )
 
-        # We should have either triggered a not implemented error, or returned earlier
         raise AssertionError(
             "Reached end of function without returning a value, this code should be unreachable."
         )
 
-    def _get_fold_outputs(self, fold_scope_location: FoldScopeLocation, all_folded_fields: Dict[FoldPath, Set[FoldScopeLocation]]):
-        """Generate output columns for innermost fold scope and add them to active SQLFoldObject."""
+    def _get_fold_outputs(
+        self,
+        fold_scope_location: FoldScopeLocation,
+        all_folded_fields: Dict[FoldPath, Set[FoldScopeLocation]],
+    ) -> List[Label]:
+        """Generate output columns for innermost fold scope and add them to _outputs."""
         # Find outputs for this fold in all_folded_fields and add to self._outputs.
         if fold_scope_location.fold_path in all_folded_fields:
             for fold_output in all_folded_fields[fold_scope_location.fold_path]:
@@ -545,6 +564,11 @@ class SQLFoldObject(object):
                     fold_scope_location.base_location,
                     fold_scope_location.fold_path,
                 ):
+                    if fold_output.field is None:
+                        raise AssertionError(
+                            f"Received invalid fold_output {fold_output}. FoldScopeLocations in "
+                            f"all_folded_fields must have their fields set."
+                        )
                     # Get SQLAlchemy column for fold_output.
                     column_clause = self._get_fold_output_column_clause(fold_output.field)
                     # Append resulting column to outputs.
@@ -557,13 +581,18 @@ class SQLFoldObject(object):
         return sorted(self._outputs, key=lambda column: column.name, reverse=True)
 
     def visit_vertex(
-        self, join_descriptor, from_table, to_table, current_fold_scope_location, all_folded_fields
-    ):
-        """Add a new traversal descriptor and add outputs, if visiting an output vertex."""
+        self,
+        join_descriptor: DirectJoinDescriptor,
+        from_table: Alias,
+        to_table: Alias,
+        current_fold_scope_location: FoldScopeLocation,
+        all_folded_fields: Dict[FoldPath, Set[FoldScopeLocation]],
+    ) -> None:
+        """Add a new SQLFoldTraversalDescriptor and add outputs, if visiting an output vertex."""
         if self._ended:
             raise AssertionError(
                 "Cannot visit traversed vertices after end_fold has been called."
-                "Invalid state encountered during fold {}".format(self)
+                f"Invalid state encountered during fold {self}."
             )
 
         self._traversal_descriptors.append(
@@ -577,18 +606,20 @@ class SQLFoldObject(object):
             if self._output_vertex_alias is not None:
                 raise AssertionError(
                     "Cannot visit multiple output vertices in one fold. "
-                    "Invalid state encountered during fold {}".format(self)
+                    f"Invalid state encountered during fold {self}."
                 )
             self._output_vertex_alias = to_table
             self._output_vertex_location = current_fold_scope_location
             self._outputs = self._get_fold_outputs(current_fold_scope_location, all_folded_fields)
 
-    def add_filter(self, predicate, aliases):
+    def add_filter(
+        self, predicate: Expression, aliases: Dict[Tuple[QueryPath, Optional[FoldPath]], Alias]
+    ) -> None:
         """Add a new filter to the SQLFoldObject."""
         if self._ended:
             raise AssertionError(
                 "Cannot add a filter after end_fold has been called. Invalid "
-                "state encountered during fold {}".format(self)
+                f"state encountered during fold {self}."
             )
         if isinstance(self._dialect, MSDialect):
             raise NotImplementedError(
@@ -598,21 +629,25 @@ class SQLFoldObject(object):
         sql_expression = predicate.to_sql(self._dialect, aliases, self._output_vertex_alias)
         self._filters.append(sql_expression)
 
-    def end_fold(self, alias_generator: "UniqueAliasGenerator", from_clause, outer_from_table):
+    def end_fold(
+        self,
+        alias_generator: "UniqueAliasGenerator",
+        from_clause: FromClause,
+        outer_from_table: Alias,
+    ) -> Tuple[Select, Join, FoldScopeLocation]:
         """Produce the final subquery and join it onto the rest of the query."""
         if self._ended:
             raise AssertionError(
                 "Cannot call end_fold more than once. "
-                "Invalid state encountered during fold {}".format(self)
+                f"Invalid state encountered during fold {self}."
             )
-        if self._output_vertex_alias is None:
+        if self._output_vertex_alias is None or self._output_vertex_location is None:
             raise AssertionError(
-                "No output vertex visited. Invalid state encountered during fold {}".format(self)
+                f"No output vertex visited. Invalid state encountered during fold {self}."
             )
         if len(self._traversal_descriptors) == 0:
             raise AssertionError(
-                "No traversed vertices visited. "
-                "Invalid state encountered during fold {}".format(self)
+                "No traversed vertices visited. " f"Invalid state encountered during fold {self}."
             )
 
         # For now, folds with more than one traversal (i.e. join) are not implemented in MSSQL.
@@ -655,7 +690,7 @@ class UniqueAliasGenerator(object):
         """Create unique subquery aliases by tracking counter."""
         self._fold_count = 1
 
-    def generate_subquery(self):
+    def generate_subquery(self) -> str:
         """Generate a new subquery alias and increment the counter."""
         alias = FOLD_SUBQUERY_FORMAT_STRING.format(self._fold_count)
         self._fold_count += 1
@@ -686,37 +721,52 @@ class CompilationState(object):
         # Immutable metadata
         self._sql_schema_info: SQLAlchemySchemaInfo = sql_schema_info
         self._ir: IrAndMetadata = ir
-        self._used_columns: Dict[VertexPath, Set[str]] = _find_columns_used_outside_folds(sql_schema_info, ir)
+        self._used_columns: Dict[VertexPath, Set[str]] = _find_columns_used_outside_folds(
+            sql_schema_info, ir
+        )
         # mapping fold paths to FoldScopeLocations with field information
         self._all_folded_fields: Dict[FoldPath, Set[FoldScopeLocation]] = _find_folded_fields(ir)
 
         # Current query location state. Only mutable by calling _relocate.
-        self._current_location: Optional[Union[Location, FoldScopeLocation]] = None  # the current location in the query. None means global.
-        self._current_alias: Optional[Alias] = None  # a sqlalchemy table Alias at the current location
+        self._current_location: Optional[
+            BaseLocation
+        ] = None  # The current location in the query. None means global.
+        self._current_alias: Optional[
+            Alias
+        ] = None  # SQLAlchemy table Alias at the current location.
 
         # Current folded subquery state.
-        self._current_fold: Optional[SQLFoldObject] = None  # SQLFoldObject to collect fold info and guide output query
-        self._fold_vertex_location: Optional[Location] = None  # location in the IR tree where the fold starts
-        self._outside_fold_location: Optional[Location] = None
+        self._current_fold: Optional[
+            SQLFoldObject
+        ] = None  # SQLFoldObject to collect fold info and create folded subqueries.
 
         # Dict mapping (some_location.query_path, fold_scope_location.fold_path) tuples to
-        # corresponding table _Aliases. some_location is either self._current_location
-        # or the base location of an open FoldScopeLocation.
+        # corresponding table Aliases. some_location is either self._current_location
+        # or the base location of an open FoldScopeLocation. For Locations, the second argument of
+        # the tuple will be None.
         # Note: for tables with an _x_count column, that column will always
         # be named "fold_output__x_count".
         self._aliases: Dict[Tuple[QueryPath, Optional[FoldPath]], Alias] = {}
+
+        # Move to the beginning location of the query.
         self._relocate(ir.query_metadata_table.root_location)
-        self._came_from: Dict[Alias, Column] = {}  # mapping aliases to the column used to join into them.
+
+        # Mapping aliases to the column used to join into them.
+        self._came_from: Dict[Alias, Column] = {}
+
         self._recurse_needs_cte: bool = False
 
         # The query being constructed as the IR is processed
-        self._from_clause: FromClause = self._current_alias  # the main sqlalchemy Selectable
-        self._outputs: List[Label] = []  # sqlalchemy Columns labelled correctly for output
-        self._filters: List[BinaryExpression] = []  # sqlalchemy Expressions to be used in the where clause
+        self._from_clause: FromClause = self._current_alias  # The main SQLAlchemy Selectable.
+        self._outputs: List[Label] = []  # SQLAlchemy Columns labelled correctly for output.
+        self._filters: List[
+            BinaryExpression
+        ] = []  # SQLAlchemy Expressions to be used in the where clause.
 
-        self._alias_generator: UniqueAliasGenerator = UniqueAliasGenerator()  # generates aliases for the fold subqueries
+        # Generates aliases for fold subqueries.
+        self._alias_generator: UniqueAliasGenerator = UniqueAliasGenerator()
 
-    def _relocate(self, new_location: Union[Location, FoldScopeLocation]):
+    def _relocate(self, new_location: BaseLocation):
         """Move to a different location in the query, updating the _current_alias."""
         self._current_location = new_location
         # Create appropriate alias key based on whether or not relocation is taking place in a fold
@@ -748,7 +798,10 @@ class CompilationState(object):
                 self._current_classname
             ].alias()
 
-    def _join_to_parent_location(self, parent_alias: Alias, from_column: str, to_column: str, optional: bool):
+    def _join_to_parent_location(
+        self, parent_alias: Alias, from_column: str, to_column: str, optional: bool
+    ):
+        """Join the current location to the parent location using the column names specified."""
         if self._current_alias is None:
             raise AssertionError("Cannot join to parent location when _current_alias is None.")
 
@@ -776,7 +829,7 @@ class CompilationState(object):
                 )
             )
 
-        # Join to where we came from
+        # Join to where we came from.
         self._from_clause = self._from_clause.join(
             self._current_alias,
             onclause=(parent_alias.c[from_column] == self._current_alias.c[to_column]),
@@ -784,21 +837,22 @@ class CompilationState(object):
         )
 
     @property
-    def _current_location_info(self):
+    def _current_location_info(self) -> LocationInfo:
         """Get the LocationInfo of the current location in the query."""
         return self._ir.query_metadata_table.get_location_info(self._current_location)
 
     @property
-    def _current_classname(self):
+    def _current_classname(self) -> str:
         """Get the string class name of the current location in the query."""
         return self._current_location_info.type.name
 
-    def _is_in_optional_scope(self):
+    def _is_in_optional_scope(self) -> bool:
+        """Determine whether the _current_location is within an optional scope."""
         if self._current_location is None:
             return False
         return self._current_location_info.optional_scopes_depth > 0
 
-    def backtrack(self, previous_location):
+    def backtrack(self, previous_location: BaseLocation) -> None:
         """Execute a Backtrack Block."""
         self._relocate(previous_location)
 
@@ -815,6 +869,11 @@ class CompilationState(object):
         edge = self._sql_schema_info.join_descriptors[self._current_classname][vertex_field]
         self._relocate(self._current_location.navigate_to_subpath(vertex_field))
         if self._current_fold is not None:
+            if not isinstance(self._current_location, FoldScopeLocation):
+                raise AssertionError(
+                    "Attempting to traverse inside a fold while the _current_location was not a "
+                    f"FoldScopeLocation. _current_location was set to {self._current_location}."
+                )
             self._current_fold.visit_vertex(
                 edge,
                 previous_alias,
@@ -888,7 +947,7 @@ class CompilationState(object):
                 f"{self._current_alias.primary_key}. The SQL backend does not support "
                 f"{directive_name} on tables with composite primary keys."
             )
-        return self._current_alias.primary_key[0].name
+        return str(self._current_alias.primary_key[0].name)
 
     def recurse(self, vertex_field: str, depth: int) -> None:
         """Execute a Recurse Block."""
@@ -898,9 +957,9 @@ class CompilationState(object):
             raise AssertionError("Cannot recurse when _current_alias is None.")
         if self._current_location is None:
             raise AssertionError("Cannot recurse when _current_location is None.")
-        if isinstance(self._current_location, FoldScopeLocation):
+        if not isinstance(self._current_location, Location):
             raise AssertionError(
-                f"Cannot recurse when _current_lcoation is a FoldScopeLocation. _current_location "
+                f"Cannot recurse when _current_location is not a Location. _current_location "
                 f"was set to {self._current_location}."
             )
 
@@ -916,9 +975,7 @@ class CompilationState(object):
 
         # Sanitize literal columns to be used in the query
         if not isinstance(depth, int):
-            raise AssertionError(
-                "Depth must be a number. Received {} {}".format(type(depth), depth)
-            )
+            raise AssertionError(f"Depth must be a number. Received {type(depth)} {depth}.")
         literal_depth = sqlalchemy.literal_column(str(depth))
         literal_0 = sqlalchemy.literal_column("0")
         literal_1 = sqlalchemy.literal_column("1")
@@ -953,7 +1010,7 @@ class CompilationState(object):
         # be a cte that contains all that information.
         self._from_clause = self._current_alias
 
-    def start_global_operations(self):
+    def start_global_operations(self) -> None:
         """Execute a GlobalOperationsStart block."""
         if self._current_location is None:
             raise AssertionError("CompilationState is already in global scope.")
@@ -985,26 +1042,24 @@ class CompilationState(object):
                 )
             self._filters.append(sql_expression)
 
-    def fold(self, fold_scope_location):
+    def fold(self, fold_scope_location: FoldScopeLocation) -> None:
         """Begin execution of a Fold Block by initializing and visiting the first vertex."""
         if self._current_fold is not None:
             raise AssertionError(
-                "Fold block {} entered while inside another "
-                "fold block at current location {}.".format(
-                    fold_scope_location, self._current_location_info
-                )
+                f"Fold block {fold_scope_location} entered while inside another "
+                f"fold block at current location {self._current_location_info}."
             )
+        if self._current_alias is None:
+            raise AssertionError("Attempted to fold while _current_alias was set to None.")
 
         # 1. Get fold metadata.
         # Location of vertex that is folded on.
-        self._fold_vertex_location = fold_scope_location
-        self._outside_fold_location = self._current_location
         outer_alias = self._current_alias.alias()
         outer_vertex_primary_key_name = self._get_current_primary_key_name("@fold")
 
         # 2. Collect edge information to join the fold subquery to the main selectable.
         edge_direction, edge_name = fold_scope_location.fold_path[0]
-        full_edge_name = "{}_{}".format(edge_direction, edge_name)
+        full_edge_name = f"{edge_direction}_{edge_name}"
         # only works if fold scope location is the immediate child of self._current_classname
         join_descriptor = self._sql_schema_info.join_descriptors[self._current_classname][
             full_edge_name
@@ -1025,10 +1080,18 @@ class CompilationState(object):
             self._all_folded_fields,
         )
 
-    def unfold(self):
+    def unfold(self) -> None:
         """Complete the execution of a Fold Block."""
+        if self._current_fold is None:
+            raise AssertionError("Attempted to unfold when _current_fold was None.")
+
         # 1. Relocate to outside of the fold.
-        self._relocate(self._outside_fold_location)
+        if not isinstance(self._current_location, FoldScopeLocation):
+            raise AssertionError(
+                "Attempted to unfold while the _current_location was not a FoldScopeLocation. "
+                f"_current_location was {self._current_location}."
+            )
+        self._relocate(self._current_location.base_location)
 
         # 2. End the fold, collecting the folded subquery, the new from clause for the main
         # selectable, and the location of the folded outputs.
@@ -1046,20 +1109,27 @@ class CompilationState(object):
 
         # 4. Clear the fold from the compilation state.
         self._current_fold = None
-        self._fold_vertex_location = None
-        self._outside_fold_location = None
 
-    def mark_location(self):
+    def mark_location(self) -> None:
         """Execute a MarkLocation Block."""
+        alias_key: Tuple[QueryPath, Optional[FoldPath]]
+        if isinstance(self._current_location, FoldScopeLocation):
+            alias_key = (
+                self._current_location.base_location.query_path,
+                self._current_location.fold_path,
+            )
+        elif isinstance(self._current_location, Location):
+            alias_key = (self._current_location.query_path, None)
+        else:
+            raise AssertionError(
+                f"Attempted to mark location at a _current_location that was not a Location or a "
+                f"FoldScopeLocation. _current_location was set to {self._current_location}."
+            )
         # If the current location is the beginning of a fold, the current alias
         # will eventually be replaced by the resulting fold subquery during Unfold.
-        self._aliases[
-            (self._current_location.base_location.query_path, self._current_location.fold_path,)
-            if self._current_fold is not None
-            else (self._current_location.query_path, None)
-        ] = self._current_alias
+        self._aliases[alias_key] = self._current_alias
 
-    def construct_result(self, output_name, field):
+    def construct_result(self, output_name: str, field: Expression) -> None:
         """Execute a ConstructResult Block."""
         self._outputs.append(
             field.to_sql(self._sql_schema_info.dialect, self._aliases, self._current_alias).label(
@@ -1068,7 +1138,7 @@ class CompilationState(object):
         )
 
     def get_query(self, extra_outputs: Optional[List[Label]] = None) -> Select:
-        """After all IR Blocks are processed, return the resulting sqlalchemy query."""
+        """After all IR Blocks are processed, return the resulting SQLAlchemy query."""
         if not extra_outputs:
             extra_outputs = []
         return (
@@ -1078,8 +1148,8 @@ class CompilationState(object):
         )
 
 
-def emit_code_from_ir(sql_schema_info: SQLAlchemySchemaInfo, ir: IrAndMetadata):
-    """Return a SQLAlchemy Query from a passed SqlQueryTree.
+def emit_code_from_ir(sql_schema_info: SQLAlchemySchemaInfo, ir: IrAndMetadata) -> Select:
+    """Return a SQLAlchemy Query for the query described by the internal representation.
 
     Args:
         sql_schema_info: SQLAlchemySchemaInfo containing all relevant schema information
@@ -1097,9 +1167,9 @@ def emit_code_from_ir(sql_schema_info: SQLAlchemySchemaInfo, ir: IrAndMetadata):
         elif isinstance(block, blocks.Backtrack):
             state.backtrack(block.location)
         elif isinstance(block, blocks.Traverse):
-            state.traverse("{}_{}".format(block.direction, block.edge_name), block.optional)
+            state.traverse(f"{block.direction}_{block.edge_name}", block.optional)
         elif isinstance(block, blocks.Recurse):
-            state.recurse("{}_{}".format(block.direction, block.edge_name), block.depth)
+            state.recurse(f"{block.direction}_{block.edge_name}", block.depth)
         elif isinstance(block, blocks.EndOptional):
             pass
         elif isinstance(block, blocks.Fold):
@@ -1114,6 +1184,6 @@ def emit_code_from_ir(sql_schema_info: SQLAlchemySchemaInfo, ir: IrAndMetadata):
             for output_name, field in sorted(six.iteritems(block.fields)):
                 state.construct_result(output_name, field)
         else:
-            raise NotImplementedError("Unsupported block {}.".format(block))
+            raise NotImplementedError(f"Unsupported block {block}.")
 
     return state.get_query()

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -560,7 +560,9 @@ class SQLFoldObject(object):
                 "state encountered during fold {}".format(self)
             )
         if isinstance(self._dialect, MSDialect):
-            raise NotImplementedError("Filtering on fields is not implemented for MSSQL yet.")
+            raise NotImplementedError(
+                "Filtering on fields inside a fold is not implemented for MSSQL yet."
+            )
         # Filters are applied to output vertices, thus current_alias=self.output_vertex_alias.
         sql_expression = predicate.to_sql(self._dialect, aliases, self._output_vertex_alias)
         self._filters.append(sql_expression)

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -45,6 +45,9 @@ FilterOperationInfo = namedtuple(
 
 T = TypeVar("T")
 
+QueryPath = Tuple[str, ...]
+FoldPath = Tuple[Tuple[str, str], ...]
+
 
 def get_only_element_from_collection(one_element_collection: Collection[T]) -> T:
     """Assert that the collection has exactly one element, then return that element."""
@@ -382,7 +385,7 @@ class BaseLocation(object):
 class Location(BaseLocation):
     """A location in the GraphQL query, anywhere except within a @fold scope."""
 
-    query_path: Tuple[str, ...]
+    query_path: QueryPath
     visit_counter: int
 
     def __init__(
@@ -545,7 +548,7 @@ class FoldScopeLocation(BaseLocation):
     """A location within a @fold scope."""
 
     base_location: Location
-    fold_path: Tuple[Tuple[str, str], ...]
+    fold_path: FoldPath
 
     def __init__(
         self,

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -83,8 +83,6 @@ def check_test_data(
         string_result = print_sqlalchemy_query_string(
             result.query, test_case.mssql_schema_info.dialect
         )
-        print("\n\n========MSSQL RESULT========")
-        print(string_result)
         compare_sql(test_case, expected_mssql, string_result)
         test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
         compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
@@ -100,8 +98,6 @@ def check_test_data(
         string_result = print_sqlalchemy_query_string(
             result.query, test_case.postgresql_schema_info.dialect
         )
-        print("\n\n========POSTGRESQL RESULT========")
-        print(string_result)
         compare_sql(test_case, expected_postgresql, string_result)
         test_case.assertEqual(test_data.expected_output_metadata, result.output_metadata)
         compare_input_metadata(test_case, test_data.expected_input_metadata, result.input_metadata)
@@ -5867,7 +5863,7 @@ class CompilerTests(unittest.TestCase):
             JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
-                    array_agg("Animal_3".name) AS fold_output_name 
+                    array_agg("Animal_3".name) AS fold_output_name
                 FROM schema_1."Animal" AS "Animal_2"
                 JOIN schema_1."Animal" AS "Animal_4"
                 ON "Animal_2".parent = "Animal_4".uuid
@@ -5877,26 +5873,6 @@ class CompilerTests(unittest.TestCase):
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
         """
-        """
-            SELECT
-                "Animal_1".name AS animal_name, 
-                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) 
-                    AS sibling_and_self_names_list 
-            FROM 
-                schema_1."Animal" AS "Animal_1" 
-            JOIN (
-                SELECT 
-                    "Animal_1".uuid AS uuid, 
-                    array_agg("Animal_2".name) AS fold_output_name 
-                FROM schema_1."Animal" AS "Animal_1" 
-                JOIN schema_1."Animal" AS "Animal_3" 
-                ON "Animal_1".parent = "Animal_3".uuid 
-                JOIN schema_1."Animal" AS "Animal_2" 
-                ON "Animal_4".uuid = "Animal_2".parent 
-                GROUP BY "Animal_1".uuid
-            ) AS folded_subquery_1 
-            ON "Animal_1".uuid = folded_subquery_1.uuid
-"""
 
         check_test_data(
             self,

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -5833,7 +5833,7 @@ class CompilerTests(unittest.TestCase):
                     ))
             ])}
         """
-        # TODO: implement multiple traversals in a separate PR
+        # TODO: implement multiple traversals for MSSQL in a separate PR
         expected_mssql = NotImplementedError
         expected_cypher = """
             MATCH (Animal___1:Animal)

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -5787,55 +5787,7 @@ class CompilerTests(unittest.TestCase):
             ])}
         """
         # TODO: implement multiple traversals in a separate PR
-        expected_mssql = SKIP_TEST
-        #
-        #     SELECT
-        #         [Animal_1].name AS animal_name,
-        #         folded_subquery_1.fold_output_name AS sibling_and_self_species_list
-        #     FROM db_1.schema_1.[Animal] AS [Animal_1]
-        #     JOIN (
-        #         SELECT
-        #             [Animal_2].uuid AS uuid,
-        #             coalesce(
-        #                 (SELECT '|' + coalesce(
-        #                     REPLACE(
-        #                         REPLACE(
-        #                             REPLACE(
-        #                                 [Species_1].name, '^', '^e'
-        #                             ), '~', '^n'),
-        #                         '|', '^d'),
-        #                     '~')
-        #                 FROM db_1.schema_1.[Species] AS [Species_1]
-        #                 WHERE [Animal_3].species = [Species_1].uuid FOR XML PATH ('')
-        #                 ),
-        #             '') AS fold_output_name
-        #         FROM db_1.schema_1.[Animal] AS [Animal_2]
-        #         JOIN db_1.schema_1.[Animal] AS [Animal_4]
-        #         ON [Animal_2].parent = [Animal_4].uuid
-        #         JOIN db_1.schema_1.[Animal] AS [Animal_3]
-        #         ON [Animal_5].uuid = [Animal_3].parent
-        #     ) AS folded_subquery_1
-        #     ON [Animal_1].uuid = folded_subquery_1.uuid
-        # expected_sql = '''
-        #     SELECT
-        #         [Animal_1].name as animal_name,
-        #         coalesce(folded_subquery_1.fold_output_1, ARRAY[]::VARCHAR[])
-        #             AS sibling_and_self_names_list
-        #     FROM
-        #         db_1.schema_1.[Animal] AS [Animal_1]
-        #     LEFT JOIN (
-        #         SELECT
-        #             [Animal_2].uuid,
-        #             array_agg([Animal_4].name) as sibling_and_self_names_list
-        #         FROM db_1.schema_1.[Animal] AS [Animal_2]
-        #         JOIN db_1.schema_1.[Animal] AS [Animal_3]
-        #         ON [Animal_2].parent = [Animal_3].uuid
-        #         JOIN db_1.schema_1.[Animal] AS [Animal_4]
-        #         ON [Animal_3].uuid = [Animal_4].parent
-        #         GROUP BY [Animal_2].uuid
-        #     ) AS folded_subquery_1
-        #     ON [Animal_1].uuid = folded_subquery_1.uuid
-        # '''
+        expected_mssql = NotImplementedError
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -5926,7 +5878,7 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         """
-        expected_sql = NotImplementedError
+        expected_mssql = NotImplementedError
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -5977,7 +5929,7 @@ class CompilerTests(unittest.TestCase):
             test_data,
             expected_match,
             expected_gremlin,
-            expected_sql,
+            expected_mssql,
             expected_cypher,
             expected_postgresql,
         )


### PR DESCRIPTION
This PR:
- adds typehints (and more error checking to make mypy happy)
- removes most instances of string `format` and replaces with fstrings
- updates a `namedtuple` to a `NamedTuple`
- updates some punctuation and grammar of comments