### PR TITLE
Improve the documentation of validate_arguments

### DIFF
--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -279,7 +279,7 @@ def validate_arguments(
     Args:
         arguments: mapping of argument names to arguments values.
         expected_types: mapping of argument names to the expected GraphQL types. All GraphQLNonNull
-                         type wrappers are stripped.
+                        type wrappers are stripped.
     """
     ensure_arguments_are_provided(expected_types, arguments)
     for name in expected_types:

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -270,7 +270,17 @@ def ensure_arguments_are_provided(
 def validate_arguments(
     expected_types: Mapping[str, GraphQLType], arguments: Mapping[str, Any]
 ) -> None:
-    """Ensure that all arguments are provided and that they are of the expected type."""
+    """Ensure that all arguments are provided and that they are of the expected type.
+
+    Backends are the database languages we have the ability to compile to, like OrientDB MATCH,
+    Gremlin, or SQLAlchemy. This function should be stricter than the validation done by any
+    specific backend. That way code that passes validation can be compiled to any backend.
+
+    Args:
+        arguments: mapping of argument names to arguments values.
+        expected_types:  mapping of argument names to the expected GraphQL types. All GraphQLNonNull
+                         type wrappers are stripped.
+    """
     ensure_arguments_are_provided(expected_types, arguments)
     for name in expected_types:
         validate_argument_type(name, expected_types[name], arguments[name])

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -278,7 +278,7 @@ def validate_arguments(
 
     Args:
         arguments: mapping of argument names to arguments values.
-        expected_types:  mapping of argument names to the expected GraphQL types. All GraphQLNonNull
+        expected_types: mapping of argument names to the expected GraphQL types. All GraphQLNonNull
                          type wrappers are stripped.
     """
     ensure_arguments_are_provided(expected_types, arguments)


### PR DESCRIPTION
This PR has a purpose that is very similar to the purpose of: https://github.com/kensho-technologies/graphql-compiler/pull/811  

Essentially, this is a public API function so it should really have better documentation. I mainly copied over some of the existing documentation from `validate_argument_type`. 