### PR TITLE
_x_count Error Messaging and Test Updates

### DIFF
--- a/graphql_compiler/compiler/expressions.py
+++ b/graphql_compiler/compiler/expressions.py
@@ -923,7 +923,7 @@ class FoldedContextField(Expression):
         template = "[x IN {mark_name} | x.{field_name}]"
 
         if field_name == COUNT_META_FIELD_NAME:
-            raise NotImplementedError()
+            raise NotImplementedError("_x_count is not implemented in the Cypher backend.")
 
         return template.format(mark_name=mark_name, field_name=field_name)
 
@@ -1038,11 +1038,11 @@ class FoldCountContextField(Expression):
 
     def to_gremlin(self) -> str:
         """Not supported yet."""
-        raise NotImplementedError()
+        raise NotImplementedError("_x_count is not implemented in the Gremlin backend")
 
     def to_cypher(self) -> str:
         """Not supported yet."""
-        raise NotImplementedError()
+        raise NotImplementedError("_x_count is not implemented in the Cypher backend.")
 
     def to_sql(self, dialect: Any, aliases: AliasesDictType, current_alias: AliasType) -> Any:
         """Return a SQLAlchemy column of a coalesced COUNT(*) from a folded subquery."""
@@ -1187,7 +1187,7 @@ class UnaryTransformation(Expression):
 
     def to_cypher(self) -> str:
         """Not implemented yet."""
-        raise NotImplementedError()
+        raise NotImplementedError("Unary operators are not implemented in the Cypher backend.")
 
     def to_sql(self, dialect: Any, aliases: AliasesDictType, current_alias: AliasType) -> Any:
         """Not implemented yet."""

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -531,6 +531,27 @@ class IntegrationTests(TestCase):
                 ],
                 [test_backend.MSSQL],
             ),
+            # Query 6: _x_count.
+            (
+                """
+            {
+                Animal {
+                    name @filter(op_name: "=", value: ["$starting_animal_name"])
+                    out_Animal_ParentOf @fold {
+                        name @output(out_name: "child_names")
+                        _x_count @output(out_name: "child_count")
+                    }
+                }
+            }""",
+                {"starting_animal_name": "Animal 1", },
+                [
+                    {
+                        "child_names": ["Animal 1", "Animal 2", "Animal 3"],
+                        "child_count": 3,
+                    },
+                ],
+                [test_backend.MSSQL, test_backend.NEO4J],
+            ),
         ]
 
         for graphql_query, parameters, expected_results, excluded_backends in queries:

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -543,13 +543,8 @@ class IntegrationTests(TestCase):
                     }
                 }
             }""",
-                {"starting_animal_name": "Animal 1", },
-                [
-                    {
-                        "child_names": ["Animal 1", "Animal 2", "Animal 3"],
-                        "child_count": 3,
-                    },
-                ],
+                {"starting_animal_name": "Animal 1",},
+                [{"child_names": ["Animal 1", "Animal 2", "Animal 3"], "child_count": 3,},],
                 [test_backend.MSSQL, test_backend.NEO4J],
             ),
         ]

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -1186,7 +1186,7 @@ class CompilerTests(unittest.TestCase):
         """
         expected_gremlin = NotImplementedError
         expected_mssql = NotImplementedError
-        expected_cypher = SKIP_TEST
+        expected_cypher = NotImplementedError
         expected_postgresql = """
             SELECT
                 "Species_1".name AS species_name
@@ -7381,7 +7381,7 @@ class CompilerTests(unittest.TestCase):
               ON "Animal_1".uuid = folded_subquery_1.uuid
               """
 
-        expected_cypher = SKIP_TEST  # _x_count not implemented for Cypher
+        expected_cypher = NotImplementedError
 
         check_test_data(
             self,
@@ -7435,7 +7435,7 @@ class CompilerTests(unittest.TestCase):
             WHERE folded_subquery_1.fold_output__x_count >= %(min_children)s
         """
 
-        expected_cypher = SKIP_TEST  # _x_count not implemented for Cypher
+        expected_cypher = NotImplementedError
 
         check_test_data(
             self,
@@ -7677,7 +7677,7 @@ class CompilerTests(unittest.TestCase):
         """
         expected_gremlin = NotImplementedError
         expected_sql = NotImplementedError
-        expected_cypher = SKIP_TEST  # _x_count not implemented for Cypher
+        expected_cypher = NotImplementedError
 
         check_test_data(
             self,
@@ -7743,7 +7743,7 @@ class CompilerTests(unittest.TestCase):
                 folded_subquery_1.fold_output__x_count >= %(min_children)s AND
                 folded_subquery_2.fold_output__x_count >= %(min_related)s
         """
-        expected_cypher = SKIP_TEST
+        expected_cypher = NotImplementedError
 
         check_test_data(
             self,
@@ -7776,7 +7776,7 @@ class CompilerTests(unittest.TestCase):
         """
         expected_gremlin = NotImplementedError
         expected_mssql = NotImplementedError
-        expected_cypher = SKIP_TEST
+        expected_cypher = NotImplementedError
         expected_postgresql = """
             SELECT
                 "Species_1".name AS name


### PR DESCRIPTION
 - Added an integration test for `_x_count`
- Updated error messaging for some `NotImplementedError`s in `compiler/expressions.py`
- Switched cypher's `SKIP_TEST` to `NotImplementedError` for `_x_count` compiler tests since we should ensure that the compiler correctly raises an error rather that just skipping the test

 Not sure when we prefer to use `SKIP_TEST` rather than `NotImplementedError` or a compiled query, but we have quite a few instances of `SKIP_TEST`. I suspect a number of them could be changed to `NotImplementedError` or a compiled query if that is desirable.