### PR TITLE
Implement filter inside a fold for MSSQL

### DIFF
--- a/graphql_compiler/tests/snapshot_tests/test_orientdb_match_query.py
+++ b/graphql_compiler/tests/snapshot_tests/test_orientdb_match_query.py
@@ -891,8 +891,8 @@ class OrientDBParameterizedMatchQueryTests(TestCase):
         self.assertMatchSnapshot(rows)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
-    def test_filter_within_fold_scope(self) -> None:
-        test_data = test_input_data.filter_within_fold_scope()
+    def test_filter_and_multiple_outputs_within_fold_scope(self) -> None:
+        test_data = test_input_data.filter_and_multiple_outputs_within_fold_scope()
         sample_parameters = {"desired": "Nazgul__2"}
 
         rows = execute_graphql(self.schema, test_data, self.orientdb_client, sample_parameters)

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -7092,6 +7092,95 @@ class CompilerTests(unittest.TestCase):
             expected_postgresql,
         )
 
+    def test_filter_and_multiple_outputs_within_fold_scope(self):
+        test_data = test_input_data.filter_and_multiple_outputs_within_fold_scope()
+
+        expected_match = """
+                    SELECT
+                        $Animal___1___out_Animal_ParentOf.description AS `child_descriptions`,
+                        $Animal___1___out_Animal_ParentOf.name AS `child_list`,
+                        Animal___1.name AS `name`
+                    FROM (
+                        MATCH {{
+                            class: Animal,
+                            as: Animal___1
+                        }}
+                        RETURN $matches
+                    ) LET
+                        $Animal___1___out_Animal_ParentOf =
+                            Animal___1.out("Animal_ParentOf")[(name = {desired})].asList()
+                """
+        expected_gremlin = """
+            g.V('@class', 'Animal')
+            .as('Animal___1')
+            .transform{it, m -> new com.orientechnologies.orient.core.record.impl.ODocument([
+                child_descriptions: (
+                    (m.Animal___1.out_Animal_ParentOf == null) ? [] : (
+                        m.Animal___1.out_Animal_ParentOf
+                         .collect{entry -> entry.inV.next()}
+                         .findAll{entry -> (entry.name == $desired)}
+                         .collect{entry -> entry.description}
+                    )
+                ),
+                child_list: (
+                    (m.Animal___1.out_Animal_ParentOf == null) ? [] : (
+                        m.Animal___1.out_Animal_ParentOf
+                         .collect{entry -> entry.inV.next()}
+                         .findAll{entry -> (entry.name == $desired)}
+                         .collect{entry -> entry.name}
+                    )
+                ),
+                name: m.Animal___1.name
+            ])}
+        """
+        expected_mssql = NotImplementedError
+        expected_postgresql = """
+            SELECT
+                coalesce(folded_subquery_1.fold_output_description, ARRAY[]::VARCHAR[])
+                    AS child_descriptions,
+                coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_list,
+                "Animal_1".name AS name
+            FROM schema_1."Animal" AS "Animal_1"
+            JOIN (
+                SELECT
+                    "Animal_2".uuid AS uuid,
+                    array_agg("Animal_3".name) AS fold_output_name,
+                    array_agg("Animal_3".description) AS fold_output_description
+                FROM schema_1."Animal" AS "Animal_2"
+                JOIN schema_1."Animal" AS "Animal_3"
+                ON "Animal_2".uuid = "Animal_3".parent
+                WHERE "Animal_3".name = %(desired)s
+                GROUP BY "Animal_2".uuid
+            ) AS folded_subquery_1
+            ON "Animal_1".uuid = folded_subquery_1.uuid
+        """
+        expected_cypher = """
+            MATCH (Animal___1:Animal)
+            OPTIONAL MATCH (Animal___1)-[:Animal_ParentOf]->(Animal__out_Animal_ParentOf___1:Animal)
+                WHERE (
+                  Animal__out_Animal_ParentOf___1.name = $desired
+                )
+            WITH
+              Animal___1 AS Animal___1,
+              collect(Animal__out_Animal_ParentOf___1) AS collected_Animal__out_Animal_ParentOf___1
+            RETURN
+              [x IN collected_Animal__out_Animal_ParentOf___1 | x.description] AS
+                `child_descriptions`,
+              [x IN collected_Animal__out_Animal_ParentOf___1 | x.name] AS
+                `child_list`,
+              Animal___1.name AS `name`
+        """
+
+        check_test_data(
+            self,
+            test_data,
+            expected_match,
+            expected_gremlin,
+            expected_mssql,
+            expected_cypher,
+            expected_postgresql,
+        )
+
     def test_filter_on_fold_scope(self):
         test_data = test_input_data.filter_on_fold_scope()
 

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -2365,6 +2365,35 @@ def filter_within_fold_scope() -> CommonTestData:  # noqa: D103
     )
 
 
