### PR TITLE
MSSQL fold postprocessing tests for all scalar types

### DIFF
--- a/graphql_compiler/deserialization.py
+++ b/graphql_compiler/deserialization.py
@@ -1,7 +1,7 @@
 # Copyright 2020-present Kensho Technologies, LLC.
 """Convert values to their underlying GraphQLType."""
 from types import MappingProxyType
-from typing import Any, Callable, Dict, Mapping, Tuple, Type
+from typing import Any, Callable, Mapping, Tuple, Type
 
 from graphql import (
     GraphQLBoolean,
@@ -13,16 +13,15 @@ from graphql import (
     GraphQLString,
 )
 
-from graphql_compiler import GraphQLInvalidArgumentError
 from graphql_compiler.compiler.helpers import strip_non_null_from_type
 from graphql_compiler.global_utils import is_same_type
-from graphql_compiler.typedefs import QueryArgumentGraphQLType
 
 from .global_utils import assert_set_equality
 from .schema import SUPPORTED_SCALAR_TYPES, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+from .typedefs import QueryArgumentGraphQLType
 
 
-_ALLOWED_JSON_SCALAR_TYPES: Mapping[str, Tuple[Type, ...]] = MappingProxyType(
+_ALLOWED_SCALAR_TYPES: Mapping[str, Tuple[Type, ...]] = MappingProxyType(
     {
         GraphQLDate.name: (str,),
         GraphQLDateTime.name: (str,),
@@ -35,7 +34,7 @@ _ALLOWED_JSON_SCALAR_TYPES: Mapping[str, Tuple[Type, ...]] = MappingProxyType(
     }
 )
 assert_set_equality(
-    set(_ALLOWED_JSON_SCALAR_TYPES.keys()),
+    set(_ALLOWED_SCALAR_TYPES.keys()),
     {graphql_type.name for graphql_type in SUPPORTED_SCALAR_TYPES},
 )
 
@@ -50,8 +49,8 @@ def _custom_boolean_deserialization(value: Any) -> bool:
         return False
     else:
         raise ValueError(
-            f"Received unexpected GraphQLBoolean value {value} ({type(value)}). Expected one "
-            f"of the following {true_values + false_values}."
+            f"Received unexpected GraphQLBoolean value {value} of type {type(value)}. Expected one "
+            f"of: {true_values + false_values}."
         )
 
 
@@ -75,7 +74,7 @@ _JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS: Mapping[
 ] = MappingProxyType(
     {
         scalar_type.name: (
-            _ALLOWED_JSON_SCALAR_TYPES[scalar_type.name],
+            _ALLOWED_SCALAR_TYPES[scalar_type.name],
             _CUSTOM_SCALAR_DESERIALIZATION_FUNCTIONS.get(scalar_type.name, scalar_type.parse_value),
         )
         for scalar_type in SUPPORTED_SCALAR_TYPES
@@ -83,78 +82,8 @@ _JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS: Mapping[
 )
 
 
-def convert_scalar_value_to_graphql_type(expected_type: GraphQLScalarType, value: Any) -> Any:
+def deserialize_scalar_value(expected_type: GraphQLScalarType, value: Any) -> Any:
     """Convert a scalar value to the appropriate type for the given GraphQLScalarType.
-
-    Args:
-        expected_type: a GraphQLScalarType to which value should be converted.
-        value: object that can be interpreted as being of expected_type.
-
-    Returns:
-        a value of the type produced by the parser of the expected type:
-            GraphQLDate: datetime.date
-            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
-            GraphQLFloat: float
-            GraphQLDecimal: decimal.Decimal
-            GraphQLInt: int
-            GraphQLString: str
-            GraphQLBoolean: bool
-            GraphQLID: str
-
-    Raises:
-        TypeError: if the value was not of the expected type.
-    """
-    types_and_deserialization = _JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS.get(expected_type.name)
-    if types_and_deserialization is None:
-        raise TypeError(
-            f"Unexpected GraphQLType {expected_type}. No deserialization function known."
-        )
-    expected_python_types, deserialization_function = types_and_deserialization
-    if not isinstance(value, expected_python_types):
-        raise TypeError(
-            f"{value} ({type(value)} cannot be deserialized to GraphQL type {expected_type}."
-        )
-    return deserialization_function(value)
-
-
-def deserialize_scalar_argument(name: str, expected_type: GraphQLScalarType, value: Any) -> Any:
-    """Deserialize a serialized scalar argument. See docstring of deserialize_argument.
-
-    Args:
-        name: the name of the argument.
-        expected_type: a GraphQLScalarType to which value should be converted.
-        value: object that can be interpreted as being of expected_type.
-
-    Returns:
-        a value of the type produced by the parser of the expected type:
-            GraphQLDate: datetime.date
-            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
-            GraphQLFloat: float
-            GraphQLDecimal: decimal.Decimal
-            GraphQLInt: int
-            GraphQLString: str
-            GraphQLBoolean: bool
-            GraphQLID: str
-
-    Raises:
-        GraphQLInvalidArgumentError: if the argument value was not of the expected type.
-    """
-    # Explicitly disallow passing boolean values for non-boolean types.
-    if isinstance(value, bool) and not is_same_type(GraphQLBoolean, expected_type):
-        raise GraphQLInvalidArgumentError("")
-    try:
-        return convert_scalar_value_to_graphql_type(expected_type, value)
-    except (ValueError, TypeError) as e:
-        raise GraphQLInvalidArgumentError("Error parsing argument {}: {}".format(name, e))
-
-
-def deserialize_argument(name: str, expected_type: QueryArgumentGraphQLType, value: Any,) -> Any:
-    """Deserialize a serialized GraphQL argument.
-
-    Passing arguments via jsonrpc, or via the GUI of standard GraphQL editors is tricky because
-    json does not support certain types like Date, Datetime, Decimal, and also confuses floats
-    for integers if there are no decimals. This function takes in a value and converts it to a
-    standard python representation.
 
     Below are examples of accepted encodings of all the types:
         GraphQLDate: "2018-02-01"
@@ -165,13 +94,57 @@ def deserialize_argument(name: str, expected_type: QueryArgumentGraphQLType, val
         GraphQLString: "Hello"
         GraphQLBoolean: True, 1, "1", "True", "true"
         GraphQLID: "13d72846-1777-6c3a-5743-5d9ced3032ed"
-        GraphQLList(GraphQLInt): [1, 2, 3]
 
     Args:
-        name: he name of the argument. It will be used to provide a more descriptive error
-              message if an error is raised.
-        expected_type: the GraphQL type. All GraphQLNonNull type wrappers are stripped.
-        value: object that can be interpreted as being of that type.
+        expected_type: a GraphQLScalarType to which value should be converted.
+        value: object that can be interpreted as being of expected_type.
+
+    Returns:
+        a value of the type produced by the parser of the expected type:
+            GraphQLDate: datetime.date
+            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
+            GraphQLFloat: float
+            GraphQLDecimal: decimal.Decimal
+            GraphQLInt: int
+            GraphQLString: str
+            GraphQLBoolean: bool
+            GraphQLID: str
+
+    Raises:
+        AssertionError: if the expected_type does not have a known deserialization function.
+        ValueError: if the value is not appropriate for the type. ValueError is chosen because
+            it is already the base case of exceptions raised by the GraphQL parsers.
+    """
+    types_and_deserialization = _JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS.get(expected_type.name)
+    if types_and_deserialization is None:
+        raise AssertionError(
+            f"Unexpected GraphQLType {expected_type}. No deserialization function known."
+        )
+
+    # Explicitly disallow passing boolean values for non-boolean types.
+    if isinstance(value, bool) and not is_same_type(GraphQLBoolean, expected_type):
+        raise AssertionError(
+            f"Cannot deserialize boolean value {value} to non-GraphQLBoolean type {expected_type}."
+        )
+
+    # Ensure value has an appropriate type and deserialize the value.
+    expected_python_types, deserialization_function = types_and_deserialization
+    if not isinstance(value, expected_python_types):
+        raise ValueError(
+            f"{value} ({type(value)} cannot be deserialized to GraphQL type {expected_type}."
+        )
+    return deserialization_function(value)
+
+
+def deserialize_value(expected_type: QueryArgumentGraphQLType, value: Any) -> Any:
+    """Convert a value to the appropriate type for the given GraphQLType.
+
+    Accepted encodings include those described in deserialize_scalar_value and lists of
+    GraphQLScalarType such as GraphQLList(GraphQLInt): [1, 2, 3]
+
+    Args:
+        expected_type: a GraphQLType to which value should be converted.
+        value: object that can be interpreted as being of expected_type.
 
     Returns:
         a value of the type produced by the parser of the expected type:
@@ -186,68 +159,16 @@ def deserialize_argument(name: str, expected_type: QueryArgumentGraphQLType, val
             GraphQLList: list of the inner type
 
     Raises:
-        GraphQLInvalidArgumentError: if the argument value was not of the expected type.
+        AssertionError: if the expected_type does not have a known deserialization function.
+        ValueError: if the value is not appropriate for the type. ValueError is chosen because
+            it is already the base case of exceptions raised by the GraphQL parsers.
     """
     stripped_type = strip_non_null_from_type(expected_type)
     if isinstance(stripped_type, GraphQLList):
         if not isinstance(value, list):
-            raise GraphQLInvalidArgumentError(
-                f"Attempted to convert argument {name} to a GraphQLList, but {name} had a non-list "
-                f"value {value}."
-            )
-
+            raise AssertionError(f"Cannot deserialize non-list value {value} to GraphQLList type.")
         inner_stripped_type = strip_non_null_from_type(stripped_type.of_type)
 
-        return [
-            deserialize_scalar_argument(name, inner_stripped_type, element) for element in value
-        ]
+        return [deserialize_scalar_value(inner_stripped_type, element) for element in value]
     else:
-        return deserialize_scalar_argument(name, stripped_type, value)
-
-
-def deserialize_multiple_arguments(
-    arguments: Mapping[str, Any], expected_types: Mapping[str, QueryArgumentGraphQLType],
-) -> Dict[str, Any]:
-    """Deserialize serialized GraphQL arguments.
-
-    Passing arguments via jsonrpc, or via the GUI of standard GraphQL editors is tricky because
-    json does not support certain types like Date, Datetime, Decimal, and also confuses floats
-    for integers if there are no decimals. This function takes in values converts them to
-    standard python representations.
-
-    Below are examples of accepted json encodings of all the types:
-        GraphQLDate: "2018-02-01"
-        GraphQLDateTime: "2018-02-01T05:11:54Z"
-        GraphQLFloat: 4.3, "5.0", 5
-        GraphQLDecimal: "5.00000000000000000000000000001"
-        GraphQLInt: 4, "3803330000000000000000000000000000000000000000000"
-        GraphQLString: "Hello"
-        GraphQLBoolean: True, 1, "1", "True", "true"
-        GraphQLID: "13d72846-1777-6c3a-5743-5d9ced3032ed"
-        GraphQLList(GraphQLInt): [1, 2, 3]
-
-    Args:
-        arguments: mapping of argument names to serialized argument values.
-        expected_types: mapping of argument names to the expected GraphQL types. All
-                        GraphQLNonNull wrappers are stripped.
-
-    Returns:
-        a mapping of argument names to deserialized argument values. The type of the deserialized
-        argument value depends on the argument's GraphQL type:
-            GraphQLDate: datetime.date
-            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
-            GraphQLFloat: float
-            GraphQLDecimal: decimal.Decimal
-            GraphQLInt: int
-            GraphQLString: str
-            GraphQLBoolean: bool
-            GraphQLID: str
-            GraphQLList: list of the inner type
-
-    Raises:
-        GraphQLInvalidArgumentError: if any of the argument values was not of the expected type.
-    """
-    return {
-        name: deserialize_argument(name, expected_types[name], value)
-        for name, value in arguments.items()
-    }
+        return deserialize_scalar_value(stripped_type, value)

--- a/graphql_compiler/deserialization.py
+++ b/graphql_compiler/deserialization.py
@@ -111,9 +111,8 @@ def deserialize_scalar_value(expected_type: GraphQLScalarType, value: Any) -> An
             GraphQLID: str
 
     Raises:
-        AssertionError: if the expected_type does not have a known deserialization function.
         ValueError: if the value is not appropriate for the type. ValueError is chosen because
-            it is already the base case of exceptions raised by the GraphQL parsers.
+                    it is already the base case of exceptions raised by the GraphQL parsers.
     """
     types_and_deserialization = _JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS.get(expected_type.name)
     if types_and_deserialization is None:
@@ -123,7 +122,7 @@ def deserialize_scalar_value(expected_type: GraphQLScalarType, value: Any) -> An
 
     # Explicitly disallow passing boolean values for non-boolean types.
     if isinstance(value, bool) and not is_same_type(GraphQLBoolean, expected_type):
-        raise AssertionError(
+        raise ValueError(
             f"Cannot deserialize boolean value {value} to non-GraphQLBoolean type {expected_type}."
         )
 
@@ -159,14 +158,13 @@ def deserialize_value(expected_type: QueryArgumentGraphQLType, value: Any) -> An
             GraphQLList: list of the inner type
 
     Raises:
-        AssertionError: if the expected_type does not have a known deserialization function.
         ValueError: if the value is not appropriate for the type. ValueError is chosen because
-            it is already the base case of exceptions raised by the GraphQL parsers.
+                    it is already the base case of exceptions raised by the GraphQL parsers.
     """
     stripped_type = strip_non_null_from_type(expected_type)
     if isinstance(stripped_type, GraphQLList):
         if not isinstance(value, list):
-            raise AssertionError(f"Cannot deserialize non-list value {value} to GraphQLList type.")
+            raise ValueError(f"Cannot deserialize non-list value {value} to GraphQLList type.")
         inner_stripped_type = strip_non_null_from_type(stripped_type.of_type)
 
         return [deserialize_scalar_value(inner_stripped_type, element) for element in value]

--- a/graphql_compiler/deserialization.py
+++ b/graphql_compiler/deserialization.py
@@ -1,0 +1,253 @@
+# Copyright 2020-present Kensho Technologies, LLC.
+"""Convert values to their underlying GraphQLType."""
+from types import MappingProxyType
+from typing import Any, Callable, Dict, Mapping, Tuple, Type
+
+from graphql import (
+    GraphQLBoolean,
+    GraphQLFloat,
+    GraphQLID,
+    GraphQLInt,
+    GraphQLList,
+    GraphQLScalarType,
+    GraphQLString,
+)
+
+from graphql_compiler import GraphQLInvalidArgumentError
+from graphql_compiler.compiler.helpers import strip_non_null_from_type
+from graphql_compiler.global_utils import is_same_type
+from graphql_compiler.typedefs import QueryArgumentGraphQLType
+
+from .global_utils import assert_set_equality
+from .schema import SUPPORTED_SCALAR_TYPES, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+
+
+_ALLOWED_JSON_SCALAR_TYPES: Mapping[str, Tuple[Type, ...]] = MappingProxyType(
+    {
+        GraphQLDate.name: (str,),
+        GraphQLDateTime.name: (str,),
+        GraphQLFloat.name: (str, float, int),
+        GraphQLDecimal.name: (str, float, int),
+        GraphQLInt.name: (int, str),
+        GraphQLString.name: (str,),
+        GraphQLBoolean.name: (bool, int, str),
+        GraphQLID.name: (int, str,),
+    }
+)
+assert_set_equality(
+    set(_ALLOWED_JSON_SCALAR_TYPES.keys()),
+    {graphql_type.name for graphql_type in SUPPORTED_SCALAR_TYPES},
+)
+
+
+def _custom_boolean_deserialization(value: Any) -> bool:
+    """Deserialize a boolean, allowing for common string or int representations."""
+    true_values = [1, "1", "true", "True", True]
+    false_values = [0, "0", "false", "False", False]
+    if value in true_values:
+        return True
+    elif value in false_values:
+        return False
+    else:
+        raise ValueError(
+            f"Received unexpected GraphQLBoolean value {value} ({type(value)}). Expected one "
+            f"of the following {true_values + false_values}."
+        )
+
+
+_CUSTOM_SCALAR_DESERIALIZATION_FUNCTIONS: Mapping[str, Callable[[Any], Any]] = MappingProxyType(
+    {
+        # Bypass the GraphQLFloat parser and allow strings as input. The JSON spec allows only
+        # for 64-bit floating point numbers, so large floats might have to be represented as
+        # strings.
+        GraphQLFloat.name: float,
+        # Bypass the GraphQLInt parser and allow long ints and strings as input. The JSON spec
+        # allows only for 64-bit floating point numbers, so large ints might have to be
+        # represented as strings.
+        GraphQLInt.name: int,
+        # Bypass the GraphQLBoolean parser and allow some strings and ints as input.
+        GraphQLBoolean.name: _custom_boolean_deserialization,
+    }
+)
+
+_JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS: Mapping[
+    str, Tuple[Tuple[Type, ...], Callable[[Any], Any]]
+] = MappingProxyType(
+    {
+        scalar_type.name: (
+            _ALLOWED_JSON_SCALAR_TYPES[scalar_type.name],
+            _CUSTOM_SCALAR_DESERIALIZATION_FUNCTIONS.get(scalar_type.name, scalar_type.parse_value),
+        )
+        for scalar_type in SUPPORTED_SCALAR_TYPES
+    }
+)
+
+
+def convert_scalar_value_to_graphql_type(expected_type: GraphQLScalarType, value: Any) -> Any:
+    """Convert a scalar value to the appropriate type for the given GraphQLScalarType.
+
+    Args:
+        expected_type: a GraphQLScalarType to which value should be converted.
+        value: object that can be interpreted as being of expected_type.
+
+    Returns:
+        a value of the type produced by the parser of the expected type:
+            GraphQLDate: datetime.date
+            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
+            GraphQLFloat: float
+            GraphQLDecimal: decimal.Decimal
+            GraphQLInt: int
+            GraphQLString: str
+            GraphQLBoolean: bool
+            GraphQLID: str
+
+    Raises:
+        TypeError: if the value was not of the expected type.
+    """
+    types_and_deserialization = _JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS.get(expected_type.name)
+    if types_and_deserialization is None:
+        raise TypeError(
+            f"Unexpected GraphQLType {expected_type}. No deserialization function known."
+        )
+    expected_python_types, deserialization_function = types_and_deserialization
+    if not isinstance(value, expected_python_types):
+        raise TypeError(
+            f"{value} ({type(value)} cannot be deserialized to GraphQL type {expected_type}."
+        )
+    return deserialization_function(value)
+
+
+def deserialize_scalar_argument(name: str, expected_type: GraphQLScalarType, value: Any) -> Any:
+    """Deserialize a serialized scalar argument. See docstring of deserialize_argument.
+
+    Args:
+        name: the name of the argument.
+        expected_type: a GraphQLScalarType to which value should be converted.
+        value: object that can be interpreted as being of expected_type.
+
+    Returns:
+        a value of the type produced by the parser of the expected type:
+            GraphQLDate: datetime.date
+            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
+            GraphQLFloat: float
+            GraphQLDecimal: decimal.Decimal
+            GraphQLInt: int
+            GraphQLString: str
+            GraphQLBoolean: bool
+            GraphQLID: str
+
+    Raises:
+        GraphQLInvalidArgumentError: if the argument value was not of the expected type.
+    """
+    # Explicitly disallow passing boolean values for non-boolean types.
+    if isinstance(value, bool) and not is_same_type(GraphQLBoolean, expected_type):
+        raise GraphQLInvalidArgumentError("")
+    try:
+        return convert_scalar_value_to_graphql_type(expected_type, value)
+    except (ValueError, TypeError) as e:
+        raise GraphQLInvalidArgumentError("Error parsing argument {}: {}".format(name, e))
+
+
+def deserialize_argument(name: str, expected_type: QueryArgumentGraphQLType, value: Any,) -> Any:
+    """Deserialize a serialized GraphQL argument.
+
+    Passing arguments via jsonrpc, or via the GUI of standard GraphQL editors is tricky because
+    json does not support certain types like Date, Datetime, Decimal, and also confuses floats
+    for integers if there are no decimals. This function takes in a value and converts it to a
+    standard python representation.
+
+    Below are examples of accepted encodings of all the types:
+        GraphQLDate: "2018-02-01"
+        GraphQLDateTime: "2018-02-01T05:11:54Z"
+        GraphQLFloat: 4.3, "5.0", 5
+        GraphQLDecimal: "5.00000000000000000000000000001"
+        GraphQLInt: 4, "3803330000000000000000000000000000000000000000000"
+        GraphQLString: "Hello"
+        GraphQLBoolean: True, 1, "1", "True", "true"
+        GraphQLID: "13d72846-1777-6c3a-5743-5d9ced3032ed"
+        GraphQLList(GraphQLInt): [1, 2, 3]
+
+    Args:
+        name: he name of the argument. It will be used to provide a more descriptive error
+              message if an error is raised.
+        expected_type: the GraphQL type. All GraphQLNonNull type wrappers are stripped.
+        value: object that can be interpreted as being of that type.
+
+    Returns:
+        a value of the type produced by the parser of the expected type:
+            GraphQLDate: datetime.date
+            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
+            GraphQLFloat: float
+            GraphQLDecimal: decimal.Decimal
+            GraphQLInt: int
+            GraphQLString: str
+            GraphQLBoolean: bool
+            GraphQLID: str
+            GraphQLList: list of the inner type
+
+    Raises:
+        GraphQLInvalidArgumentError: if the argument value was not of the expected type.
+    """
+    stripped_type = strip_non_null_from_type(expected_type)
+    if isinstance(stripped_type, GraphQLList):
+        if not isinstance(value, list):
+            raise GraphQLInvalidArgumentError(
+                f"Attempted to convert argument {name} to a GraphQLList, but {name} had a non-list "
+                f"value {value}."
+            )
+
+        inner_stripped_type = strip_non_null_from_type(stripped_type.of_type)
+
+        return [
+            deserialize_scalar_argument(name, inner_stripped_type, element) for element in value
+        ]
+    else:
+        return deserialize_scalar_argument(name, stripped_type, value)
+
+
+def deserialize_multiple_arguments(
+    arguments: Mapping[str, Any], expected_types: Mapping[str, QueryArgumentGraphQLType],
+) -> Dict[str, Any]:
+    """Deserialize serialized GraphQL arguments.
+
+    Passing arguments via jsonrpc, or via the GUI of standard GraphQL editors is tricky because
+    json does not support certain types like Date, Datetime, Decimal, and also confuses floats
+    for integers if there are no decimals. This function takes in values converts them to
+    standard python representations.
+
+    Below are examples of accepted json encodings of all the types:
+        GraphQLDate: "2018-02-01"
+        GraphQLDateTime: "2018-02-01T05:11:54Z"
+        GraphQLFloat: 4.3, "5.0", 5
+        GraphQLDecimal: "5.00000000000000000000000000001"
+        GraphQLInt: 4, "3803330000000000000000000000000000000000000000000"
+        GraphQLString: "Hello"
+        GraphQLBoolean: True, 1, "1", "True", "true"
+        GraphQLID: "13d72846-1777-6c3a-5743-5d9ced3032ed"
+        GraphQLList(GraphQLInt): [1, 2, 3]
+
+    Args:
+        arguments: mapping of argument names to serialized argument values.
+        expected_types: mapping of argument names to the expected GraphQL types. All
+                        GraphQLNonNull wrappers are stripped.
+
+    Returns:
+        a mapping of argument names to deserialized argument values. The type of the deserialized
+        argument value depends on the argument's GraphQL type:
+            GraphQLDate: datetime.date
+            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
+            GraphQLFloat: float
+            GraphQLDecimal: decimal.Decimal
+            GraphQLInt: int
+            GraphQLString: str
+            GraphQLBoolean: bool
+            GraphQLID: str
+            GraphQLList: list of the inner type
+
+    Raises:
+        GraphQLInvalidArgumentError: if any of the argument values was not of the expected type.
+    """
+    return {
+        name: deserialize_argument(name, expected_types[name], value)
+        for name, value in arguments.items()
+    }

--- a/graphql_compiler/post_processing/sql_post_processing.py
+++ b/graphql_compiler/post_processing/sql_post_processing.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence
 from graphql import GraphQLList, GraphQLScalarType
 
 from ..compiler.compiler_frontend import OutputMetadata
-from ..deserialization import convert_scalar_value_to_graphql_type
+from ..deserialization import deserialize_scalar_value
 
 
 def _mssql_xml_path_string_to_list(
@@ -80,9 +80,7 @@ def _mssql_xml_path_string_to_list(
 
     # Convert to the appropriate return type.
     list_result_to_return: List[Optional[Any]] = [
-        convert_scalar_value_to_graphql_type(list_entry_type, result)
-        if result is not None
-        else None
+        deserialize_scalar_value(list_entry_type, result) if result is not None else None
         for result in list_result
     ]
 

--- a/graphql_compiler/post_processing/sql_post_processing.py
+++ b/graphql_compiler/post_processing/sql_post_processing.py
@@ -6,12 +6,11 @@ from typing import Any, Dict, List, Optional, Sequence
 from graphql import GraphQLList, GraphQLScalarType
 
 from ..compiler.compiler_frontend import OutputMetadata
-
-from ..query_formatting.common import deserialize_json_argument
+from ..query_formatting.common import deserialize_anonymous_argument
 
 
 def _mssql_xml_path_string_to_list(
-    output_name: str, xml_path_result: str, list_entry_type: GraphQLScalarType
+    xml_path_result: str, list_entry_type: GraphQLScalarType
 ) -> List[Any]:
     """Convert the string result produced with XML PATH for MSSQL folds to a list.
 
@@ -80,12 +79,8 @@ def _mssql_xml_path_string_to_list(
     ]
 
     # Convert to the appropriate return type.
-    # list_result_to_return: List[Optional[Any]] = [
-    #     list_entry_type.parse_value(result) if result is not None else None
-    #     for result in list_result
-    # ]
     list_result_to_return: List[Optional[Any]] = [
-        deserialize_json_argument(output_name, list_entry_type, result) if result is not None else None
+        deserialize_anonymous_argument(list_entry_type, result) if result is not None else None
         for result in list_result
     ]
 
@@ -123,5 +118,5 @@ def post_process_mssql_folds(
         if metadata.folded and isinstance(metadata.type, GraphQLList):
             for query_result in query_results:
                 xml_path_result = query_result[out_name]
-                list_result = _mssql_xml_path_string_to_list(out_name, xml_path_result, metadata.type.of_type)
+                list_result = _mssql_xml_path_string_to_list(xml_path_result, metadata.type.of_type)
                 query_result[out_name] = list_result

--- a/graphql_compiler/post_processing/sql_post_processing.py
+++ b/graphql_compiler/post_processing/sql_post_processing.py
@@ -6,11 +6,11 @@ from typing import Any, Dict, List, Optional, Sequence
 from graphql import GraphQLList, GraphQLScalarType
 
 from ..compiler.compiler_frontend import OutputMetadata
-from ..query_formatting.common import deserialize_scalar_argument
+from ..deserialization import convert_scalar_value_to_graphql_type
 
 
 def _mssql_xml_path_string_to_list(
-    output_name: str, xml_path_result: str, list_entry_type: GraphQLScalarType
+    xml_path_result: str, list_entry_type: GraphQLScalarType
 ) -> List[Any]:
     """Convert the string result produced with XML PATH for MSSQL folds to a list.
 
@@ -80,7 +80,7 @@ def _mssql_xml_path_string_to_list(
 
     # Convert to the appropriate return type.
     list_result_to_return: List[Optional[Any]] = [
-        deserialize_scalar_argument(output_name, list_entry_type, result)
+        convert_scalar_value_to_graphql_type(list_entry_type, result)
         if result is not None
         else None
         for result in list_result
@@ -120,7 +120,5 @@ def post_process_mssql_folds(
         if metadata.folded and isinstance(metadata.type, GraphQLList):
             for query_result in query_results:
                 xml_path_result = query_result[out_name]
-                list_result = _mssql_xml_path_string_to_list(
-                    out_name, xml_path_result, metadata.type.of_type
-                )
+                list_result = _mssql_xml_path_string_to_list(xml_path_result, metadata.type.of_type)
                 query_result[out_name] = list_result

--- a/graphql_compiler/post_processing/sql_post_processing.py
+++ b/graphql_compiler/post_processing/sql_post_processing.py
@@ -81,7 +81,8 @@ def _mssql_xml_path_string_to_list(
     # Convert to the appropriate return type.
     list_result_to_return: List[Optional[Any]] = [
         deserialize_scalar_argument(output_name, list_entry_type, result)
-        if result is not None else None
+        if result is not None
+        else None
         for result in list_result
     ]
 
@@ -119,5 +120,7 @@ def post_process_mssql_folds(
         if metadata.folded and isinstance(metadata.type, GraphQLList):
             for query_result in query_results:
                 xml_path_result = query_result[out_name]
-                list_result = _mssql_xml_path_string_to_list(out_name, xml_path_result, metadata.type.of_type)
+                list_result = _mssql_xml_path_string_to_list(
+                    out_name, xml_path_result, metadata.type.of_type
+                )
                 query_result[out_name] = list_result

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -201,4 +201,5 @@ def deserialize_multiple_arguments(
         for name, value in arguments.items()
     }
 
+
 ######

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -187,7 +187,7 @@ def deserialize_argument(name: str, expected_type: QueryArgumentGraphQLType, val
     """Deserialize a GraphQL argument, raising a GraphQLInvalidArgumentError if invalid."""
     try:
         return deserialize_value(expected_type, value)
-    except (ValueError, TypeError, AssertionError) as e:
+    except (ValueError, TypeError) as e:
         raise GraphQLInvalidArgumentError(f"Error parsing argument {name}: {e}")
 
 
@@ -200,6 +200,5 @@ def deserialize_multiple_arguments(
         name: deserialize_argument(name, expected_types[name], value)
         for name, value in arguments.items()
     }
-
 
 ######

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -74,9 +74,9 @@ def _custom_boolean_deserialization(value: Any) -> bool:
         return False
     else:
         raise ValueError(
-                f"Received unexpected GraphQLBoolean value {value} ({type(value)}). Expected one "
-                f"of the following {true_values + false_values}."
-            )
+            f"Received unexpected GraphQLBoolean value {value} ({type(value)}). Expected one "
+            f"of the following {true_values + false_values}."
+        )
 
 
 _CUSTOM_SCALAR_DESERIALIZATION_FUNCTIONS: Mapping[str, Callable[[Any], Any]] = MappingProxyType(
@@ -112,14 +112,14 @@ _JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS: Mapping[
 ######
 
 
-def deserialize_scalar_argument(
-    name: str, expected_type: GraphQLScalarType, value: Any
-) -> Any:
+def deserialize_scalar_argument(name: str, expected_type: GraphQLScalarType, value: Any) -> Any:
     """Deserialize a serialized scalar argument. See docstring of deserialize_argument.
+
     Args:
         name: the name of the argument
         expected_type: GraphQL type we expect.
         value: object that can be interpreted as being of that type
+
     Returns:
         a value of the type produced by the parser of the expected type:
             GraphQLDate: datetime.date
@@ -130,6 +130,7 @@ def deserialize_scalar_argument(
             GraphQLString: str
             GraphQLBoolean: bool
             GraphQLID: str
+
     Raises:
         GraphQLInvalidArgumentError: if the argument value was not of the expected type.
     """
@@ -154,9 +155,7 @@ def deserialize_scalar_argument(
             raise GraphQLInvalidArgumentError("Error parsing argument {}: {}".format(name, e))
 
 
-def deserialize_argument(
-    name: str, expected_type: QueryArgumentGraphQLType, value: Any,
-) -> Any:
+def deserialize_argument(name: str, expected_type: QueryArgumentGraphQLType, value: Any,) -> Any:
     """Deserialize a serialized GraphQL argument.
 
     Passing arguments via jsonrpc, or via the GUI of standard GraphQL editors is tricky because
@@ -174,11 +173,13 @@ def deserialize_argument(
         GraphQLBoolean: True, 1, "1", "True", "true"
         GraphQLID: "13d72846-1777-6c3a-5743-5d9ced3032ed"
         GraphQLList(GraphQLInt): [1, 2, 3]
+
     Args:
         name: string, the name of the argument. It will be used to provide a more descriptive error
               message if an error is raised.
         expected_type: the GraphQL type. All GraphQLNonNull type wrappers are stripped.
         value: object that can be interpreted as being of that type
+
     Returns:
         a value of the type produced by the parser of the expected type:
             GraphQLDate: datetime.date
@@ -190,6 +191,7 @@ def deserialize_argument(
             GraphQLBoolean: bool
             GraphQLID: str
             GraphQLList: list of the inner type
+
     Raises:
         GraphQLInvalidArgumentError: if the argument value was not of the expected type.
     """
@@ -201,8 +203,7 @@ def deserialize_argument(
         inner_stripped_type = strip_non_null_from_type(stripped_type.of_type)
 
         return [
-            deserialize_scalar_argument(name, inner_stripped_type, element)
-            for element in value
+            deserialize_scalar_argument(name, inner_stripped_type, element) for element in value
         ]
     else:
         return deserialize_scalar_argument(name, stripped_type, value)
@@ -228,10 +229,12 @@ def deserialize_multiple_arguments(
         GraphQLBoolean: True, 1, "1", "True", "true"
         GraphQLID: "13d72846-1777-6c3a-5743-5d9ced3032ed"
         GraphQLList(GraphQLInt): [1, 2, 3]
+
     Args:
         arguments: mapping of argument names to serialized argument values.
         expected_types: mapping of argument names to the expected GraphQL types. All
                         GraphQLNonNull wrappers are stripped.
+
     Returns:
         a mapping of argument names to deserialized argument values. The type of the deserialized
         argument value depends on the argument's GraphQL type:
@@ -244,6 +247,7 @@ def deserialize_multiple_arguments(
             GraphQLBoolean: bool
             GraphQLID: str
             GraphQLList: list of the inner type
+
     Raises:
         GraphQLInvalidArgumentError: if any of the argument values was not of the expected type.
     """
@@ -256,9 +260,11 @@ def deserialize_multiple_arguments(
 
 def validate_argument_type(name: str, expected_type: QueryArgumentGraphQLType, value: Any):
     """Ensure the value has the expected type and is usable in any of our backends, or raise errors.
+
     Backends are the database languages we have the ability to compile to, like OrientDB MATCH,
     Gremlin, or SQLAlchemy. This function should be stricter than the validation done by any
     specific backend. That way code that passes validation can be compiled to any backend.
+
     Args:
         name: string, the name of the argument. It will be used to provide a more descriptive error
               message if an error is raised.
@@ -344,9 +350,11 @@ def validate_arguments(
     expected_types: Mapping[str, QueryArgumentGraphQLType], arguments: Mapping[str, Any]
 ) -> None:
     """Ensure that all arguments are provided and that they are of the expected type.
+
     Backends are the database languages we have the ability to compile to, like OrientDB MATCH,
     Gremlin, or SQLAlchemy. This function should be stricter than the validation done by any
     specific backend. That way code that passes validation can be compiled to any backend.
+
     Args:
         arguments: mapping of argument names to arguments values.
         expected_types: mapping of argument names to the expected GraphQL types. All GraphQLNonNull
@@ -359,9 +367,11 @@ def validate_arguments(
 
 def insert_arguments_into_query(compilation_result: CompilationResult, arguments: Dict[str, Any]):
     """Insert the arguments into the compiled GraphQL query to form a complete query.
+
     Args:
         compilation_result: a CompilationResult object derived from the GraphQL compiler
         arguments: dict, mapping argument name to its value, for every parameter the query expects.
+
     Returns:
         string, a query in the appropriate output language, with inserted argument data
     """

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -2,8 +2,7 @@
 """Safely insert runtime arguments into compiled GraphQL queries."""
 import datetime
 import decimal
-from types import MappingProxyType
-from typing import Any, Callable, Collection, Dict, Mapping, NoReturn, Tuple, Type
+from typing import Any, Collection, Dict, Mapping, NoReturn, Type
 
 import arrow
 from graphql import (
@@ -12,7 +11,6 @@ from graphql import (
     GraphQLID,
     GraphQLInt,
     GraphQLList,
-    GraphQLScalarType,
     GraphQLString,
     GraphQLType,
 )
@@ -27,8 +25,8 @@ from ..compiler import (
 )
 from ..compiler.helpers import strip_non_null_from_type
 from ..exceptions import GraphQLInvalidArgumentError
-from ..global_utils import assert_set_equality, is_same_type
-from ..schema import SUPPORTED_SCALAR_TYPES, GraphQLDate, GraphQLDateTime, GraphQLDecimal
+from ..global_utils import is_same_type
+from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from ..typedefs import QueryArgumentGraphQLType
 from .cypher_formatting import insert_arguments_into_cypher_query_redisgraph
 from .gremlin_formatting import insert_arguments_into_gremlin_query
@@ -46,216 +44,9 @@ def _raise_invalid_type_error(
     )
 
 
-_ALLOWED_JSON_SCALAR_TYPES: Mapping[str, Tuple[Type, ...]] = MappingProxyType(
-    {
-        GraphQLDate.name: (str,),
-        GraphQLDateTime.name: (str,),
-        GraphQLFloat.name: (str, float, int),
-        GraphQLDecimal.name: (str, float, int),
-        GraphQLInt.name: (int, str),
-        GraphQLString.name: (str,),
-        GraphQLBoolean.name: (bool, int, str),
-        GraphQLID.name: (int, str,),
-    }
-)
-assert_set_equality(
-    set(_ALLOWED_JSON_SCALAR_TYPES.keys()),
-    {graphql_type.name for graphql_type in SUPPORTED_SCALAR_TYPES},
-)
-
-
-def _custom_boolean_deserialization(value: Any) -> bool:
-    """Deserialize a boolean, allowing for common string or int representations."""
-    true_values = [1, "1", "true", "True", True]
-    false_values = [0, "0", "false", "False", False]
-    if value in true_values:
-        return True
-    elif value in false_values:
-        return False
-    else:
-        raise ValueError(
-            f"Received unexpected GraphQLBoolean value {value} ({type(value)}). Expected one "
-            f"of the following {true_values + false_values}."
-        )
-
-
-_CUSTOM_SCALAR_DESERIALIZATION_FUNCTIONS: Mapping[str, Callable[[Any], Any]] = MappingProxyType(
-    {
-        # Bypass the GraphQLFloat parser and allow strings as input. The JSON spec allows only
-        # for 64-bit floating point numbers, so large floats might have to be represented as
-        # strings.
-        GraphQLFloat.name: float,
-        # Bypass the GraphQLInt parser and allow long ints and strings as input. The JSON spec
-        # allows only for 64-bit floating point numbers, so large ints might have to be
-        # represented as strings.
-        GraphQLInt.name: int,
-        # Bypass the GraphQLBoolean parser and allow some strings and ints as input.
-        GraphQLBoolean.name: _custom_boolean_deserialization,
-    }
-)
-
-_JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS: Mapping[
-    str, Tuple[Tuple[Type, ...], Callable[[Any], Any]]
-] = MappingProxyType(
-    {
-        scalar_type.name: (
-            _ALLOWED_JSON_SCALAR_TYPES[scalar_type.name],
-            _CUSTOM_SCALAR_DESERIALIZATION_FUNCTIONS.get(scalar_type.name, scalar_type.parse_value),
-        )
-        for scalar_type in SUPPORTED_SCALAR_TYPES
-    }
-)
-
-
 ######
 # Public API
 ######
-
-
-def deserialize_scalar_argument(name: str, expected_type: GraphQLScalarType, value: Any) -> Any:
-    """Deserialize a serialized scalar argument. See docstring of deserialize_argument.
-
-    Args:
-        name: the name of the argument
-        expected_type: GraphQL type we expect.
-        value: object that can be interpreted as being of that type
-
-    Returns:
-        a value of the type produced by the parser of the expected type:
-            GraphQLDate: datetime.date
-            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
-            GraphQLFloat: float
-            GraphQLDecimal: decimal.Decimal
-            GraphQLInt: int
-            GraphQLString: str
-            GraphQLBoolean: bool
-            GraphQLID: str
-
-    Raises:
-        GraphQLInvalidArgumentError: if the argument value was not of the expected type.
-    """
-    types_and_deserialization = _JSON_TYPES_AND_DESERIALIZATION_FUNCTIONS.get(expected_type.name)
-    if types_and_deserialization is None:
-        raise AssertionError(
-            f"Got unsupported GraphQL type {expected_type} for argument {name} with value {value}."
-        )
-    else:
-        expected_python_types, deserialization_function = types_and_deserialization
-        if any(
-            (
-                not isinstance(value, expected_python_types),
-                # We explicitly disallow passing boolean values for non-boolean types
-                (isinstance(value, bool) and not is_same_type(GraphQLBoolean, expected_type)),
-            )
-        ):
-            _raise_invalid_type_error(name, expected_python_types, value)
-        try:
-            return deserialization_function(value)
-        except (ValueError, TypeError) as e:
-            raise GraphQLInvalidArgumentError("Error parsing argument {}: {}".format(name, e))
-
-
-def deserialize_argument(name: str, expected_type: QueryArgumentGraphQLType, value: Any,) -> Any:
-    """Deserialize a serialized GraphQL argument.
-
-    Passing arguments via jsonrpc, or via the GUI of standard GraphQL editors is tricky because
-    json does not support certain types like Date, Datetime, Decimal, and also confuses floats
-    for integers if there are no decimals. This function takes in a value and converts it to a
-    standard python representation.
-
-    Below are examples of accepted encodings of all the types:
-        GraphQLDate: "2018-02-01"
-        GraphQLDateTime: "2018-02-01T05:11:54Z"
-        GraphQLFloat: 4.3, "5.0", 5
-        GraphQLDecimal: "5.00000000000000000000000000001"
-        GraphQLInt: 4, "3803330000000000000000000000000000000000000000000"
-        GraphQLString: "Hello"
-        GraphQLBoolean: True, 1, "1", "True", "true"
-        GraphQLID: "13d72846-1777-6c3a-5743-5d9ced3032ed"
-        GraphQLList(GraphQLInt): [1, 2, 3]
-
-    Args:
-        name: string, the name of the argument. It will be used to provide a more descriptive error
-              message if an error is raised.
-        expected_type: the GraphQL type. All GraphQLNonNull type wrappers are stripped.
-        value: object that can be interpreted as being of that type
-
-    Returns:
-        a value of the type produced by the parser of the expected type:
-            GraphQLDate: datetime.date
-            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
-            GraphQLFloat: float
-            GraphQLDecimal: decimal.Decimal
-            GraphQLInt: int
-            GraphQLString: str
-            GraphQLBoolean: bool
-            GraphQLID: str
-            GraphQLList: list of the inner type
-
-    Raises:
-        GraphQLInvalidArgumentError: if the argument value was not of the expected type.
-    """
-    stripped_type = strip_non_null_from_type(expected_type)
-    if isinstance(stripped_type, GraphQLList):
-        if not isinstance(value, list):
-            _raise_invalid_type_error(name, (list,), value)
-
-        inner_stripped_type = strip_non_null_from_type(stripped_type.of_type)
-
-        return [
-            deserialize_scalar_argument(name, inner_stripped_type, element) for element in value
-        ]
-    else:
-        return deserialize_scalar_argument(name, stripped_type, value)
-
-
-def deserialize_multiple_arguments(
-    arguments: Mapping[str, Any], expected_types: Mapping[str, QueryArgumentGraphQLType],
-) -> Dict[str, Any]:
-    """Deserialize serialized GraphQL arguments.
-
-    Passing arguments via jsonrpc, or via the GUI of standard GraphQL editors is tricky because
-    json does not support certain types like Date, Datetime, Decimal, and also confuses floats
-    for integers if there are no decimals. This function takes in values converts them to
-    standard python representations.
-
-    Below are examples of accepted json encodings of all the types:
-        GraphQLDate: "2018-02-01"
-        GraphQLDateTime: "2018-02-01T05:11:54Z"
-        GraphQLFloat: 4.3, "5.0", 5
-        GraphQLDecimal: "5.00000000000000000000000000001"
-        GraphQLInt: 4, "3803330000000000000000000000000000000000000000000"
-        GraphQLString: "Hello"
-        GraphQLBoolean: True, 1, "1", "True", "true"
-        GraphQLID: "13d72846-1777-6c3a-5743-5d9ced3032ed"
-        GraphQLList(GraphQLInt): [1, 2, 3]
-
-    Args:
-        arguments: mapping of argument names to serialized argument values.
-        expected_types: mapping of argument names to the expected GraphQL types. All
-                        GraphQLNonNull wrappers are stripped.
-
-    Returns:
-        a mapping of argument names to deserialized argument values. The type of the deserialized
-        argument value depends on the argument's GraphQL type:
-            GraphQLDate: datetime.date
-            GraphQLDateTime: datetime.datetime with tzinfo=pytz.utc
-            GraphQLFloat: float
-            GraphQLDecimal: decimal.Decimal
-            GraphQLInt: int
-            GraphQLString: str
-            GraphQLBoolean: bool
-            GraphQLID: str
-            GraphQLList: list of the inner type
-
-    Raises:
-        GraphQLInvalidArgumentError: if any of the argument values was not of the expected type.
-    """
-    ensure_arguments_are_provided(expected_types, arguments)
-    return {
-        name: deserialize_argument(name, expected_types[name], value)
-        for name, value in arguments.items()
-    }
 
 
 def validate_argument_type(name: str, expected_type: QueryArgumentGraphQLType, value: Any):

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -19,10 +19,13 @@ import six
 
 from .. import graphql_to_gremlin, graphql_to_match
 from ..compiler import compile_graphql_to_gremlin, compile_graphql_to_match
-from ..deserialization import deserialize_argument, deserialize_multiple_arguments
 from ..exceptions import GraphQLInvalidArgumentError
 from ..query_formatting import insert_arguments_into_query
-from ..query_formatting.common import ensure_arguments_are_provided, validate_argument_type
+from ..query_formatting.common import (
+    deserialize_argument,
+    deserialize_multiple_arguments,
+    validate_argument_type,
+)
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal, GraphQLSchemaFieldType
 from ..schema.schema_info import CommonSchemaInfo
 from ..typedefs import QueryArgumentGraphQLType
@@ -345,7 +348,6 @@ class QueryFormattingTests(unittest.TestCase):
             "amount": 5,
             "birthday": datetime.date(2014, 2, 5),
         }
-        ensure_arguments_are_provided(expected_types, serialized_arguments)
         self.assertEqual(
             expected_deserialization,
             deserialize_multiple_arguments(serialized_arguments, expected_types),

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -18,8 +18,8 @@ import pytz
 import six
 
 from .. import graphql_to_gremlin, graphql_to_match
-from ..deserialization import deserialize_argument, deserialize_multiple_arguments
 from ..compiler import compile_graphql_to_gremlin, compile_graphql_to_match
+from ..deserialization import deserialize_argument, deserialize_multiple_arguments
 from ..exceptions import GraphQLInvalidArgumentError
 from ..query_formatting import insert_arguments_into_query
 from ..query_formatting.common import ensure_arguments_are_provided, validate_argument_type

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -18,14 +18,11 @@ import pytz
 import six
 
 from .. import graphql_to_gremlin, graphql_to_match
+from ..deserialization import deserialize_argument, deserialize_multiple_arguments
 from ..compiler import compile_graphql_to_gremlin, compile_graphql_to_match
 from ..exceptions import GraphQLInvalidArgumentError
 from ..query_formatting import insert_arguments_into_query
-from ..query_formatting.common import (
-    deserialize_argument,
-    deserialize_multiple_arguments,
-    validate_argument_type,
-)
+from ..query_formatting.common import ensure_arguments_are_provided, validate_argument_type
 from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal, GraphQLSchemaFieldType
 from ..schema.schema_info import CommonSchemaInfo
 from ..typedefs import QueryArgumentGraphQLType
@@ -348,6 +345,7 @@ class QueryFormattingTests(unittest.TestCase):
             "amount": 5,
             "birthday": datetime.date(2014, 2, 5),
         }
+        ensure_arguments_are_provided(expected_types, serialized_arguments)
         self.assertEqual(
             expected_deserialization,
             deserialize_multiple_arguments(serialized_arguments, expected_types),

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -393,24 +393,18 @@ class QueryFormattingTests(unittest.TestCase):
         self.assertEqual([], deserialize_argument("numbers", GraphQLList(GraphQLFloat), []))
 
         # With list with one element
-        self.assertEqual(
-            [1.2], deserialize_argument("numbers", GraphQLList(GraphQLFloat), [1.2])
-        )
+        self.assertEqual([1.2], deserialize_argument("numbers", GraphQLList(GraphQLFloat), [1.2]))
 
         # With outer null wrapper.
         self.assertEqual(
             [1.2, 2.3],
-            deserialize_argument(
-                "numbers", GraphQLNonNull(GraphQLList(GraphQLFloat)), [1.2, 2.3]
-            ),
+            deserialize_argument("numbers", GraphQLNonNull(GraphQLList(GraphQLFloat)), [1.2, 2.3]),
         )
 
         # With inner null wrapper.
         self.assertEqual(
             [1.2, 2.3],
-            deserialize_argument(
-                "numbers", GraphQLList(GraphQLNonNull(GraphQLFloat)), [1.2, 2.3]
-            ),
+            deserialize_argument("numbers", GraphQLList(GraphQLNonNull(GraphQLFloat)), [1.2, 2.3]),
         )
 
         # With outer and inner null wrapper.

--- a/graphql_compiler/tests/test_post_processing.py
+++ b/graphql_compiler/tests/test_post_processing.py
@@ -3,7 +3,7 @@ import datetime
 from unittest import TestCase
 
 from dateutil.tz import tzoffset, tzutc
-from graphql import GraphQLList, GraphQLString
+from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 
 from graphql_compiler import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 
@@ -39,7 +39,7 @@ class MssqlXmlPathTests(TestCase):
         post_process_mssql_folds(query_output, output_metadata)
         self.assertEqual(query_output, expected_result)
 
-    def test_convert_basic(self):
+    def test_convert_basic_string(self):
         """Test basic XML path encoding (only pipe separations) is correctly decoded.
 
         {
@@ -278,6 +278,118 @@ class MssqlXmlPathTests(TestCase):
                         2000, 2, 29, 13, 2, 27, 1835, tzinfo=tzutc()
                     ),  # with microsecond information
                     None,
+                ],
+            }
+        ]
+
+        post_process_mssql_folds(query_output, output_metadata)
+        self.assertEqual(query_output, expected_result)
+
+    def test_convert_basic_int(self):
+        """Test basic XML path encoding for datetimes is correctly decoded.
+
+        Example query for the given results:
+        {
+            Animal {
+                in_Animal_ParentOf @fold {
+                    int_field @output(out_name: "child_int_fields")
+                }
+            }
+        }"""
+        query_output = [{"child_names": "|1|~|100", }]
+        output_metadata = {
+            "child_names": OutputMetadata(
+                type=GraphQLList(GraphQLInt), optional=False, folded=True
+            ),
+        }
+
+        expected_result = [
+            {
+                "child_datetime_fields": [1, None, 100
+                ],
+            }
+        ]
+
+        post_process_mssql_folds(query_output, output_metadata)
+        self.assertEqual(query_output, expected_result)
+
+    def test_convert_basic_float(self):
+        """Test basic XML path encoding for datetimes is correctly decoded.
+
+        Example query for the given results:
+        {
+            Animal {
+                in_Animal_ParentOf @fold {
+                    int_field @output(out_name: "child_int_fields")
+                }
+            }
+        }"""
+        query_output = [{"child_names": "|1|~|100", }]
+        output_metadata = {
+            "child_names": OutputMetadata(
+                type=GraphQLList(GraphQLFloat), optional=False, folded=True
+            ),
+        }
+
+        expected_result = [
+            {
+                "child_datetime_fields": [1, None, 100
+                ],
+            }
+        ]
+
+        post_process_mssql_folds(query_output, output_metadata)
+        self.assertEqual(query_output, expected_result)
+
+    def test_convert_basic_bool(self):
+        """Test basic XML path encoding for datetimes is correctly decoded.
+
+        Example query for the given results:
+        {
+            Animal {
+                in_Animal_ParentOf @fold {
+                    int_field @output(out_name: "child_int_fields")
+                }
+            }
+        }"""
+        query_output = [{"child_bool_fields": "|~|True", }]
+        output_metadata = {
+            "child_bool_fields": OutputMetadata(
+                type=GraphQLList(GraphQLBoolean), optional=False, folded=True
+            ),
+        }
+
+        expected_result = [
+            {
+                "child_bool_fields": [1, None, 100
+                ],
+            }
+        ]
+
+        post_process_mssql_folds(query_output, output_metadata)
+        self.assertEqual(query_output, expected_result)
+
+    def test_convert_basic_id(self):
+        """Test basic XML path encoding for datetimes is correctly decoded.
+
+        Example query for the given results:
+        {
+            Animal {
+                in_Animal_ParentOf @fold {
+                    id_field @output(out_name: "child_id_fields")
+                }
+            }
+        }"""
+        query_output = [{"child_id_fields": "|1|~|100|uuids_can_be_strings_too", }]
+        output_metadata = {
+            "child_id_fields": OutputMetadata(
+                type=GraphQLList(GraphQLID), optional=False, folded=True
+            ),
+        }
+
+        expected_result = [
+            {
+                "child_id_fields": ["1", None, "100", "uuids_can_be_strings_too"
                 ],
             }
         ]

--- a/graphql_compiler/tests/test_post_processing.py
+++ b/graphql_compiler/tests/test_post_processing.py
@@ -295,20 +295,16 @@ class MssqlXmlPathTests(TestCase):
                     int_field @output(out_name: "child_int_fields")
                 }
             }
-        }"""
-        query_output = [{"child_names": "|1|~|100", }]
+        }
+        """
+        query_output = [{"child_int_fields": "|1|~|100",}]
         output_metadata = {
-            "child_names": OutputMetadata(
+            "child_int_fields": OutputMetadata(
                 type=GraphQLList(GraphQLInt), optional=False, folded=True
             ),
         }
 
-        expected_result = [
-            {
-                "child_datetime_fields": [1, None, 100
-                ],
-            }
-        ]
+        expected_result = [{"child_int_fields": [1, None, 100],}]
 
         post_process_mssql_folds(query_output, output_metadata)
         self.assertEqual(query_output, expected_result)
@@ -320,23 +316,19 @@ class MssqlXmlPathTests(TestCase):
         {
             Animal {
                 in_Animal_ParentOf @fold {
-                    int_field @output(out_name: "child_int_fields")
+                    float_field @output(out_name: "child_float_fields")
                 }
             }
-        }"""
-        query_output = [{"child_names": "|1|~|100", }]
+        }
+        """
+        query_output = [{"child_float_fields": "|1|~|100.12",}]
         output_metadata = {
-            "child_names": OutputMetadata(
+            "child_float_fields": OutputMetadata(
                 type=GraphQLList(GraphQLFloat), optional=False, folded=True
             ),
         }
 
-        expected_result = [
-            {
-                "child_datetime_fields": [1, None, 100
-                ],
-            }
-        ]
+        expected_result = [{"child_float_fields": [1.0, None, 100.12],}]
 
         post_process_mssql_folds(query_output, output_metadata)
         self.assertEqual(query_output, expected_result)
@@ -351,20 +343,16 @@ class MssqlXmlPathTests(TestCase):
                     int_field @output(out_name: "child_int_fields")
                 }
             }
-        }"""
-        query_output = [{"child_bool_fields": "|~|True", }]
+        }
+        """
+        query_output = [{"child_bool_fields": "|~|True|1|true|False|false|0",}]
         output_metadata = {
             "child_bool_fields": OutputMetadata(
                 type=GraphQLList(GraphQLBoolean), optional=False, folded=True
             ),
         }
 
-        expected_result = [
-            {
-                "child_bool_fields": [1, None, 100
-                ],
-            }
-        ]
+        expected_result = [{"child_bool_fields": [None, True, True, True, False, False, False],}]
 
         post_process_mssql_folds(query_output, output_metadata)
         self.assertEqual(query_output, expected_result)
@@ -379,8 +367,9 @@ class MssqlXmlPathTests(TestCase):
                     id_field @output(out_name: "child_id_fields")
                 }
             }
-        }"""
-        query_output = [{"child_id_fields": "|1|~|100|uuids_can_be_strings_too", }]
+        }
+        """
+        query_output = [{"child_id_fields": "|1|~|100|uuids_can_be_strings_too|10.1",}]
         output_metadata = {
             "child_id_fields": OutputMetadata(
                 type=GraphQLList(GraphQLID), optional=False, folded=True
@@ -388,10 +377,7 @@ class MssqlXmlPathTests(TestCase):
         }
 
         expected_result = [
-            {
-                "child_id_fields": ["1", None, "100", "uuids_can_be_strings_too"
-                ],
-            }
+            {"child_id_fields": ["1", None, "100", "uuids_can_be_strings_too", "10.1"],}
         ]
 
         post_process_mssql_folds(query_output, output_metadata)


### PR DESCRIPTION
Adding MSSQL fold postprocessing tests for all builtin graphQL scalar types.  

Fold postprocessing relies on converting from an XML PATH aggregated string. However, the GraphQLType `parse_value` function does not take in string representations for all types. For example, `"1"` would not be parsed to `1` using GraphQLInt's `parse_value`. 

Our json deserialization code already handled most of these types of conversions. I have refactored the json deserialization to be more generic, and have allowed more representations for booleans (such as `0`, `"True"`, `"true"`, and `"0"`).