### PR TITLE
Type hint batch: compiler/ir_lowering_common/

### DIFF
--- a/graphql_compiler/compiler/ir_lowering_common/common.py
+++ b/graphql_compiler/compiler/ir_lowering_common/common.py
@@ -1,9 +1,9 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Language-independent IR lowering and optimization functions."""
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
-from typing_extensions import TypedDict
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import six
+from typing_extensions import TypedDict
 
 from ...compiler.compiler_entities import BasicBlockT
 from ..blocks import (
@@ -28,7 +28,7 @@ from ..expressions import (
     TernaryConditional,
     TrueLiteral,
 )
-from ..helpers import BaseLocation, FoldScopeLocation, LocationT, validate_safe_string
+from ..helpers import BaseLocation, FoldScopeLocation, validate_safe_string
 from ..metadata import QueryMetadataTable
 
 
@@ -194,9 +194,9 @@ def optimize_boolean_expression_comparisons(ir_blocks: List[BasicBlock]) -> List
         elif expression.right == identity_literal and left_is_binary_composition:
             return expression.left
         elif expression.left == inverse_literal and right_is_binary_composition:
-            expression_to_rewrite = expression.right  # type: ignore
+            expression_to_rewrite = cast(BinaryComposition, expression.right)
         elif expression.right == inverse_literal and left_is_binary_composition:
-            expression_to_rewrite = expression.left  # type: ignore
+            expression_to_rewrite = cast(BinaryComposition, expression.left)
 
         if expression_to_rewrite is None:
             # We couldn't find anything to rewrite, return the expression as-is.
@@ -222,8 +222,7 @@ def optimize_boolean_expression_comparisons(ir_blocks: List[BasicBlock]) -> List
 def extract_folds_from_ir_blocks(
     ir_blocks: List[BasicBlock],
 ) -> Tuple[
-    Dict[FoldScopeLocation, List[BasicBlock]],
-    List[BasicBlock],
+    Dict[FoldScopeLocation, List[BasicBlock]], List[BasicBlock],
 ]:
     """Extract all @fold data from the IR blocks, and cut the folded IR blocks out of the IR.
 