+def filter_and_multiple_outputs_within_fold_scope() -> CommonTestData:  # noqa: D103
+    graphql_input = """{
+            Animal {
+                name @output(out_name: "name")
+                out_Animal_ParentOf @fold {
+                    name @filter(op_name: "=", value: ["$desired"]) @output(out_name: "child_list")
+                    description @output(out_name: "child_descriptions")
+                }
+            }
+        }"""
+    expected_output_metadata = {
+        "name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+        "child_list": OutputMetadata(type=GraphQLList(GraphQLString), optional=False, folded=True),
+        "child_descriptions": OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False, folded=True
+        ),
+    }
+    expected_input_metadata = {
+        "desired": GraphQLString,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None,
+    )
+
+
 def filter_on_fold_scope() -> CommonTestData:  # noqa: D103
     graphql_input = """{
         Animal {

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -2344,17 +2344,14 @@ def filter_within_fold_scope() -> CommonTestData:  # noqa: D103
         Animal {
             name @output(out_name: "name")
             out_Animal_ParentOf @fold {
-                name @filter(op_name: "=", value: ["$desired"]) @output(out_name: "child_list")
-                description @output(out_name: "child_descriptions")
+                name @filter(op_name: "has_substring", value: ["$desired"])
+                     @output(out_name: "child_list")
             }
         }
     }"""
     expected_output_metadata = {
         "name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
         "child_list": OutputMetadata(type=GraphQLList(GraphQLString), optional=False, folded=True),
-        "child_descriptions": OutputMetadata(
-            type=GraphQLList(GraphQLString), optional=False, folded=True
-        ),
     }
     expected_input_metadata = {
         "desired": GraphQLString,

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -4171,7 +4171,7 @@ class IrGenerationTests(unittest.TestCase):
             blocks.Fold(base_parent_fold),
             blocks.Filter(
                 expressions.BinaryComposition(
-                    "=",
+                    "has_substring",
                     expressions.LocalField("name", GraphQLString),
                     expressions.Variable("$desired", GraphQLString),
                 )
@@ -4186,10 +4186,6 @@ class IrGenerationTests(unittest.TestCase):
                     ),
                     "child_list": expressions.FoldedContextField(
                         base_parent_fold.navigate_to_field("name"), GraphQLList(GraphQLString)
-                    ),
-                    "child_descriptions": expressions.FoldedContextField(
-                        base_parent_fold.navigate_to_field("description"),
-                        GraphQLList(GraphQLString),
                     ),
                 }
             ),

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -4197,6 +4197,48 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
+    def test_filter_and_multiple_outputs_within_fold_scope(self):
+        test_data = test_input_data.filter_and_multiple_outputs_within_fold_scope()
+
+        base_location = helpers.Location(("Animal",))
+        base_parent_fold = base_location.navigate_to_fold("out_Animal_ParentOf")
+
+        expected_blocks = [
+            blocks.QueryRoot({"Animal"}),
+            blocks.MarkLocation(base_location),
+            blocks.Fold(base_parent_fold),
+            blocks.Filter(
+                expressions.BinaryComposition(
+                    "=",
+                    expressions.LocalField("name", GraphQLString),
+                    expressions.Variable("$desired", GraphQLString),
+                )
+            ),
+            blocks.MarkLocation(base_parent_fold),
+            blocks.Unfold(),
+            blocks.GlobalOperationsStart(),
+            blocks.ConstructResult(
+                {
+                    "name": expressions.OutputContextField(
+                        base_location.navigate_to_field("name"), GraphQLString
+                    ),
+                    "child_list": expressions.FoldedContextField(
+                        base_parent_fold.navigate_to_field("name"), GraphQLList(GraphQLString)
+                    ),
+                    "child_descriptions": expressions.FoldedContextField(
+                        base_parent_fold.navigate_to_field("description"),
+                        GraphQLList(GraphQLString),
+                    ),
+                }
+            ),
+        ]
+        expected_location_types = {
+            base_location: "Animal",
+            base_parent_fold: "Animal",
+        }
+
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
+
     def test_filter_on_fold_scope(self):
         test_data = test_input_data.filter_on_fold_scope()
 


### PR DESCRIPTION
I also updated the query for `filter_within_fold_scope` because the old query also included multiple outputs. We have separate tests for multiple folded outputs and it seemed like a test called `filter_within_fold_scope` should test just that functionality. I can add in a test for both filtering and having multiple folded outputs if that is desirable, but we definitely want separate tests for each these functionalities since multiple folded outputs are not implemented for MSSQL. Note that updating this test is causing a snapshot test to fail. 