### PR TITLE
Pin pipenv version to 2018.11.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_install:
   - sudo ACCEPT_EULA=Y apt-get install msodbcsql17
 install:
   - pip install --upgrade pip
-  - pip install --upgrade setuptools pipenv
+  # The pipenv install --deploy --system command has a bug in the latest release.
+  - pip install pipenv==2018.11.26
+  - pip install --upgrade setuptools
   - pipenv install --dev --deploy --system
   - pipenv install --system --skip-lock -e .
 matrix:


### PR DESCRIPTION
The latest pipenv --deploy --system command has a bug in the latest release. So we pin the version to the previous one. I will submit an pipenv issue soon.