@@ -343,11 +342,7 @@ def extract_optional_location_root_info(
 
 
 SimpleOptionalLocationInfo = TypedDict(
-    "SimpleOptionalLocationInfo",
-    {
-        "inner_location": BaseLocation,
-        "edge_field": str,
-    }
+    "SimpleOptionalLocationInfo", {"inner_location": BaseLocation, "edge_field": str,}
 )
 
 

--- a/graphql_compiler/compiler/ir_lowering_common/common.py
+++ b/graphql_compiler/compiler/ir_lowering_common/common.py
@@ -163,8 +163,8 @@ def optimize_boolean_expression_comparisons(ir_blocks: List[BasicBlock]) -> List
         if not isinstance(expression, BinaryComposition):
             return expression
 
-        left_is_binary_composition = isinstance(expression.left, BinaryComposition)
-        right_is_binary_composition = isinstance(expression.right, BinaryComposition)
+        left_is_binary_composition: Optional[BinaryComposition] = expression.left if isinstance(expression.left, BinaryComposition) else None
+        right_is_binary_composition: Optional[BinaryComposition] = expression.right if isinstance(expression.right, BinaryComposition) else None
 
         if not left_is_binary_composition and not right_is_binary_composition:
             # Nothing to rewrite, return the expression as-is.
@@ -194,9 +194,9 @@ def optimize_boolean_expression_comparisons(ir_blocks: List[BasicBlock]) -> List
         elif expression.right == identity_literal and left_is_binary_composition:
             return expression.left
         elif expression.left == inverse_literal and right_is_binary_composition:
-            expression_to_rewrite = cast(BinaryComposition, expression.right)
+            expression_to_rewrite = right_is_binary_composition
         elif expression.right == inverse_literal and left_is_binary_composition:
-            expression_to_rewrite = cast(BinaryComposition, expression.left)
+            expression_to_rewrite = left_is_binary_composition
 
         if expression_to_rewrite is None:
             # We couldn't find anything to rewrite, return the expression as-is.

--- a/graphql_compiler/compiler/ir_lowering_common/common.py
+++ b/graphql_compiler/compiler/ir_lowering_common/common.py
@@ -1,6 +1,6 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 """Language-independent IR lowering and optimization functions."""
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple
 
 import six
 from typing_extensions import TypedDict
@@ -186,13 +186,6 @@ def optimize_boolean_expression_comparisons(ir_blocks: List[BasicBlock]) -> List
             return expression
 
         expression_to_rewrite: Optional[BinaryComposition] = None
-        # N.B. cast statements occur in the last 2 elif statements because of the following:
-        # ```
-        # Incompatible types in assignment (expression has type "Expression", variable has type
-        # "Optional[BinaryComposition]")
-        # ```
-        # Given the logic at the time of writing this comment, we know that
-        # `right_is_binary_composition` says that right is BinaryComposition, not just Expression
         if expression.left == identity_literal and right_is_binary_composition:
             return expression.right
         elif expression.right == identity_literal and left_is_binary_composition:

--- a/graphql_compiler/compiler/ir_lowering_common/common.py
+++ b/graphql_compiler/compiler/ir_lowering_common/common.py
@@ -82,7 +82,7 @@ def lower_context_field_existence(
 ) -> List[BasicBlock]:
     """Lower ContextFieldExistence expressions into lower-level expressions."""
 
-    def regular_visitor_fn(expression: Any) -> Any:
+    def regular_visitor_fn(expression: Expression) -> Expression:
         """Expression visitor function that rewrites ContextFieldExistence expressions."""
         if not isinstance(expression, ContextFieldExistence):
             return expression
@@ -125,7 +125,7 @@ def short_circuit_ternary_conditionals(
 ) -> List[BasicBlockT]:
     """If the predicate outcome in a TernaryConditional is a Literal, evaluate and simplify it."""
 
-    def visitor_fn(expression: Any) -> Any:
+    def visitor_fn(expression: Expression) -> Expression:
         """Simplify TernaryConditionals."""
         if isinstance(expression, TernaryConditional) and isinstance(expression.predicate, Literal):
             if isinstance(expression.predicate.value, bool):

--- a/graphql_compiler/compiler/ir_lowering_common/common.py
+++ b/graphql_compiler/compiler/ir_lowering_common/common.py
@@ -182,13 +182,13 @@ def optimize_boolean_expression_comparisons(ir_blocks: List[BasicBlock]) -> List
             return expression
 
         expression_to_rewrite: Optional[BinaryComposition] = None
-        # N.B. the type checks in the last 2 elif statements are disabled because of the following:
+        # N.B. cast statements occur in the last 2 elif statements because of the following:
         # ```
         # Incompatible types in assignment (expression has type "Expression", variable has type
         # "Optional[BinaryComposition]")
         # ```
-        # However, given the logic, we know that `right_is_binary_composition` is even more
-        # specifically that the right is BinaryComposition, not a basic Expression
+        # Given the logic at the time of writing this comment, we know that
+        # `right_is_binary_composition` says that right is BinaryComposition, not just Expression
         if expression.left == identity_literal and right_is_binary_composition:
             return expression.right
         elif expression.right == identity_literal and left_is_binary_composition:

--- a/graphql_compiler/compiler/ir_lowering_common/common.py
+++ b/graphql_compiler/compiler/ir_lowering_common/common.py
@@ -163,8 +163,12 @@ def optimize_boolean_expression_comparisons(ir_blocks: List[BasicBlock]) -> List
         if not isinstance(expression, BinaryComposition):
             return expression
 
-        left_is_binary_composition: Optional[BinaryComposition] = expression.left if isinstance(expression.left, BinaryComposition) else None
-        right_is_binary_composition: Optional[BinaryComposition] = expression.right if isinstance(expression.right, BinaryComposition) else None
+        left_is_binary_composition: Optional[BinaryComposition] = expression.left if isinstance(
+            expression.left, BinaryComposition
+        ) else None
+        right_is_binary_composition: Optional[BinaryComposition] = expression.right if isinstance(
+            expression.right, BinaryComposition
+        ) else None
 
         if not left_is_binary_composition and not right_is_binary_composition:
             # Nothing to rewrite, return the expression as-is.

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -1,12 +1,12 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 """Utilities for rewriting IR to replace one set of locations with another."""
-from typing import Any, Callable, Dict, Type
+from typing import Callable, Dict
 
 import six
 
+from ...compiler.expressions import ExpressionT
 from ..helpers import FoldScopeLocation, Location, LocationT
 from ..metadata import QueryMetadataTable
-from ...compiler.expressions import ExpressionT
 
 
 def make_revisit_location_translations(
@@ -24,8 +24,7 @@ def make_revisit_location_translations(
 
 
 def translate_potential_location(
-    location_translations: Dict[Location, Location],
-    potential_location: LocationT,
+    location_translations: Dict[Location, Location], potential_location: LocationT,
 ) -> LocationT:
     """If the input is a BaseLocation object, translate it, otherwise return it as-is."""
     if isinstance(potential_location, Location):

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -1,10 +1,10 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 """Utilities for rewriting IR to replace one set of locations with another."""
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Type
 
 import six
 
-from ..helpers import FoldScopeLocation, Location, LocationT
+from ..helpers import FoldScopeLocation, BaseLocation, Location, LocationT
 from ..metadata import QueryMetadataTable
 
 
@@ -23,8 +23,8 @@ def make_revisit_location_translations(
 
 
 def translate_potential_location(
-    location_translations: Dict[LocationT, LocationT], potential_location: LocationT
-) -> LocationT:
+    location_translations: Dict[Type[BaseLocation], Type[BaseLocation]], potential_location: Type[BaseLocation]
+) -> Type[BaseLocation]:
     """If the input is a BaseLocation object, translate it, otherwise return it as-is."""
     if isinstance(potential_location, Location):
         old_location_at_vertex = potential_location.at_vertex()
@@ -50,7 +50,9 @@ def translate_potential_location(
         return potential_location
 
 
-def make_location_rewriter_visitor_fn(location_translations: Dict[LocationT, LocationT]) -> Callable:
+def make_location_rewriter_visitor_fn(
+    location_translations: Dict[Type[BaseLocation], Type[BaseLocation]]
+) -> Callable:
     """Return a visitor function that is able to replace locations with equivalent locations."""
 
     def visitor_fn(expression: Any) -> Any:

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -4,13 +4,13 @@ from typing import Any, Callable, Dict
 
 import six
 
-from ..helpers import FoldScopeLocation, LocationT
+from ..helpers import FoldScopeLocation, Location, LocationT
 from ..metadata import QueryMetadataTable
 
 
 def make_revisit_location_translations(
     query_metadata_table: QueryMetadataTable,
-) -> Dict[Location, Location]:
+) -> Dict[LocationT, LocationT]:
     """Return a dict mapping location revisits to the location being revisited, for rewriting."""
     location_translations = dict()
 

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Type
 import six
 
 from ..compiler_entities import Expression
-from ..helpers import FoldScopeLocation, BaseLocation, Location, LocationT
+from ..helpers import BaseLocation, FoldScopeLocation, Location, LocationT
 from ..metadata import QueryMetadataTable
 
 
@@ -24,7 +24,8 @@ def make_revisit_location_translations(
 
 
 def translate_potential_location(
-    location_translations: Dict[Type[BaseLocation], Type[BaseLocation]], potential_location: Type[BaseLocation]
+    location_translations: Dict[Type[BaseLocation], Type[BaseLocation]],
+    potential_location: Type[BaseLocation],
 ) -> Type[BaseLocation]:
     """If the input is a BaseLocation object, translate it, otherwise return it as-is."""
     if isinstance(potential_location, Location):

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -4,9 +4,9 @@ from typing import Any, Callable, Dict, Type
 
 import six
 
-from ..compiler_entities import Expression
-from ..helpers import BaseLocation, FoldScopeLocation, Location, LocationT
+from ..helpers import FoldScopeLocation, Location, LocationT
 from ..metadata import QueryMetadataTable
+from ...compiler.expressions import ExpressionT
 
 
 def make_revisit_location_translations(

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -24,9 +24,9 @@ def make_revisit_location_translations(
 
 
 def translate_potential_location(
-    location_translations: Dict[Type[BaseLocation], Type[BaseLocation]],
-    potential_location: Type[BaseLocation],
-) -> Type[BaseLocation]:
+    location_translations: Dict[Location, Location],
+    potential_location: LocationT,
+) -> LocationT:
     """If the input is a BaseLocation object, translate it, otherwise return it as-is."""
     if isinstance(potential_location, Location):
         old_location_at_vertex = potential_location.at_vertex()
@@ -53,11 +53,11 @@ def translate_potential_location(
 
 
 def make_location_rewriter_visitor_fn(
-    location_translations: Dict[Type[BaseLocation], Type[BaseLocation]]
-) -> Callable[[Expression], Expression]:
+    location_translations: Dict[Location, Location]
+) -> Callable[[ExpressionT], ExpressionT]:
     """Return a visitor function that is able to replace locations with equivalent locations."""
 
-    def visitor_fn(expression: Any) -> Any:
+    def visitor_fn(expression: ExpressionT) -> ExpressionT:
         """Expression visitor function used to rewrite expressions with updated Location data."""
         # All CompilerEntity objects store their exact constructor input args/kwargs.
         # To minimize the chances that we forget to update a location somewhere in an expression,

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -1,17 +1,22 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 """Utilities for rewriting IR to replace one set of locations with another."""
-from typing import Callable, Dict
+from typing import Callable, Dict, TypeVar
 
 import six
 
 from ...compiler.expressions import ExpressionT
-from ..helpers import FoldScopeLocation, Location, LocationT
+from ..helpers import FoldScopeLocation, Location
 from ..metadata import QueryMetadataTable
+
+
+# This type exists in order to reduce the scope of what is allowed to be translated
+# since LocationT was not sufficiently specific.
+TranslatedLocationT = TypeVar("TranslatedLocationT", Location, FoldScopeLocation)
 
 
 def make_revisit_location_translations(
     query_metadata_table: QueryMetadataTable,
-) -> Dict[LocationT, LocationT]:
+) -> Dict[Location, Location]:
     """Return a dict mapping location revisits to the location being revisited, for rewriting."""
     location_translations = dict()
 
@@ -24,8 +29,8 @@ def make_revisit_location_translations(
 
 
 def translate_potential_location(
-    location_translations: Dict[Location, Location], potential_location: LocationT,
-) -> LocationT:
+    location_translations: Dict[Location, Location], potential_location: TranslatedLocationT,
+) -> TranslatedLocationT:
     """If the input is a BaseLocation object, translate it, otherwise return it as-is."""
     if isinstance(potential_location, Location):
         old_location_at_vertex = potential_location.at_vertex()

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -1,11 +1,16 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 """Utilities for rewriting IR to replace one set of locations with another."""
+from typing import Any, Callable, Dict
+
 import six
 
-from ..helpers import FoldScopeLocation, Location
+from ..helpers import FoldScopeLocation, LocationT
+from ..metadata import QueryMetadataTable
 
 
-def make_revisit_location_translations(query_metadata_table):
+def make_revisit_location_translations(
+    query_metadata_table: QueryMetadataTable,
+) -> Dict[Location, Location]:
     """Return a dict mapping location revisits to the location being revisited, for rewriting."""
     location_translations = dict()
 
@@ -17,7 +22,9 @@ def make_revisit_location_translations(query_metadata_table):
     return location_translations
 
 
-def translate_potential_location(location_translations, potential_location):
+def translate_potential_location(
+    location_translations: Dict[LocationT, LocationT], potential_location: LocationT
+) -> LocationT:
     """If the input is a BaseLocation object, translate it, otherwise return it as-is."""
     if isinstance(potential_location, Location):
         old_location_at_vertex = potential_location.at_vertex()
@@ -43,10 +50,10 @@ def translate_potential_location(location_translations, potential_location):
         return potential_location
 
 
-def make_location_rewriter_visitor_fn(location_translations):
+def make_location_rewriter_visitor_fn(location_translations: Dict[LocationT, LocationT]) -> Callable:
     """Return a visitor function that is able to replace locations with equivalent locations."""
 
-    def visitor_fn(expression):
+    def visitor_fn(expression: Any) -> Any:
         """Expression visitor function used to rewrite expressions with updated Location data."""
         # All CompilerEntity objects store their exact constructor input args/kwargs.
         # To minimize the chances that we forget to update a location somewhere in an expression,

--- a/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
+++ b/graphql_compiler/compiler/ir_lowering_common/location_renaming.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Type
 
 import six
 
+from ..compiler_entities import Expression
 from ..helpers import FoldScopeLocation, BaseLocation, Location, LocationT
 from ..metadata import QueryMetadataTable
 
@@ -52,7 +53,7 @@ def translate_potential_location(
 
 def make_location_rewriter_visitor_fn(
     location_translations: Dict[Type[BaseLocation], Type[BaseLocation]]
-) -> Callable:
+) -> Callable[[Expression], Expression]:
     """Return a visitor function that is able to replace locations with equivalent locations."""
 
     def visitor_fn(expression: Any) -> Any:


### PR DESCRIPTION
Adding type hints per instructions in #688 

Most of the manual changes involved changing the paths in the imports and `Location` -> `LocationT` and `Any` -> `BasicBlockT`.