### PR TITLE
Fix filter_and_multiple_outputs_within_fold_scope indentation

### DIFF
--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -7096,20 +7096,20 @@ class CompilerTests(unittest.TestCase):
         test_data = test_input_data.filter_and_multiple_outputs_within_fold_scope()
 
         expected_match = """
-                    SELECT
-                        $Animal___1___out_Animal_ParentOf.description AS `child_descriptions`,
-                        $Animal___1___out_Animal_ParentOf.name AS `child_list`,
-                        Animal___1.name AS `name`
-                    FROM (
-                        MATCH {{
-                            class: Animal,
-                            as: Animal___1
-                        }}
-                        RETURN $matches
-                    ) LET
-                        $Animal___1___out_Animal_ParentOf =
-                            Animal___1.out("Animal_ParentOf")[(name = {desired})].asList()
-                """
+            SELECT
+                $Animal___1___out_Animal_ParentOf.description AS `child_descriptions`,
+                $Animal___1___out_Animal_ParentOf.name AS `child_list`,
+                Animal___1.name AS `name`
+            FROM (
+                MATCH {{
+                    class: Animal,
+                    as: Animal___1
+                }}
+                RETURN $matches
+            ) LET
+                $Animal___1___out_Animal_ParentOf =
+                    Animal___1.out("Animal_ParentOf")[(name = {desired})].asList()
+        """
         expected_gremlin = """
             g.V('@class', 'Animal')
             .as('Animal___1')

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -2367,14 +2367,14 @@ def filter_within_fold_scope() -> CommonTestData:  # noqa: D103
 
 def filter_and_multiple_outputs_within_fold_scope() -> CommonTestData:  # noqa: D103
     graphql_input = """{
-            Animal {
-                name @output(out_name: "name")
-                out_Animal_ParentOf @fold {
-                    name @filter(op_name: "=", value: ["$desired"]) @output(out_name: "child_list")
-                    description @output(out_name: "child_descriptions")
-                }
+        Animal {
+            name @output(out_name: "name")
+            out_Animal_ParentOf @fold {
+                name @filter(op_name: "=", value: ["$desired"]) @output(out_name: "child_list")
+                description @output(out_name: "child_descriptions")
             }
-        }"""
+        }
+    }"""
     expected_output_metadata = {
         "name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
         "child_list": OutputMetadata(type=GraphQLList(GraphQLString), optional=False, folded=True),


### PR DESCRIPTION
Accidentally over indented test data and test for `filter_and_multiple_outputs_within_fold_scope` in #844. This PR fixes indentation.