### PR TITLE
Implement folded traversals for MSSQL

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -192,7 +192,7 @@ class SQLFoldTraversalDescriptor(NamedTuple):
     # appears on the left side of the join.
     from_table: Alias
 
-    # SQLAlchemy table corresponding to corresponding to the inside vertex of the traversal,
+    # SQLAlchemy table corresponding to the inside vertex of the traversal,
     # appears on the right side of the join.
     to_table: Alias
 

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -188,7 +188,7 @@ class SQLFoldTraversalDescriptor(NamedTuple):
     # DirectJoinDescriptor giving columns used to join from_table/to_table.
     join_descriptor: DirectJoinDescriptor
 
-    # SQLAlchemy table corresponding to corresponding to the outside vertex of the traversal,
+    # SQLAlchemy table corresponding to the outside vertex of the traversal,
     # appears on the left side of the join.
     from_table: Alias
 

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -226,7 +226,7 @@ def compile_xmlpath(element, compiler, **kw):
 
 
 def _construct_traversal_joins(traversals: List[SQLFoldTraversalDescriptor]) -> Join:
-    """Perform JOINs corresponding the described traversals.
+    """Perform JOINs corresponding to the described traversals.
 
     Args:
         traversals: list of at least 1 SQLFoldTraversalDescriptors in the order they were traversed,
@@ -237,7 +237,7 @@ def _construct_traversal_joins(traversals: List[SQLFoldTraversalDescriptor]) -> 
     """
     if len(traversals) == 0:
         raise AssertionError(
-            "Must pass at least 1 traversal in order to construct traversals JOINs. Received an "
+            "Must pass at least 1 traversal in order to construct traversal JOINs. Received an "
             "empty traversals list."
         )
     join_clause = traversals[0].from_table
@@ -504,7 +504,7 @@ class FoldSubqueryBuilder(object):
         - ENCODE is shorthand for a function composition which replaces '~' (null),
         '|' (list delimiter), '^' (escape) with '^n', '^d', '^e', respectively.
 
-        - Additional JOINs are optional and correspond to traversals inside the fold scope.
+        - JOINs are optional and correspond to traversals inside the fold scope.
 
         - VertexPrecedingOutput is the vertex immediately preceding the output vertex in the
         chain of traversals, beginning at the vertex immediately outside the fold.

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -531,6 +531,23 @@ class IntegrationTests(TestCase):
                 ],
                 [test_backend.MSSQL],
             ),
+            # Query 6: Traversal in a fold scope.
+            (
+                """
+            {
+                Animal {
+                    name @filter(op_name: "=", value: ["$starting_animal_name"])
+                    out_Animal_ParentOf @fold {
+                        out_Animal_ParentOf {
+                            name @output(out_name: "grandchild_names")
+                        }
+                    }
+                }
+            }""",
+                {"starting_animal_name": "Animal 1",},
+                [{"grandchild_names": ["Animal 1", "Animal 2", "Animal 3", "Animal 4"],},],
+                [],
+            ),
         ]
 
         for graphql_query, parameters, expected_results, excluded_backends in queries:

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -5847,8 +5847,32 @@ class CompilerTests(unittest.TestCase):
                     ))
             ])}
         """
-        # TODO: implement multiple traversals for MSSQL in a separate PR
-        expected_mssql = NotImplementedError
+        expected_mssql = """
+            SELECT
+                [Animal_1].name AS animal_name,
+                folded_subquery_1.fold_output_name AS sibling_and_self_names_list
+            FROM db_1.schema_1.[Animal] AS [Animal_1]
+            JOIN (
+                SELECT
+                    [Animal_2].uuid AS uuid,
+                    coalesce((
+                        SELECT
+                            '|' + coalesce(
+                                REPLACE(
+                                    REPLACE(
+                                        REPLACE([Animal_3].name, '^', '^e'),
+                                    '~', '^n'),
+                                '|', '^d'),
+                            '~')
+                        FROM db_1.schema_1.[Animal] AS [Animal_4]
+                        JOIN db_1.schema_1.[Animal] AS [Animal_3]
+                        ON [Animal_4].uuid = [Animal_3].parent
+                        WHERE [Animal_2].parent = [Animal_4].uuid
+                        FOR XML PATH ('')
+                    ), '') AS fold_output_name
+                FROM db_1.schema_1.[Animal] AS [Animal_2]) AS folded_subquery_1
+                ON [Animal_1].uuid = folded_subquery_1.uuid
+            """
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -5939,7 +5963,35 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         """
-        expected_mssql = NotImplementedError
+        expected_mssql = """
+            SELECT
+                [Animal_1].name AS animal_name,
+                folded_subquery_1.fold_output_name AS sibling_and_self_species_list
+            FROM db_1.schema_1.[Animal] AS [Animal_1]
+            JOIN (
+                SELECT
+                    [Animal_2].uuid AS uuid,
+                    coalesce((
+                        SELECT
+                            '|' + coalesce(
+                                REPLACE(
+                                    REPLACE(
+                                        REPLACE([Species_1].name, '^', '^e'),
+                                    '~', '^n'),
+                                '|', '^d'),
+                            '~')
+                        FROM db_1.schema_1.[Animal] AS [Animal_3]
+                        JOIN db_1.schema_1.[Animal] AS [Animal_4]
+                        ON [Animal_3].uuid = [Animal_4].parent
+                        JOIN db_1.schema_1.[Species] AS [Species_1]
+                        ON [Animal_4].species = [Species_1].uuid
+                        WHERE [Animal_2].parent = [Animal_3].uuid
+                        FOR XML PATH ('')
+                    ), '') AS fold_output_name
+                FROM db_1.schema_1.[Animal] AS [Animal_2]
+            ) AS folded_subquery_1
+            ON [Animal_1].uuid = folded_subquery_1.uuid
+        """
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -6042,7 +6094,34 @@ class CompilerTests(unittest.TestCase):
                     ))
             ])}
         """
