### PR TITLE
Upgrade to graphql-core 3.1.x.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -83,7 +83,7 @@ teardown. These can be optionally skipped during development by running:
 
 .. code:: bash
 
-   pytest -m 'no-slow'
+   pytest -m 'not slow'
 
 If you run into any issues, please consult the TROUBLESHOOTING.md file.
 If you encounter and resolve an issue that is not already part of the

--- a/Pipfile
+++ b/Pipfile
@@ -37,7 +37,7 @@ sphinx = ">=1.8,<2"
 [packages]  # Make sure to keep in sync with setup.py requirements.
 arrow = ">=0.15.0,<1"
 funcy = ">=1.7.3,<2"
-graphql-core = ">=3,<3.1" # 3.1 contains breaking change
+graphql-core = ">=3.1,<3.2"  # minor versions sometimes contain breaking changes
 pytz = ">=2017.2"
 six = ">=1.10.0"
 sqlalchemy = ">=1.3.0,<2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9cc6fbac654418da9b455713de6ebbf8544da4502880f57c73147a3c64fea6e7"
+            "sha256": "f94f71022717ed1f235c4bf301d947442cae49f33eca52dd1e3de3c23f9fb412"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -45,18 +45,18 @@
         },
         "graphql-core": {
             "hashes": [
-                "sha256:51f7dab06b5035515b23984f6fcb677ed909b56c672152699cca32e03624992e",
-                "sha256:dfc374d3426677727772d8da9dd010e92d10305ddd9c2f7f0fc388f07cee94c4"
+                "sha256:1fdc57d08f4492f06b21f3d487311e88fa8c33e0ac1e2d74ec79fb411ceba64a",
+                "sha256:25c2f537b430abc380de8765577938c78b5993584af627b7eb56b061b4ae234d"
             ],
             "index": "pypi",
-            "version": "==3.0.5"
+            "version": "==3.1.1"
         },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "pytz": {
@@ -401,23 +401,23 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:1fe322a51df7ec60e4060c358422732359dda4467c1bd240f2172433b26b39be",
-                "sha256:2bc1fe8f793f1b1809afd6f57c2d9b948e1bf525a78e4c2957392a383c86a4a4",
-                "sha256:43335f3ff3288eb877de6d186ec08e10ea61093405189678756e14c7ccee4a9b",
-                "sha256:5c75603ea44bffad0356df333bd1b411facad321e0692d6b0687d65d94fcd8e1",
-                "sha256:738a8df84da4e9ce1f59cbdebc7d1d03310149405df9a95308d4f2a62a6d7c13",
-                "sha256:845abd8a9537da01e6b96f091e2d6d4ece18e52339f81f9fbbac1b6db2aa8d2d",
-                "sha256:94bb664868b5cf4ca1147d875a4c77883d8c605cf2e916853006e4c6194f1e84",
-                "sha256:b0c6ae0cb991a7a11013d0cc7edf8343184465b6e2dcbb9e44265c7bb3fde3af",
-                "sha256:ca56382e6ebdeb3cb928ae4ce87031cc752a1eca40ff86abc14dc712def41798",
-                "sha256:d6e9611ae026be70604672cd71bee468cb231078d8d9b3d6b43f8dcbd4d9b776",
-                "sha256:d7c9255ba6626e1745bd68e1b85e3d7888844eaf38252fefb8157194e55fd3e9",
-                "sha256:e2f193a2076e4508a88c93c25348a1cea5e6b717ee50b4422a001e9ac819c3d5",
-                "sha256:e60674723cad7b7c7fc4e9075f7a9d5d927d23d290e30cf86aeb987ef135ca1d",
-                "sha256:ec45f2a5935b291d86974a24e09676e467ac108d0c7ce94de44d7650c43a5805"
+                "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c",
+                "sha256:3fdda71c067d3ddfb21da4b80e2686b71e9e5c72cca65fa216d207a358827f86",
+                "sha256:5dd13ff1f2a97f94540fd37a49e5d255950ebcdf446fb597463a40d0df3fac8b",
+                "sha256:6731603dfe0ce4352c555c6284c6db0dc935b685e9ce2e4cf220abe1e14386fd",
+                "sha256:6bb93479caa6619d21d6e7160c552c1193f6952f0668cdda2f851156e85186fc",
+                "sha256:81c7908b94239c4010e16642c9102bfc958ab14e36048fa77d0be3289dda76ea",
+                "sha256:9c7a9a7ceb2871ba4bac1cf7217a7dd9ccd44c27c2950edbc6dc08530f32ad4e",
+                "sha256:a4a2cbcfc4cbf45cd126f531dedda8485671545b43107ded25ce952aac6fb308",
+                "sha256:b7fbfabdbcc78c4f6fc4712544b9b0d6bf171069c6e0e3cb82440dd10ced3406",
+                "sha256:c05b9e4fb1d8a41d41dec8786c94f3b95d3c5f528298d769eb8e73d293abc48d",
+                "sha256:d7df6eddb6054d21ca4d3c6249cae5578cb4602951fd2b6ee2f5510ffb098707",
+                "sha256:e0b61738ab504e656d1fe4ff0c0601387a5489ca122d55390ade31f9ca0e252d",
+                "sha256:eff7d4a85e9eea55afa34888dfeaccde99e7520b51f867ac28a48492c0b1130c",
+                "sha256:f05644db6779387ccdb468cc47a44b4356fc2ffa9287135d05b70a98dc83b89a"
             ],
             "index": "pypi",
