### PR TITLE
Raise NotImplementedError for MSSQL _x_count and multiple outputs within the same fold scope

### DIFF
--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -436,9 +436,12 @@ class IntegrationTests(TestCase):
     @use_all_backends(except_backends=(test_backend.REDISGRAPH,))  # Not implemented yet
     @integration_fixtures
     def test_fold_basic(self, backend_name: str) -> None:
-        # (query, args, expected_results) tuples.
-        # The queries are ran in the order specified here.
-        queries: List[Tuple[str, Dict[str, Any], List[Dict[str, Any]]]] = [
+        # (query, args, expected_results, excluded_backends) tuples.
+        # Note: excluded_backends is distinct from `@use_all_backends(expect_backends=(...)) because
+        # some backends such as MSSQL haven most, but not all, fold functionality implemented.
+        # excluded_backends can be use to bypass a subset of the fold tests.
+        # The queries are run in the order specified here.
+        queries: List[Tuple[str, Dict[str, Any], List[Dict[str, Any]]], List[str]] = [
             # Query 1: Unfolded children of Animal 1
             (
                 """
@@ -456,6 +459,7 @@ class IntegrationTests(TestCase):
                     {"descendant_name": "Animal 2"},
                     {"descendant_name": "Animal 3"},
                 ],
+                [],
             ),
             # Query 2: Folded children of Animal 1
             (
@@ -470,6 +474,7 @@ class IntegrationTests(TestCase):
             }""",
                 {"starting_animal_name": "Animal 1",},
                 [{"child_names": ["Animal 1", "Animal 2", "Animal 3"]},],
+                [],
             ),
             # Query 3: Unfolded children of Animal 4
             (
@@ -483,6 +488,7 @@ class IntegrationTests(TestCase):
                 }
             }""",
                 {"starting_animal_name": "Animal 4",},
+                [],
                 [],
             ),
             # Query 4: Folded children of Animal 4
@@ -498,6 +504,7 @@ class IntegrationTests(TestCase):
             }""",
                 {"starting_animal_name": "Animal 4",},
                 [{"child_names": []},],
+                [],
             ),
             # Query 5: Multiple outputs in a fold scope.
             (
@@ -522,10 +529,13 @@ class IntegrationTests(TestCase):
                         ],
                     },
                 ],
+                [test_backend.MSSQL],
             ),
         ]
 