-        expected_mssql = NotImplementedError
+        expected_mssql = """
+            SELECT
+                [Animal_1].name AS animal_name,
+                folded_subquery_1.fold_output_name AS sibling_and_self_species_list
+            FROM db_1.schema_1.[Animal] AS [Animal_1]
+            JOIN db_1.schema_1.[Animal] AS [Animal_2]
+            ON [Animal_1].parent = [Animal_2].uuid
+            JOIN (
+                SELECT
+                    [Animal_3].uuid AS uuid,
+                    coalesce((
+                        SELECT
+                            '|' + coalesce(
+                                REPLACE(
+                                    REPLACE(
+                                        REPLACE([Species_1].name, '^', '^e'),
+                                    '~', '^n'),
+                                '|', '^d'),
+                            '~')
+                        FROM db_1.schema_1.[Animal] AS [Animal_4]
+                        JOIN db_1.schema_1.[Species] AS [Species_1]
+                        ON [Animal_4].species = [Species_1].uuid
+                        WHERE [Animal_3].uuid = [Animal_4].parent
+                        FOR XML PATH ('')
+                    ), '') AS fold_output_name
+                FROM db_1.schema_1.[Animal] AS [Animal_3]
+            ) AS folded_subquery_1 ON [Animal_2].uuid = folded_subquery_1.uuid
+        """
         expected_cypher = """
             MATCH (Animal___1:Animal)
             MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -9945,7 +10024,39 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         """
-        expected_mssql = NotImplementedError
+        expected_mssql = """
+            SELECT
+                [Animal_1].name AS animal_name,
+                folded_subquery_1.fold_output_name AS grandchild_names_list,
+                [Animal_2].name AS grandparent_name
+            FROM db_1.schema_1.[Animal] AS [Animal_1]
+            LEFT OUTER JOIN db_1.schema_1.[Animal] AS [Animal_3]
+            ON [Animal_1].parent = [Animal_3].uuid
+            LEFT OUTER JOIN db_1.schema_1.[Animal] AS [Animal_2]
+            ON [Animal_3].parent = [Animal_2].uuid
+            JOIN (
+                SELECT
+                    [Animal_4].uuid AS uuid,
+                    coalesce((
+                        SELECT
+                            '|' + coalesce(
+                                REPLACE(
+                                    REPLACE(
+                                        REPLACE([Animal_5].name, '^', '^e'),
+                                    '~', '^n'),
+                                '|', '^d'),
+                            '~')
+                        FROM db_1.schema_1.[Animal] AS [Animal_6]
+                        JOIN db_1.schema_1.[Animal] AS [Animal_5]
+                        ON [Animal_6].uuid = [Animal_5].parent
+                        WHERE [Animal_4].uuid = [Animal_6].parent
+                        FOR XML PATH ('')
+                    ), '') AS fold_output_name
+                FROM db_1.schema_1.[Animal] AS [Animal_4]
+            ) AS folded_subquery_1
+            ON [Animal_1].uuid = folded_subquery_1.uuid
+            WHERE [Animal_2].uuid IS NOT NULL OR [Animal_3].uuid IS NULL
+        """
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)
@@ -10081,7 +10192,39 @@ class CompilerTests(unittest.TestCase):
                 )
             ])}
         """
-        expected_mssql = NotImplementedError
+        expected_mssql = """
+            SELECT
+                [Animal_1].name AS animal_name,
+                folded_subquery_1.fold_output_name AS grandchild_names_list,
+                [Animal_2].name AS grandparent_name
+            FROM db_1.schema_1.[Animal] AS [Animal_1]
+            JOIN (
+                SELECT
+                    [Animal_3].uuid AS uuid,
+                    coalesce((
+                        SELECT
+                            '|' + coalesce(
+                                REPLACE(
+                                    REPLACE(
+                                        REPLACE([Animal_4].name, '^', '^e'),
+                                    '~', '^n'),
+                                '|', '^d'),
+                            '~')
+                        FROM db_1.schema_1.[Animal] AS [Animal_5]
+                        JOIN db_1.schema_1.[Animal] AS [Animal_4]
+                        ON [Animal_5].uuid = [Animal_4].parent
+                        WHERE [Animal_3].uuid = [Animal_5].parent
+                        FOR XML PATH ('')
+                    ), '') AS fold_output_name
+                FROM db_1.schema_1.[Animal] AS [Animal_3]
+            ) AS folded_subquery_1
+            ON [Animal_1].uuid = folded_subquery_1.uuid
+            LEFT OUTER JOIN db_1.schema_1.[Animal] AS [Animal_6]
+            ON [Animal_1].parent = [Animal_6].uuid
+            LEFT OUTER JOIN db_1.schema_1.[Animal] AS [Animal_2]
+            ON [Animal_6].parent = [Animal_2].uuid
+            WHERE [Animal_2].uuid IS NOT NULL OR [Animal_6].uuid IS NULL
+"""
         expected_cypher = """
             MATCH (Animal___1:Animal)
             OPTIONAL MATCH (Animal___1)<-[:Animal_ParentOf]-(Animal__in_Animal_ParentOf___1:Animal)


### PR DESCRIPTION
This PR implements folded traversals for the MSSQL backends. A new integration test for folded traversals has been added, and all relevant `test_compiler` tests have been updated.