### PR TITLE
Rename and test SQLFoldObject

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -286,21 +286,14 @@ class SQLFoldTraversalDescriptor(NamedTuple):
     to_table: Alias
 
 
-# TODO(bojanserafimov): Rename to FoldSubqueryBuilder and simplify usage and spec.
 class FoldSubqueryBuilder(object):
-    """Object used to collect info for folds in order to ensure correct code emission."""
+    """Builder that emits a subquery for a fold scope."""
 
-    # A FoldSubqueryBuilder consists of information related to the SELECT clause of the fold subquery,
-    # the GROUP BY clause, the WHERE clause (if applying filters) and the FROM clause which contains
-    # one JOIN per vertex traversed in the fold, including the traversal from the vertex outside
-    # the fold to the folded vertex itself.
-    #
     # The life cycle for the FoldSubqueryBuilder is:
-    #   1. initializing it with the information for the outer vertex (the one outside the fold)
-    #   2. at least one traversal
-    #   3. visiting the output vertex to collect the output columns
-    #   4. optionally adding a filter condition
-    #   5. ending the fold by producing the resulting subquery
+    #   1. initialize at the vertex preceding the fold
+    #   2. visit all locations inside the fold scope
+    #   3. optinally add fold scope filters
+    #   5. end the fold, producing the resulting subquery
     #
     # This life cycle is completed via calls to __init__, visit_vertex, add_filter, and end_fold.
     #

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -293,7 +293,7 @@ class FoldSubqueryBuilder(object):
     #   1. initialize at the vertex preceding the fold
     #   2. visit all locations inside the fold scope
     #   3. optinally add fold scope filters
-    #   5. end the fold, producing the resulting subquery
+    #   4. end the fold, producing the resulting subquery
     #
     # This life cycle is completed via calls to __init__, visit_vertex, add_filter, and end_fold.
     #

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -575,18 +575,13 @@ class FoldSubqueryBuilder(object):
         # Sort to make select order deterministic.
         return sorted(self._outputs, key=lambda column: column.name, reverse=True)
 
-    # This function communicates both a traversal to a new node and output information at the
-    # new node. It could be split into two functions that are easier to spec:
-    # 1. traverse(self, join_descriptor)
-    # 2. expose_column(self, column_name)
-    #
-    # This way there is no need to define what is considered a folded field. It is up to the
-    # caller to expose all they will want to use.
-    #
-    # Note: The traverse and expose_colum functions would look very similar to the
-    #       _join_to_parent_location and output functions of CompilationState. A generic
-    #       query bulder could simplify both these classes, if we continue down the object
-    #       oriented approach of emitting sql.
+    # TODO(bojanserafimov): This function communicates both a traversal to a new node and
+    #                       outputting information at the new node. It could be split into two
+    #                       functions that are easier to spec:
+    #                       1. traverse(self, join_descriptor)
+    #                       2. add_output(self, column_name)
+    #                       This way there is no need to define what is considered a folded
+    #                       field. It is up to the caller to expose all they will want to use.
     def visit_vertex(
         self,
         join_descriptor: DirectJoinDescriptor,
@@ -595,11 +590,7 @@ class FoldSubqueryBuilder(object):
         current_fold_scope_location: FoldScopeLocation,
         all_folded_fields: Dict[FoldPath, Set[FoldScopeLocation]],
     ) -> None:
