### PR TITLE
Schema rename suppress types

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -1,20 +1,22 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from collections import namedtuple
-from typing import Optional, Dict
+from typing import Dict, Optional
 
-from graphql import build_ast_schema, DocumentNode
-from graphql.language.visitor import Visitor, visit, REMOVE
+from graphql import DocumentNode, build_ast_schema
+from graphql.language.visitor import REMOVE, Visitor, visit
 import six
 
+from ..ast_manipulation import get_ast_with_non_null_and_list_stripped
 from .utils import (
+    CascadingSuppressionError,
     SchemaNameConflictError,
     check_ast_schema_is_valid,
     check_type_name_is_valid,
     get_copy_of_node_with_new_name,
     get_query_type_name,
-    get_scalar_names, CascadingSuppressionError,
+    get_scalar_names,
 )
-from ..ast_manipulation import get_ast_with_non_null_and_list_stripped
+
 
 RenamedSchemaDescriptor = namedtuple(
     "RenamedSchemaDescriptor",
@@ -27,7 +29,9 @@ RenamedSchemaDescriptor = namedtuple(
 )
 
 
-def rename_schema(ast: DocumentNode, renamings: Dict[str, Optional[str]]) -> RenamedSchemaDescriptor:
+def rename_schema(
+    ast: DocumentNode, renamings: Dict[str, Optional[str]]
+) -> RenamedSchemaDescriptor:
     """Create a RenamedSchemaDescriptor; types and query type fields are renamed using renamings.
 
     Any type, interface, enum, or fields of the root type/query type whose name
@@ -75,6 +79,7 @@ def rename_schema(ast: DocumentNode, renamings: Dict[str, Optional[str]]) -> Ren
 
     # Rename query type fields
     from graphql.language.printer import print_ast
+
     ast = _rename_fields(ast, renamings, query_type)
     return RenamedSchemaDescriptor(
         schema_ast=ast,

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -57,6 +57,13 @@ class InvalidCrossSchemaEdgeError(SchemaTransformError):
     """
 
 
+class CascadingSuppressionError(SchemaTransformError):
+    """Raised if the schema suppressions would result in empty types that would need to be, in turn, suppressed (possibly leading to a cascade of suppressions).
+
+    This may be raised if all the fields of a type are suppressed but the type itself is not suppressed, if all the members of a union are suppressed but the union itself is not suppressed, or if a type is suppressed but a field of that type is not suppressed.
+    """
+
+
 _alphanumeric_and_underscore = frozenset(six.text_type(string.ascii_letters + string.digits + "_"))
 
 

--- a/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
+++ b/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
@@ -202,8 +202,13 @@ class InputSchemaStrings(object):
           friend: Dog!
         }
 
+        type Cat {
+            id: String
+        }
+
         type SchemaQuery {
           Dog: Dog!
+          Cat: Cat
         }
     """
     )
@@ -368,6 +373,29 @@ class InputSchemaStrings(object):
         type SchemaQuery {
           Person: Person
           Kid: Kid
+        }
+    """
+    )
+
+    multiple_fields_schema = dedent(
+        """\
+        schema {
+          query: SchemaQuery
+        }
+
+        type Human  {
+          id: String
+          name: String
+          pet: Dog
+        }
+
+        type Dog {
+          nickname: String
+        }
+
+        type SchemaQuery {
+          Human: Human
+          Dog: Dog
         }
     """
     )

--- a/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
+++ b/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
@@ -160,6 +160,34 @@ class InputSchemaStrings(object):
     """
     )
 
+    extended_union_schema = dedent(
+        """\
+        schema {
+          query: SchemaQuery
+        }
+
+        type Human {
+          id: String
+        }
+
+        type Droid {
+          id: String
+        }
+        
+        type Dog {
+          nickname: String
+        }
+        
+        union HumanOrDroid = Human | Droid
+
+        type SchemaQuery {
+          Human: Human
+          Droid: Droid
+          Dog: Dog
+        }
+    """
+    )
+
     list_schema = dedent(
         """\
         schema {

--- a/graphql_compiler/tests/schema_transformation_tests/test_merge_schemas.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_merge_schemas.py
@@ -88,6 +88,7 @@ class TestMergeSchemasNoCrossSchemaEdges(unittest.TestCase):
               Character: Character
               Kid: Kid
               Dog: Dog!
+              Cat: Cat
             }
 
             directive @stitch(source_field: String!, sink_field: String!) on FIELD_DEFINITION
@@ -116,6 +117,10 @@ class TestMergeSchemasNoCrossSchemaEdges(unittest.TestCase):
             type Dog {
               id: String!
               friend: Dog!
+            }
+
+            type Cat {
+              id: String
             }
         """
         )

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -8,7 +8,11 @@ from graphql.language.visitor import QUERY_DOCUMENT_KEYS
 from graphql.pyutils import snake_to_camel
 
 from ...schema_transformation.rename_schema import RenameSchemaTypesVisitor, rename_schema
-from ...schema_transformation.utils import InvalidTypeNameError, SchemaNameConflictError, CascadingSuppressionError
+from ...schema_transformation.utils import (
+    CascadingSuppressionError,
+    InvalidTypeNameError,
+    SchemaNameConflictError,
+)
 from .input_schema_strings import InputSchemaStrings as ISS
 
 
@@ -352,14 +356,11 @@ class TestRenameSchema(unittest.TestCase):
         )
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual(
-            {"NewDroid": "Droid"},
-            renamed_schema.reverse_name_map,
+            {"NewDroid": "Droid"}, renamed_schema.reverse_name_map,
         )
 
     def test_union_member_suppress(self):
-        renamed_schema = rename_schema(
-            parse(ISS.union_schema), {"Droid": None}
-        )
+        renamed_schema = rename_schema(parse(ISS.union_schema), {"Droid": None})
         renamed_schema_string = dedent(
             """\
             schema {
@@ -379,8 +380,7 @@ class TestRenameSchema(unittest.TestCase):
         )
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual(
-            {},
-            renamed_schema.reverse_name_map,
+            {}, renamed_schema.reverse_name_map,
         )
 
     def test_list_rename(self):
@@ -693,7 +693,9 @@ class TestRenameSchema(unittest.TestCase):
 
     def test_field_still_depends_on_suppressed_type(self):
         with self.assertRaises(CascadingSuppressionError):
-            rename_schema(parse(ISS.multiple_fields_schema), {"Dog": None})  # a field in Human is of type Dog.
+            rename_schema(
+                parse(ISS.multiple_fields_schema), {"Dog": None}
+            )  # a field in Human is of type Dog.
 
     def test_field_in_list_still_depends_on_suppressed_type(self):
         with self.assertRaises(CascadingSuppressionError):


### PR DESCRIPTION
First part of the implementation described in pull request #828 and issue #810, covering just 1-0 renaming for types (aka suppressing types). I'm going to read over the changes here first and then when it's ready, I'll mark it as ready for review