### PR TITLE
Allow undefined variables for virtualenv check in lint script.

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,11 +29,13 @@ done
 cd "$(git -C "$(dirname "${0}")" rev-parse --show-toplevel )"
 
 # Assert script is running inside pipenv shell
+set +u
 if [[ "$VIRTUAL_ENV" == "" ]]
 then
     echo "Please run pipenv shell first"
     exit 1
 fi
+set -u
 
 # Get all python files or directories that need to be linted.
 lintable_locations="."


### PR DESCRIPTION
The fact that `set -u` was set meant that referencing the virtualenv variable with it undefined would immediately fail, and not produce the intended error message.

To fix, disable the `set -u` option just for that block of code.