### PR TITLE
Fix division by zero

### DIFF
--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -229,6 +229,13 @@ def _estimate_edges_to_children_per_parent(
     # Count the number of parents, over which we assume the edges are uniformly distributed.
     parent_location_counts = schema_info.statistics.get_class_count(parent_name_from_location)
 
+    # Anticipate division by zero
+    if parent_location_counts == 0:
+        # This implies that edge_counts is also 0. The reason we don't assert that is that
+        # we can't expect statistics to be collected at the same time, so raising an error
+        # is too aggressive.
+        return 0
+
     # False-positive bug in pylint: https://github.com/PyCQA/pylint/issues/3039
     # pylint: disable=old-division
     #

--- a/graphql_compiler/cost_estimation/cardinality_estimator.py
+++ b/graphql_compiler/cost_estimation/cardinality_estimator.py
@@ -231,10 +231,9 @@ def _estimate_edges_to_children_per_parent(
 
     # Anticipate division by zero
     if parent_location_counts == 0:
-        # This implies that edge_counts is also 0. The reason we don't assert that is that
-        # we can't expect statistics to be collected at the same time, so raising an error
-        # is too aggressive.
-        return 0
+        # This implies that edge_counts is also 0. However, asserting that edge_counts is 0 is
+        # too aggressive because we can't expect all statistics to be collected at the same time.
+        return 0.0
 
     # False-positive bug in pylint: https://github.com/PyCQA/pylint/issues/3039
     # pylint: disable=old-division

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation.py
@@ -109,6 +109,25 @@ class CostEstimationTests(unittest.TestCase):
         self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
+    def test_traverse_zero_edge_case(self) -> None:
+        """Ensure we correctly estimate cardinality over edges."""
+        schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
+        test_data = test_input_data.traverse_and_output()
+
+        count_data = {
+            "Animal": 0,
+            "Animal_ParentOf": 0,
+        }
+        statistics = LocalStatistics(count_data)
+
+        cardinality_estimate = _make_schema_info_and_estimate_cardinality(
+            schema_graph, statistics, test_data.graphql_input, dict()
+        )
+        expected_cardinality_estimate = 0.0
+
+        self.assertAlmostEqual(expected_cardinality_estimate, cardinality_estimate)
+
+    @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_fragment(self) -> None:
         """Ensure we correctly adjust for fragments."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture


### PR DESCRIPTION
If our statistics think that there are `0` instances of a certain class, cost estimation in queries involving it divide by zero.