### PR TITLE
Improve custom deserializations comments and remove unneeded code

### DIFF
--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -88,7 +88,6 @@ def _deserialize_anonymous_json_argument(expected_type: GraphQLScalarType, value
         )
 
     name_to_custom_type = {graphql_type.name: graphql_type for graphql_type in CUSTOM_SCALAR_TYPES}
-
     # Bypass the GraphQLFloat parser and allow strings as input. The JSON spec allows only for
     # 64-bit floating point numbers, so large floats might have to be represented as strings.
     if is_same_type(expected_type, GraphQLFloat):

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -75,17 +75,6 @@ def _deserialize_anonymous_json_argument(expected_type: GraphQLScalarType, value
         GraphQLID.name: (int, str,),
     }
 
-    # Check for long integers, bypassing the GraphQLInt parser
-    if is_same_type(GraphQLInt, expected_type):
-        if isinstance(value, int):
-            return value
-        elif isinstance(value, str):
-            return int(value)
-        else:
-            raise ValueError(
-                "Unexpected type {}. Expected one of {}.".format(type(value), (int, str))
-            )
-
     # Check if the type of the value is correct
     correct_type = True
     expected_python_types = allowed_types_for_graphql_type[expected_type.name]
@@ -99,11 +88,15 @@ def _deserialize_anonymous_json_argument(expected_type: GraphQLScalarType, value
         )
 
     name_to_custom_type = {graphql_type.name: graphql_type for graphql_type in CUSTOM_SCALAR_TYPES}
-    # Parse the value. In most cases we can use the default GraphQL parser, but there are some
-    # special cases where we are more permissive than the default.
-    # By default, strings cannot be parsed to float.
+
+    # Bypass the GraphQLFloat parser and allow strings as input. The JSON spec allows only for
+    # 64-bit floating point numbers, so large floats might have to be represented as strings.
     if is_same_type(expected_type, GraphQLFloat):
         return float(value)
+    # Bypass the GraphQLInt parser and allow long ints and strings as input. The JSON spec allows
+    # only for 64-bit floating point numbers, so large ints might have to be represented as strings.
+    elif is_same_type(expected_type, GraphQLInt):
+        return int(value)
     # Use the default GraphQL parser to parse the value
     elif expected_type.name in name_to_custom_type:
         # Since we cannot serialize the parse_value function of custom scalar types when


### PR DESCRIPTION
Addressing the following comment:
https://github.com/kensho-technologies/graphql-compiler/pull/804/files#r415973184

I don't think that we should allow "nan" and "inf" as inputs and I am not sure that this was an intentional choice so I am not documenting it. Also, I think that what we do about these input values is going to be very controversial, but everything in this PR currently isn't. So I would like to address these in a subsequent PR in whatever way we agree its best to address them. 

https://github.com/kensho-technologies/graphql-compiler/issues/812