-        for graphql_query, parameters, expected_results in queries:
+        for graphql_query, parameters, expected_results, excluded_backends in queries:
+            if backend_name in excluded_backends:
+                continue
             self.assertResultsEqual(graphql_query, parameters, backend_name, expected_results)
 
     @use_all_backends(

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -438,7 +438,7 @@ class IntegrationTests(TestCase):
     def test_fold_basic(self, backend_name: str) -> None:
         # (query, args, expected_results, excluded_backends) tuples.
         # Note: excluded_backends is distinct from `@use_all_backends(expect_backends=(...)) because
-        # some backends such as MSSQL haven most, but not all, fold functionality implemented.
+        # some backends such as MSSQL have most, but not all, fold functionality implemented.
         # excluded_backends can be use to bypass a subset of the fold tests.
         # The queries are run in the order specified here.
         queries: List[Tuple[str, Dict[str, Any], List[Dict[str, Any]], List[str]]] = [

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -441,7 +441,7 @@ class IntegrationTests(TestCase):
         # some backends such as MSSQL haven most, but not all, fold functionality implemented.
         # excluded_backends can be use to bypass a subset of the fold tests.
         # The queries are run in the order specified here.
-        queries: List[Tuple[str, Dict[str, Any], List[Dict[str, Any]]], List[str]] = [
+        queries: List[Tuple[str, Dict[str, Any], List[Dict[str, Any]], List[str]]] = [
             # Query 1: Unfolded children of Animal 1
             (
                 """

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -1185,7 +1185,7 @@ class CompilerTests(unittest.TestCase):
             )
         """
         expected_gremlin = NotImplementedError
-        expected_mssql = SKIP_TEST
+        expected_mssql = NotImplementedError
         expected_cypher = SKIP_TEST
         expected_postgresql = """
             SELECT
@@ -5448,52 +5448,7 @@ class CompilerTests(unittest.TestCase):
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
         """
-        expected_mssql = """
-            SELECT
-                [Animal_1].name AS animal_name,
-                folded_subquery_1.fold_output_color AS child_color_list,
-                folded_subquery_1.fold_output_name AS child_names_list
-            FROM
-                db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN(
-                SELECT
-                    [Animal_2].uuid AS uuid,
-                    coalesce((
-                        SELECT
-                            '|' + coalesce(
-                                REPLACE(
-                                    REPLACE(
-                                        REPLACE([Animal_3].name, '^', '^e'),
-                                    '~',
-                                    '^n'),
-                                '|',
-                                '^d'),
-                            '~')
-                        FROM
-                            db_1.schema_1.[Animal] AS [Animal_3]
-                        WHERE
-                            [Animal_2].uuid = [Animal_3].parent FOR XML PATH('')),
-                    '') AS fold_output_name,
-                    coalesce((
-                        SELECT
-                            '|' + coalesce(
-                                REPLACE(
-                                    REPLACE(
-                                        REPLACE([Animal_3].color, '^', '^e'),
-                                    '~',
-                                    '^n'),
-                                '|',
-                                '^d'),
-                            '~')
-                        FROM
-                            db_1.schema_1.[Animal] AS [Animal_3]
-                        WHERE
-                            [Animal_2].uuid = [Animal_3].parent FOR XML PATH('')),
-                    '') AS fold_output_color
-                FROM
-                  db_1.schema_1.[Animal] AS [Animal_2]
-            ) AS folded_subquery_1 ON [Animal_1].uuid = folded_subquery_1.uuid
-        """
+        expected_mssql = NotImplementedError
         expected_match = SKIP_TEST
         expected_gremlin = SKIP_TEST
         expected_cypher = SKIP_TEST
@@ -6178,52 +6133,7 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         """
-        expected_mssql = """
-            SELECT
-                [Animal_1].name AS animal_name,
-                folded_subquery_1.fold_output_name AS child_names_list,
-                folded_subquery_1.fold_output_uuid AS child_uuids_list
-            FROM db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN (
-                SELECT
-                    [Animal_2].uuid AS uuid,
-                    coalesce(
-                        (
-                            SELECT
-                                '|' + coalesce(
-                                    REPLACE(
-                                        REPLACE(
-                                            REPLACE(
-                                                [Animal_3].uuid, '^', '^e'
-                                            ),
-                                        '~', '^n'),
-                                    '|', '^d'),
-                                '~')
-                            FROM db_1.schema_1.[Animal] AS [Animal_3]
-                            WHERE [Animal_2].uuid = [Animal_3].parent
-                            FOR XML PATH ('')
-                        ),
-                    '') AS fold_output_uuid,
-                    coalesce(
-                        (
-                            SELECT
-                                '|' + coalesce(
-                                    REPLACE(
-                                        REPLACE(
-                                            REPLACE(
-                                                [Animal_3].name, '^', '^e'
-                                            ),
-                                        '~', '^n'),
-                                    '|', '^d'),
-                                '~')
-                            FROM db_1.schema_1.[Animal] AS [Animal_3]
-                            WHERE [Animal_2].uuid = [Animal_3].parent
-                            FOR XML PATH ('')
-                        ),
-                    '') AS fold_output_name
-                FROM db_1.schema_1.[Animal] AS [Animal_2]
-            ) AS folded_subquery_1 ON [Animal_1].uuid = folded_subquery_1.uuid
-        """
+        expected_mssql = NotImplementedError
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)-[:Animal_ParentOf]->(Animal__out_Animal_ParentOf___1:Animal)
@@ -6413,91 +6323,7 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         """
-        expected_mssql = """
-            SELECT
-                [Animal_1].name AS animal_name,
-                folded_subquery_1.fold_output_name AS child_names_list,
-                folded_subquery_1.fold_output_uuid AS child_uuids_list,
-                folded_subquery_2.fold_output_name AS parent_names_list,
-                folded_subquery_2.fold_output_uuid AS parent_uuids_list
-            FROM db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN (
-                SELECT
-                    [Animal_2].uuid AS uuid,
-                    coalesce(
-                        (
-                            SELECT
-                                '|' + coalesce(
-                                REPLACE(
-                                    REPLACE(
-                                        REPLACE(
-                                            [Animal_3].uuid, '^', '^e'
-                                        ),
-                                    '~', '^n'),
-                                '|', '^d'),
-                            '~')
-                            FROM db_1.schema_1.[Animal] AS [Animal_3]
-                            WHERE [Animal_2].uuid = [Animal_3].parent
-                            FOR XML PATH ('')
-                        ),
-                    '') AS fold_output_uuid,
-                    coalesce(
-                        (
-                            SELECT '|' + coalesce(
-                                REPLACE(
-                                    REPLACE(
-                                        REPLACE(
-                                            [Animal_3].name, '^', '^e'
-                                        ),
-                                    '~', '^n'),
-                                '|', '^d'),
-                            '~')
-                            FROM db_1.schema_1.[Animal] AS [Animal_3]
-                            WHERE [Animal_2].uuid = [Animal_3].parent
-                            FOR XML PATH ('')
-                        ),
-                    '') AS fold_output_name
-                    FROM db_1.schema_1.[Animal] AS [Animal_2]
-            ) AS folded_subquery_1 ON [Animal_1].uuid = folded_subquery_1.uuid
-            JOIN (
-                SELECT
-                    [Animal_4].uuid AS uuid,
-                        coalesce(
-                            (
-                                SELECT '|' + coalesce(
-                                    REPLACE(
-                                        REPLACE(
-                                            REPLACE(
-                                                [Animal_5].uuid, '^', '^e'
-                                            ),
-                                        '~', '^n'),
-                                    '|', '^d'),
-                                '~')
-                                FROM db_1.schema_1.[Animal] AS [Animal_5]
-                                WHERE [Animal_4].parent = [Animal_5].uuid
-                                FOR XML PATH ('')
-                            ),
-                        '') AS fold_output_uuid,
-                        coalesce(
-                            (
-                                SELECT
-                                    '|' + coalesce(
-                                        REPLACE(
-                                            REPLACE(
-                                                REPLACE(
-                                                    [Animal_5].name, '^', '^e'
-                                                ),
-                                            '~', '^n'),
-                                        '|', '^d'),
-                                    '~')
-                                FROM db_1.schema_1.[Animal] AS [Animal_5]
-                                WHERE [Animal_4].parent = [Animal_5].uuid
-                                FOR XML PATH ('')
-                            ),
-                        '') AS fold_output_name
-                        FROM db_1.schema_1.[Animal] AS [Animal_4]
-                ) AS folded_subquery_2 ON [Animal_1].uuid = folded_subquery_2.uuid
-                """
+        expected_mssql = NotImplementedError
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -7535,7 +7361,7 @@ class CompilerTests(unittest.TestCase):
                 $Animal___1___out_Animal_ParentOf = Animal___1.out("Animal_ParentOf").asList()
         """
         expected_gremlin = NotImplementedError
-        expected_mssql = SKIP_TEST
+        expected_mssql = NotImplementedError
         expected_postgresql = """
             SELECT
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names,
@@ -7588,7 +7414,7 @@ class CompilerTests(unittest.TestCase):
         """
         expected_gremlin = NotImplementedError
 
-        expected_mssql = SKIP_TEST
+        expected_mssql = NotImplementedError
 
         expected_postgresql = """
             SELECT
@@ -7737,7 +7563,7 @@ class CompilerTests(unittest.TestCase):
             )
         """
         expected_gremlin = NotImplementedError
-        expected_mssql = SKIP_TEST
+        expected_mssql = NotImplementedError
         expected_postgresql = """
             SELECT
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names,
@@ -7796,7 +7622,7 @@ class CompilerTests(unittest.TestCase):
                 ($Animal___1___out_Animal_ParentOf.size() >= Animal__out_Animal_OfSpecies___1.limbs)
         """
         expected_gremlin = NotImplementedError
-        expected_mssql = SKIP_TEST
+        expected_mssql = NotImplementedError
         expected_postgresql = """
             SELECT
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names,
@@ -7888,7 +7714,7 @@ class CompilerTests(unittest.TestCase):
                 )
         """
         expected_gremlin = NotImplementedError
-        expected_mssql = SKIP_TEST
+        expected_mssql = NotImplementedError
         expected_postgresql = """
             SELECT
                 "Animal_1".name AS name


### PR DESCRIPTION
The current implementation of `_x_count` does not actually count the number of results returned with the fold. Using `COUNT(*)` outside the `XML PATH` statement causes the count to always be 1 for the 1 string result returned through `XML PATH` aggregation. 

The current implementation for multiple outputs within a fold produces an individual `XML PATH` statement per output. This does not guarantee that the outputs from within the same fold will be returned in the same order.

Both these things should raise `NotImplementedError` for now, but should be implemented in the future.