### PR TITLE
Split FoldSubqueryBuilder's visit_vertex into add_traversal and mark_output_location

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -591,7 +591,7 @@ class FoldSubqueryBuilder(object):
             SQLFoldTraversalDescriptor(join_descriptor, from_table, to_table)
         )
 
-    def mark_output_location(self, output_table: Alias, output_table_location: FoldScopeLocation):
+    def mark_output_location(self, output_table: Alias, output_table_location: FoldScopeLocation) -> None:
         """Mark the location of the output vertex."""
         if self._ended:
             raise AssertionError(

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -591,7 +591,9 @@ class FoldSubqueryBuilder(object):
             SQLFoldTraversalDescriptor(join_descriptor, from_table, to_table)
         )
 
-    def mark_output_location(self, output_table: Alias, output_table_location: FoldScopeLocation) -> None:
+    def mark_output_location(
+        self, output_table: Alias, output_table_location: FoldScopeLocation
+    ) -> None:
         """Mark the location of the output vertex."""
         if self._ended:
             raise AssertionError(

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -187,7 +187,7 @@ def _get_output_fields_at_fold_location(
     all_folded_fields: Dict[FoldPath, Set[FoldScopeLocation]],
 ) -> Set[str]:
     """Collect output field names for the specified output_fold_scope_location."""
-    # If the location does not have any outputs, return an empty set.git
+    # If the location does not have any outputs, return an empty set.
     if output_fold_scope_location.fold_path not in all_folded_fields:
         return set()
     folded_fields = set()

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -713,10 +713,8 @@ class EmitSQLTests(unittest.TestCase):
 
         builder = emit_sql.FoldSubqueryBuilder(dialect, from_alias, "uuid")
         builder.add_traversal(join_descriptor, from_alias, to_alias)
-        builder.mark_output_location(to_alias, fold_scope_location)
-        subquery, output_location = builder.end_fold(
-            {fold_scope_location.fold_path: {fold_scope_location.navigate_to_field("name")}}
-        )
+        builder.mark_output_location_and_fields(to_alias, fold_scope_location, {"name"})
+        subquery, output_location = builder.end_fold()
 
         expected_mssql = """
             SELECT

--- a/graphql_compiler/tests/test_emit_output.py
+++ b/graphql_compiler/tests/test_emit_output.py
@@ -712,14 +712,11 @@ class EmitSQLTests(unittest.TestCase):
         fold_scope_location = Location(("Animal",)).navigate_to_fold("out_Animal_ParentOf")
 
         builder = emit_sql.FoldSubqueryBuilder(dialect, from_alias, "uuid")
-        builder.visit_vertex(
-            join_descriptor,
-            from_alias,
-            to_alias,
-            fold_scope_location,
-            {fold_scope_location.fold_path: {fold_scope_location.navigate_to_field("name")}},
+        builder.add_traversal(join_descriptor, from_alias, to_alias)
+        builder.mark_output_location(to_alias, fold_scope_location)
+        subquery, output_location = builder.end_fold(
+            {fold_scope_location.fold_path: {fold_scope_location.navigate_to_field("name")}}
         )
-        subquery, output_location = builder.end_fold()
 
         expected_mssql = """
             SELECT


### PR DESCRIPTION
`visit_vertex` performed both a traversal and a check for outputs at the traversed location. This PR splits these functions up into `add_traversal` and `mark_output_location`. The construction of the outputs is moved to `end_fold` where the outputs are constructed based on the marked `_output_vertex_location`. 

Decoupling traversals and outputs will make adding MSSQL filters easier. `Filter` blocks in the IR occur after the `Traverse` blocks. However, filters are needed to construct `XML PATH`-based array aggregation. When outputting during a traversal, all the information about filters has not yet been added to the `FoldSubqueryBuilder`. By moving output construct to the `end_fold` (`Unfold` IR block), we ensure that all necessary information for outputting has been collected (output location, filters, and traversals).