### PR TITLE
Add GraphQL type maps for Oracle SQL database column types.

### DIFF
--- a/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
@@ -1,11 +1,12 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from functools import reduce
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 import warnings
 
 from graphql.type import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLScalarType, GraphQLString
 import sqlalchemy.dialects.mssql.base as mssqltypes
 import sqlalchemy.dialects.mysql.base as mysqltypes
+import sqlalchemy.dialects.oracle as oracletypes
 import sqlalchemy.dialects.postgresql as postgrestypes
 import sqlalchemy.sql.sqltypes as sqltypes
 from sqlalchemy.sql.type_api import TypeEngine
@@ -164,6 +165,79 @@ MYSQL_CLASS_TO_GRAPHQL_TYPE = {
 }
 
 
+# Based on info from https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm
+ORACLE_CLASS_TO_GRAPHQL_TYPE = {
+    oracletypes.BINARY_DOUBLE: GraphQLFloat,
+    oracletypes.BINARY_FLOAT: GraphQLFloat,
+    oracletypes.DATE: GraphQLDate,
+    oracletypes.DOUBLE_PRECISION: GraphQLFloat,
+}
+
+
+UNSUPPORTED_ORACLE_TYPES = frozenset(
+    {
+        oracletypes.BFILE,
+        oracletypes.BLOB,
+        oracletypes.CLOB,
+        oracletypes.LONG,
+        oracletypes.NCLOB,
+        oracletypes.RAW,
+        oracletypes.ROWID,
+    }
+)
+
+
+def _deduce_graphql_type_for_oracle_number_type(number_type: TypeEngine) -> GraphQLScalarType:
+    """Figure out whether Float, Int, or Decimal is the best representation of this NUMBER type.
+
+    Based on info from https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#i22289
+
+    Args:
+        number_type: the specific NUMBER type (containing precision and scale info) which we are
+                     converting to a suitable GraphQL scalar type
+
+    Returns:
+        the appropriate GraphQL type (Float, Int, or Decimal) that is best suited to representing
+        this NUMBER database type
+    """
+    if not isinstance(number_type, oracletypes.NUMBER):
+        raise AssertionError(
+            "Unreachable code reached: expected an Oracle NUMBER data type object, but "
+            "got {} instead: ".format(number_type)
+        )
+
+    if number_type.asdecimal:
+        # SQLAlchemy has decided that this number is a decimal. No reason for us to disagree.
+        return GraphQLDecimal
+
+    if number_type.scale > 0:
+        # This number type has decimal places. It has to be either a decimal or a float.
+        if number_type.precision >= 15:
+            # This number type can hold more digits than a 64-bit float would support.
+            # Therefore, it can only be properly represented as a decimal data type.
+            return GraphQLDecimal
+        else:
+            return GraphQLFloat
+    elif number_type.scale < 0:
+        # Negative scale means rounding integer places in base 10, starting with the "ones" place.
+        # For example, a scale of -2 means "round to nearest hundred".
+        significant_figures = number_type.precision - number_type.scale
+    else:
+        significant_figures = number_type.precision
+
+    if significant_figures >= 19:
+        # This number can hold more significant figures than a signed 64-bit integer could hold.
+        # The best type for it is the decimal type.
+        return GraphQLDecimal
+    else:
+        return GraphQLInt
+
+
+SPECIAL_ORACLE_TYPES: Dict[TypeEngine, Callable[[TypeEngine], GraphQLScalarType]] = {
+    oracletypes.NUMBER: _deduce_graphql_type_for_oracle_number_type,
+}
+
+
 SQL_CLASS_TO_GRAPHQL_TYPE: Dict[Any, GraphQLScalarType] = reduce(
     merge_non_overlapping_dicts,
     (
@@ -171,6 +245,7 @@ SQL_CLASS_TO_GRAPHQL_TYPE: Dict[Any, GraphQLScalarType] = reduce(
         MSSQL_CLASS_TO_GRAPHQL_TYPE,
         POSTGRES_CLASS_TO_GRAPHQL_TYPES,
         MYSQL_CLASS_TO_GRAPHQL_TYPE,
+        ORACLE_CLASS_TO_GRAPHQL_TYPE,
     ),
     {},
 )
@@ -188,11 +263,18 @@ def try_get_graphql_scalar_type(
         return None
     else:
         maybe_graphql_type = SQL_CLASS_TO_GRAPHQL_TYPE.get(type(column_type), None)
-        if maybe_graphql_type is None:
-            # Trying to get the string representation of the SQLAlchemy JSON and ARRAY types
-            # will lead to an error. We therefore use repr instead.
-            warnings.warn(
-                f'Ignoring column "{column_name}" with unsupported SQL datatype: '
-                f"{type(column_type).__name__}"
-            )
-        return maybe_graphql_type
+        if maybe_graphql_type is not None:
+            return maybe_graphql_type
+
+        maybe_special_handler = SPECIAL_ORACLE_TYPES.get(type(column_type), None)
+        if maybe_special_handler is not None:
+            # This type is mapped to a GraphQL type on a case-by-case basis.
+            # Invoke its handler function and let it decide on the appropriate type.
+            return maybe_special_handler(column_type)
+
+        # We were not able to deduce an appropriate GraphQL type for this column.
+        warnings.warn(
+            f'Ignoring column "{column_name}" with unsupported SQL datatype: '
+            f"{type(column_type).__name__}"
+        )
+        return None

--- a/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/scalar_type_mapper.py
@@ -213,8 +213,11 @@ def _deduce_graphql_type_for_oracle_number_type(number_type: TypeEngine) -> Grap
     if number_type.scale > 0:
         # This number type has decimal places. It has to be either a decimal or a float.
         if number_type.precision >= 15:
-            # This number type can hold more digits than a 64-bit float would support.
-            # Therefore, it can only be properly represented as a decimal data type.
+            # This number type can hold more digits than a 64-bit float would support:
+            # a 64-bit float has a 53-bit mantissa, but 2^53 - 1 < 10^16 i.e. not all 15-digit
+            # integers are representable as a 64-bit float without loss of precision.
+            # Therefore, this data can only be properly represented as a Decimal,
+            # the arbitrary-precision numeric data type.
             return GraphQLDecimal
         else:
             return GraphQLFloat
@@ -226,8 +229,9 @@ def _deduce_graphql_type_for_oracle_number_type(number_type: TypeEngine) -> Grap
         significant_figures = number_type.precision
 
     if significant_figures >= 19:
-        # This number can hold more significant figures than a signed 64-bit integer could hold.
-        # The best type for it is the decimal type.
+        # This number can hold more significant figures than a signed 64-bit integer could hold,
+        # since 2^63 - 1 < 10^19 i.e. not all 19-digit integers are representable in 64 signed bits.
+        # The best type for it is the Decimal type, the arbitrary-precision numeric data type.
         return GraphQLDecimal
     else:
         return GraphQLInt


### PR DESCRIPTION
These type maps should be sufficient to autogenerate a GraphQL schema based on the reflection of an Oracle SQL database, and then suitably query it via compiled queries.