-        """Add a new SQLFoldTraversalDescriptor and add outputs, if visiting an output vertex.
-
-        Args:
-            join_descriptor: the join descriptor corresponding to the edge leading to this vertex
-        """
+        """Add a new SQLFoldTraversalDescriptor and add outputs, if visiting an output vertex."""
         if self._ended:
             raise AssertionError(
                 "Cannot visit traversed vertices after end_fold has been called."

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -575,6 +575,8 @@ class FoldSubqueryBuilder(object):
         # Sort to make select order deterministic.
         return sorted(self._outputs, key=lambda column: column.name, reverse=True)
 
+    # TODO these arguments need to be explained. Should this function be called on the
+    #      first vertex inside the fold? If so, what is from_table in that case?
     def visit_vertex(
         self,
         join_descriptor: DirectJoinDescriptor,

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -575,8 +575,10 @@ class FoldSubqueryBuilder(object):
         # Sort to make select order deterministic.
         return sorted(self._outputs, key=lambda column: column.name, reverse=True)
 
-    # TODO these arguments need to be explained. Should this function be called on the
-    #      first vertex inside the fold? If so, what is from_table in that case?
+    # TODO these arguments need to be explained/simplified:
+    #      - the relationship between the two tables and the vertex mentioned
+    #      - the meaning of current in current_fold_scope_location
+    #      - spec for all_folded_fields. What is a folded field?
     def visit_vertex(
         self,
         join_descriptor: DirectJoinDescriptor,

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -291,8 +291,8 @@ class FoldSubqueryBuilder(object):
 
     # The life cycle for the FoldSubqueryBuilder is:
     #   1. initialize at the vertex preceding the fold
-    #   2. visit all locations inside the fold scope
-    #   3. optinally add fold scope filters
+    #   2. visit all locations inside the fold scope. Must visit at least one location with outputs.
+    #   3. optionally add fold scope filters
     #   4. end the fold, producing the resulting subquery
     #
     # This life cycle is completed via calls to __init__, visit_vertex, add_filter, and end_fold.
@@ -341,7 +341,7 @@ class FoldSubqueryBuilder(object):
     # JOIN VertexPrecedingOutput
     # ON ...
     def __init__(self, dialect: DefaultDialect, outer_vertex_table: Alias, primary_key_name: str):
-        """Create an FoldSubqueryBuilder with table, type, and join information supplied by the IR.
+        """Create a FoldSubqueryBuilder with table, type, and join information supplied by the IR.
 
         Args:
             dialect: dialect to which the query will be compiled.

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -708,9 +708,7 @@ class EmitSQLTests(unittest.TestCase):
         join_descriptor = self.schema_infos["mssql"].join_descriptors["Animal"]["out_Animal_ParentOf"]
         from_alias = table.alias()
         to_alias = table.alias()
-
-        fold_path = (("out", "Animal_ParentOf"),)
-        fold_scope_location = FoldScopeLocation(Location(("Animal",)), fold_path)
+        fold_scope_location = Location(("Animal",)).navigate_to_fold("out_Animal_ParentOf")
 
         builder = emit_sql.FoldSubqueryBuilder(dialect, table.alias(), "uuid")
         builder.visit_vertex(
@@ -718,7 +716,7 @@ class EmitSQLTests(unittest.TestCase):
             from_alias,
             to_alias,
             fold_scope_location,
-            {fold_path: {fold_scope_location.navigate_to_field("name")}}
+            {fold_scope_location.fold_path: {fold_scope_location.navigate_to_field("name")}}
         )
         subquery, output_location = builder.end_fold()
 

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -722,7 +722,7 @@ class EmitSQLTests(unittest.TestCase):
         )
         subquery, output_location = builder.end_fold()
 
-
+        # TODO This is not the expected sql, just the output I got.
         expected_mssql = """
             SELECT
                 [Animal_1].uuid,
@@ -744,10 +744,6 @@ class EmitSQLTests(unittest.TestCase):
                 db_1.schema_1.[Animal] AS [Animal_1],
                 db_1.schema_1.[Animal] AS [Animal_3]
         """
-        # TODO the FROM clause is wrong
-        print(subquery)
-
-        self.assertEqual({"uuid", "fold_output_name"}, set(subquery.c.keys()))
 
         string_result = print_sqlalchemy_query_string(subquery, dialect)
         compare_sql(self, expected_mssql, string_result)

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -1,11 +1,9 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 import unittest
 
-from sqlalchemy.dialects.mssql.base import MSDialect
-from sqlalchemy.dialects.postgresql.base import PGDialect
 from graphql import GraphQLString
+from sqlalchemy.dialects.mssql.base import MSDialect
 
-from ..compiler.sqlalchemy_extensions import print_sqlalchemy_query_string
 from ..compiler import emit_cypher, emit_gremlin, emit_match, emit_sql
 from ..compiler.blocks import (
     Backtrack,
@@ -27,20 +25,21 @@ from ..compiler.expressions import (
     TernaryConditional,
     Variable,
 )
-from ..compiler.helpers import Location, FoldScopeLocation
+from ..compiler.helpers import Location
 from ..compiler.ir_lowering_common.common import OutputContextVertex
 from ..compiler.ir_lowering_match.utils import CompoundMatchQuery
 from ..compiler.match_query import convert_to_match_query
 from ..compiler.metadata import LocationInfo, QueryMetadataTable
+from ..compiler.sqlalchemy_extensions import print_sqlalchemy_query_string
 from ..schema import GraphQLDateTime
 from .test_helpers import (
-    compare_sql,
     compare_cypher,
     compare_gremlin,
     compare_match,
+    compare_sql,
     get_common_schema_info,
-    get_sqlalchemy_schema_info,
     get_schema,
+    get_sqlalchemy_schema_info,
 )
 
 
@@ -705,7 +704,9 @@ class EmitSQLTests(unittest.TestCase):
     def test_fold_subquery_builder(self) -> None:
         dialect = MSDialect()
         table = self.schema_infos["mssql"].vertex_name_to_table["Animal"]
-        join_descriptor = self.schema_infos["mssql"].join_descriptors["Animal"]["out_Animal_ParentOf"]
+        join_descriptor = self.schema_infos["mssql"].join_descriptors["Animal"][
+            "out_Animal_ParentOf"
+        ]
         from_alias = table.alias()
         to_alias = table.alias()
         fold_scope_location = Location(("Animal",)).navigate_to_fold("out_Animal_ParentOf")
@@ -716,7 +717,7 @@ class EmitSQLTests(unittest.TestCase):
             from_alias,
             to_alias,
             fold_scope_location,
-            {fold_scope_location.fold_path: {fold_scope_location.navigate_to_field("name")}}
+            {fold_scope_location.fold_path: {fold_scope_location.navigate_to_field("name")}},
         )
         subquery, output_location = builder.end_fold()
 
@@ -740,8 +741,8 @@ class EmitSQLTests(unittest.TestCase):
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
         """
-
         string_result = print_sqlalchemy_query_string(subquery, dialect)
         compare_sql(self, expected_mssql, string_result)
-        self.assertEqual({"uuid", "fold_output_name"}, set(subquery.c.keys()))
 
+        self.assertEqual({"uuid", "fold_output_name"}, set(subquery.c.keys()))
+        self.assertEqual(fold_scope_location, output_location)

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -710,7 +710,7 @@ class EmitSQLTests(unittest.TestCase):
         to_alias = table.alias()
         fold_scope_location = Location(("Animal",)).navigate_to_fold("out_Animal_ParentOf")
 
-        builder = emit_sql.FoldSubqueryBuilder(dialect, table.alias(), "uuid")
+        builder = emit_sql.FoldSubqueryBuilder(dialect, from_alias, "uuid")
         builder.visit_vertex(
             join_descriptor,
             from_alias,
@@ -720,7 +720,6 @@ class EmitSQLTests(unittest.TestCase):
         )
         subquery, output_location = builder.end_fold()
 
-        # TODO This is not the expected sql, just the output I got.
         expected_mssql = """
             SELECT
                 [Animal_1].uuid,
@@ -735,13 +734,13 @@ class EmitSQLTests(unittest.TestCase):
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_2]
                 WHERE
-                    [Animal_3].uuid = [Animal_2].parent
+                    [Animal_1].uuid = [Animal_2].parent
                 FOR XML PATH ('')
                 ), '') AS fold_output_name
             FROM
-                db_1.schema_1.[Animal] AS [Animal_1],
-                db_1.schema_1.[Animal] AS [Animal_3]
+                db_1.schema_1.[Animal] AS [Animal_1]
         """
+        # TODO where is the label for uuid? is fold_output_name the right label for the xml subquery?
 
         string_result = print_sqlalchemy_query_string(subquery, dialect)
         compare_sql(self, expected_mssql, string_result)

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -740,7 +740,8 @@ class EmitSQLTests(unittest.TestCase):
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
         """
-        # TODO where is the label for uuid? is fold_output_name the right label for the xml subquery?
 
         string_result = print_sqlalchemy_query_string(subquery, dialect)
         compare_sql(self, expected_mssql, string_result)
+        self.assertEqual({"uuid", "fold_output_name"}, set(subquery.c.keys()))
+


### PR DESCRIPTION
Renamed `SQLFoldObject` to `FoldSubqueryBuilder` to tighten its spec. Wrote the first dedicated test for the class (we have many end-to-end fold tests), which helped reveal where the spec is most blurry. Spec simplifications coming in future PR.