-            "version": "==0.781"
+            "version": "==0.782"
         },
         "mypy-extensions": {
             "hashes": [
@@ -617,7 +617,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -840,10 +840,10 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
-                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
-            "version": "==0.2.4"
+            "version": "==0.2.5"
         },
         "wrapt": {
             "hashes": [

--- a/docs/source/about/contributing.rst
+++ b/docs/source/about/contributing.rst
@@ -84,7 +84,7 @@ teardown. These can be optionally skipped during development by running:
 
 .. code:: bash
 
-   pytest -m 'no-slow'
+   pytest -m 'not slow'
 
 If you run into any issues, please consult the :ref:`troubleshooting guide <troubleshooting>`.
 If you encounter and resolve an issue that is not already part of the

--- a/graphql_compiler/macros/__init__.py
+++ b/graphql_compiler/macros/__init__.py
@@ -14,8 +14,7 @@ from graphql.language.ast import (
 )
 from graphql.language.printer import print_ast
 from graphql.pyutils import FrozenList
-from graphql.utilities.build_ast_schema import build_ast_schema
-from graphql.utilities.schema_printer import print_schema
+from graphql.utilities import build_ast_schema, print_schema
 import six
 
 from ..ast_manipulation import safe_parse_graphql

--- a/graphql_compiler/schema_transformation/split_query.py
+++ b/graphql_compiler/schema_transformation/split_query.py
@@ -15,9 +15,7 @@ from graphql.language.ast import (
     SelectionSetNode,
     StringValueNode,
 )
-from graphql.language.visitor import TypeInfoVisitor, Visitor, visit
-from graphql.utilities.type_info import TypeInfo
-from graphql.validation import validate
+from graphql import TypeInfo, TypeInfoVisitor, Visitor, validate, visit
 import six
 
 from ..ast_manipulation import get_only_query_definition

--- a/graphql_compiler/schema_transformation/split_query.py
+++ b/graphql_compiler/schema_transformation/split_query.py
@@ -2,6 +2,7 @@
 from collections import OrderedDict, namedtuple
 from copy import copy
 
+from graphql import TypeInfo, TypeInfoVisitor, Visitor, validate, visit
 from graphql.language.ast import (
     ArgumentNode,
     DirectiveNode,
@@ -15,7 +16,6 @@ from graphql.language.ast import (
     SelectionSetNode,
     StringValueNode,
 )
-from graphql import TypeInfo, TypeInfoVisitor, Visitor, validate, visit
 import six
 
 from ..ast_manipulation import get_only_query_definition

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -11,7 +11,7 @@ from graphql.type import (
     GraphQLObjectType,
     GraphQLScalarType,
 )
-from graphql.utilities.schema_printer import print_schema
+from graphql.utilities import print_schema
 from parameterized import parameterized
 import pytest
 from sqlalchemy import Column, Integer, MetaData, String, Table

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -25,8 +25,13 @@ from ...schema_generation.sqlalchemy.sqlalchemy_reflector import (
     get_first_column_in_table,
 )
 from ...tests import test_backend
-from ...tests.test_helpers import generate_schema, generate_schema_graph
-from ..test_helpers import SCHEMA_TEXT, compare_ignoring_whitespace, get_schema
+from ..test_helpers import (
+    SCHEMA_TEXT,
+    compare_schema_texts_order_independently,
+    generate_schema,
+    generate_schema_graph,
+    get_schema,
+)
 from .integration_backend_config import (
     MATCH_BACKENDS,
     NEO4J_BACKENDS,
@@ -712,7 +717,7 @@ class IntegrationTests(TestCase):
             class_to_field_type_overrides=class_to_field_type_overrides,
             hidden_classes={ORIENTDB_BASE_VERTEX_CLASS_NAME},
         )
-        compare_ignoring_whitespace(self, SCHEMA_TEXT, print_schema(schema), None)
+        compare_schema_texts_order_independently(self, SCHEMA_TEXT, print_schema(schema))
 
     @integration_fixtures
     def test_override_field_types(self) -> None:

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from inspect import getmembers, isfunction
 from pprint import pformat
 import re
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 from unittest import TestCase
 
 from graphql import GraphQLList, parse

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -83,8 +83,8 @@ SCHEMA_TEXT = """
 
     directive @recurse(
         \"\"\"
-        Recurse up to this many times on this edge. A depth of 1 produces the current
-        vertex and its immediate neighbors along the given edge.
+        Recurse up to this many times on this edge. A depth of 1 produces the current \
+vertex and its immediate neighbors along the given edge.
         \"\"\"
         depth: Int!
     ) on FIELD

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -553,10 +553,22 @@ def compare_input_metadata(
 
 
 def compare_ignoring_whitespace(
-    test_case: Any, expected: str, received: str, msg: Optional[str]
+    test_case: TestCase, expected: str, received: str, msg: Optional[str]
 ) -> None:
     """Compare expected and received code, ignoring whitespace, with the given failure message."""
     test_case.assertEqual(transform(expected), transform(received), msg=msg)
+
+
+def compare_schema_texts_order_independently(
+    test_case: TestCase, expected_schema_text: str, received_schema_text: str,
+) -> None:
+    """Compare expected and received schema texts, ignoring order of definitions."""
+    expected_schema_blocks = expected_schema_text.split("\n\n")
+    received_schema_blocks = expected_schema_text.split("\n\n")
+
+    # This is the preferred order-independent comparison method in Python:
+    # https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertCountEqual
+    test_case.assertCountEqual(expected_schema_blocks, received_schema_blocks)
 
 
 def get_schema() -> GraphQLSchema:

--- a/graphql_compiler/tests/test_macro_schema.py
+++ b/graphql_compiler/tests/test_macro_schema.py
@@ -2,7 +2,7 @@
 import unittest
 
 from graphql.type import GraphQLList
-from graphql.utilities.schema_printer import print_schema
+from graphql.utilities import print_schema
 from graphql.validation import validate
 
 from ..ast_manipulation import safe_parse_graphql

--- a/graphql_compiler/tests/test_schema.py
+++ b/graphql_compiler/tests/test_schema.py
@@ -7,7 +7,7 @@ import re
 import unittest
 
 from graphql.type import GraphQLField, GraphQLInt, GraphQLObjectType, GraphQLSchema, GraphQLString
-from graphql.utilities.schema_printer import print_schema
+from graphql.utilities import print_schema
 import pytz
 import six
 

--- a/graphql_compiler/tests/test_schema_fingerprint.py
+++ b/graphql_compiler/tests/test_schema_fingerprint.py
@@ -168,13 +168,6 @@ class SchemaFingerprintTests(unittest.TestCase):
         """
         _assert_not_equal_fingerprints(self, schema_text1, schema_text2)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Type extension information is lost when a schema is print and parsed. "
-            "See https://github.com/graphql/graphql-js/issues/2386"
-        ),
-    )
     def test_field_equivalency_with_type_extension(self):
         schema_text1 = """
             type Object {
@@ -192,13 +185,6 @@ class SchemaFingerprintTests(unittest.TestCase):
         """
         _assert_equal_fingerprints(self, schema_text1, schema_text2)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Type extension information is lost when a schema is print and parsed. "
-            "See https://github.com/graphql/graphql-js/issues/2386"
-        ),
-    )
     def test_interface_equivalency_with_type_extension(self):
         schema_text1 = """
             type Object {
@@ -216,13 +202,6 @@ class SchemaFingerprintTests(unittest.TestCase):
         """
         _assert_equal_fingerprints(self, schema_text1, schema_text2)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Type extension information is lost when a schema is print and parsed. "
-            "See https://github.com/graphql/graphql-js/issues/2386"
-        ),
-    )
     def test_different_type_extensions(self):
         schema_text1 = """
             type Object {

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[  # Make sure to keep in sync with Pipfile requirements.
         "arrow>=0.15.0,<1",
         "funcy>=1.7.3,<2",
-        "graphql-core>=3,<3.1",
+        "graphql-core>=3.1,<3.2",
         "pytz>=2017.2",
         "six>=1.10.0",
         "sqlalchemy>=1.3.0,<2",


### PR DESCRIPTION
This allows us to remove three `xfail` test markers, since the underlying issues were resolved in `graphql-core`.

I also fixed a CONTRIBUTING.rst typo, where running the command it specified had the exact opposite effect from the one described.

In general, if we try to have less specific imports (`from graphql import print_schema` rather than `from graphql.utilities.schema_printer import print_schema`), these version upgrades will go more smoothly in the future. Nearly all the changes here were due to things moving around, breaking the specific imports but preserving the less-specific ones.