### PR TITLE
Fix fold after recurse

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -81,7 +81,7 @@ def _traverse_and_validate_blocks(ir: IrAndMetadata) -> Iterator[BasicBlock]:
         yield block
 
 
-def _find_columns_used(
+def _find_used_columns(
     sql_schema_info: SQLAlchemySchemaInfo, ir: IrAndMetadata
 ) -> Dict[VertexPath, Set[str]]:
     """For each query path, find which of its columns would be used in the resulting query."""
@@ -702,7 +702,7 @@ class CompilationState(object):
         # Immutable metadata
         self._sql_schema_info: SQLAlchemySchemaInfo = sql_schema_info
         self._ir: IrAndMetadata = ir
-        self._used_columns: Dict[VertexPath, Set[str]] = _find_columns_used(sql_schema_info, ir)
+        self._used_columns: Dict[VertexPath, Set[str]] = _find_used_columns(sql_schema_info, ir)
         # Mapping FoldScopeLocations (without field information) to output fields at that location.
         self._all_folded_fields: Dict[FoldScopeLocation, Set[str]] = _find_folded_fields(ir)
 

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -85,6 +85,16 @@ def _find_used_columns(
     sql_schema_info: SQLAlchemySchemaInfo, ir: IrAndMetadata
 ) -> Dict[VertexPath, Set[str]]:
     """For each query path, find which of its columns would be used in the resulting query."""
+    # TODO(bojanserafimov): The IR only talks about fields, and the query builder that emits
+    #                       sql interprets them as columns in some complicated way. This function
+    #                       spec implicitly depends on the implementation of the sql emitter in
+    #                       this module, as it tries to predict what columns it will use.
+    #
+    #                       It would be much cleaner to go the other way: To define here what
+    #                       the field->column conversion strategy is, specify what columns are
+    #                       considered "used", and put the burden on the query builder to respect
+    #                       that: to expose all "used" columns when encapsulating with subqueries
+    #                       or CTEs, and only ask for "used" columns from those encapsulations.
     used_columns: Dict[VertexPath, Set[str]] = {}
 
     # Find filters used

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -713,10 +713,12 @@ def _compare_location_and_fold_scope_location(
 
 
 def get_vertex_path(location: BaseLocation) -> VertexPath:
+    """Return a path leading to the vertex. The field component of the location is ignored."""
     if isinstance(location, Location):
         return location.query_path
     elif isinstance(location, FoldScopeLocation):
         return location.base_location.query_path + tuple(
-            f"{direction}_{edge_name}"
-            for direction, edge_name in location.fold_path
+            f"{direction}_{edge_name}" for direction, edge_name in location.fold_path
         )
+    else:
+        raise AssertionError(f"Unknown type {type(location)}: {location}")

--- a/graphql_compiler/compiler/helpers.py
+++ b/graphql_compiler/compiler/helpers.py
@@ -19,6 +19,7 @@ from graphql.type.definition import (
 import six
 
 from ..exceptions import GraphQLCompilationError
+from ..global_utils import VertexPath
 from ..schema import (
     INBOUND_EDGE_FIELD_PREFIX,
     OUTBOUND_EDGE_FIELD_PREFIX,
@@ -709,3 +710,13 @@ def _compare_location_and_fold_scope_location(
     if location != fold_scope_location.base_location:
         return location < fold_scope_location.base_location
     return False
+
+
+def get_vertex_path(location: BaseLocation) -> VertexPath:
+    if isinstance(location, Location):
+        return location.query_path
+    elif isinstance(location, FoldScopeLocation):
+        return location.base_location.query_path + tuple(
+            f"{direction}_{edge_name}"
+            for direction, edge_name in location.fold_path
+        )

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -5424,6 +5424,11 @@ class CompilerTests(unittest.TestCase):
         )
 
     def test_fold_after_recurse(self):
+        # This is a regression test, checking that:
+        # - the fold subquery picks the right column of the recursive cte to join to
+        # - the recursive CTE exposes the columns needed to perform the folded traverse
+        #
+        # Testing in any of the SQL backends is sufficient.
         test_data = test_input_data.fold_after_recurse()
 
         expected_postgresql = SKIP_TEST

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -1845,6 +1845,31 @@ def fold_on_many_to_one_edge() -> CommonTestData:  # noqa: D103
     )
 
 
+def fold_after_recurse() -> CommonTestData:  # noqa: D103
+    graphql_input = """{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_ParentOf @recurse(depth: 3) {
+                out_Animal_LivesIn @fold {
+                    name @output(out_name: "homes_list")
+                }
+            }
+        }
+    }"""
+    expected_output_metadata = {
+        "animal_name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+        "homes_list": OutputMetadata(type=GraphQLList(GraphQLString), optional=False, folded=True),
+    }
+    expected_input_metadata: Dict[str, GraphQLSchemaFieldType] = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None,
+    )
+
+
 def fold_same_edge_type_in_different_locations() -> CommonTestData:  # noqa: D103
     graphql_input = """{
         Animal {

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -3543,6 +3543,7 @@ class IrGenerationTests(unittest.TestCase):
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
+
     def test_fold_after_traverse(self):
         test_data = test_input_data.fold_after_traverse()
 

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -3508,6 +3508,41 @@ class IrGenerationTests(unittest.TestCase):
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
 
+    def test_fold_after_recurse(self):
+        test_data = test_input_data.fold_after_recurse()
+
+        base_location = helpers.Location(("Animal",))
+        base_recurse = base_location.navigate_to_subpath("out_Animal_ParentOf")
+        base_fold = base_recurse.navigate_to_fold("out_Animal_LivesIn")
+
+        expected_blocks = [
+            blocks.QueryRoot({"Animal"}),
+            blocks.MarkLocation(base_location),
+            blocks.Recurse("out", "Animal_ParentOf", 3, within_optional_scope=False),
+            blocks.MarkLocation(base_recurse),
+            blocks.Fold(base_fold),
+            blocks.MarkLocation(base_fold),
+            blocks.Unfold(),
+            blocks.Backtrack(base_location),
+            blocks.GlobalOperationsStart(),
+            blocks.ConstructResult(
+                {
+                    "animal_name": expressions.OutputContextField(
+                        base_location.navigate_to_field("name"), GraphQLString
+                    ),
+                    "homes_list": expressions.FoldedContextField(
+                        base_fold.navigate_to_field("name"), GraphQLList(GraphQLString)
+                    ),
+                }
+            ),
+        ]
+        expected_location_types = {
+            base_location: "Animal",
+            base_recurse: "Animal",
+            base_fold: "Location",
+        }
+
+        check_test_data(self, test_data, expected_blocks, expected_location_types)
     def test_fold_after_traverse(self):
         test_data = test_input_data.fold_after_traverse()
 


### PR DESCRIPTION
Using `@fold` inside `@recurse` is allowed, but our SQL backend didn't implement it, and didn't raise a good error. This PR implements this functionality.

Changes in this PR:
- Extend the `_find_columns_used_outside_folds` analysis to also reach into `FoldScopeLocation`s so that the recurse CTE can anticipate the upcoming fold and expose any columns needed for it
- Allow the fold subquery to be joined to a cte, by selecting the right cte output to serve as a primary key.
- Test

The test I added uncovered an unrelated recurse bug (see newly added TODO). I'll address this in a separate PR.