### PR TITLE
Enable strict mypy enforcement with per-module exclusions.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,8 @@ pylint = ">=2.4.4,<2.5"
 pytest = ">=5.1.3,<6"
 pytest-cov = ">=2.6.1,<3"
 snapshottest = ">=0.5.1,<1"
+# TODO: add dependency on https://github.com/dropbox/sqlalchemy-stubs and corresponding mypy plugin
+#       when we can make everything type-check correctly with it.
 
 # Documentation requirements. Keep in sync with docs/requirements.txt.
 # Read the Docs doesn't support pipfiles: https://github.com/readthedocs/readthedocs.org/issues/3181

--- a/graphql_compiler/debugging_utils.py
+++ b/graphql_compiler/debugging_utils.py
@@ -4,13 +4,13 @@ import re
 import six
 
 
-def remove_custom_formatting(query):
+def remove_custom_formatting(query: str) -> str:
     """Prepare the query string for pretty-printing by removing all unusual formatting."""
     query = re.sub("[\n ]+", " ", query)
     return query.replace("( ", "(").replace(" )", ")")
 
 
-def pretty_print_gremlin(gremlin):
+def pretty_print_gremlin(gremlin: str) -> str:
     """Return a human-readable representation of a gremlin command string."""
     gremlin = remove_custom_formatting(gremlin)
     too_many_parts = re.split(r"([)}]|scatter)[ ]?\.", gremlin)
@@ -48,7 +48,7 @@ def pretty_print_gremlin(gremlin):
     return "\n".join(output).strip()
 
 
-def pretty_print_match(match, parameterized=True):
+def pretty_print_match(match: str, parameterized: bool = True) -> str:
     """Return a human-readable representation of a parameterized MATCH query string."""
     left_curly = "{{" if parameterized else "{"
     right_curly = "}}" if parameterized else "}"

--- a/graphql_compiler/global_utils.py
+++ b/graphql_compiler/global_utils.py
@@ -1,8 +1,8 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 from dataclasses import dataclass
-from typing import Any, Dict, NamedTuple, Set, Tuple
+from typing import Any, Dict, NamedTuple, Set, Tuple, TypeVar
 
-from graphql import DocumentNode, GraphQLList, GraphQLNamedType, GraphQLNonNull
+from graphql import DocumentNode, GraphQLList, GraphQLNamedType, GraphQLNonNull, GraphQLType
 import six
 
 
@@ -33,7 +33,11 @@ class ASTWithParameters:
     parameters: Dict[str, Any]
 
 
-def merge_non_overlapping_dicts(merge_target, new_data):
+KT = TypeVar("KT")
+VT = TypeVar("VT")
+
+
+def merge_non_overlapping_dicts(merge_target: Dict[KT, VT], new_data: Dict[KT, VT]) -> Dict[KT, VT]:
     """Produce the merged result of two dicts that are supposed to not overlap."""
     result = dict(merge_target)
 
@@ -49,7 +53,7 @@ def merge_non_overlapping_dicts(merge_target, new_data):
     return result
 
 
-def is_same_type(left, right):
+def is_same_type(left: GraphQLType, right: GraphQLType) -> bool:
     """Determine if two GraphQL types are the same type."""
     if isinstance(left, GraphQLNamedType) and isinstance(right, GraphQLNamedType):
         return left.__class__ is right.__class__ and left.name == right.name

--- a/graphql_compiler/tool.py
+++ b/graphql_compiler/tool.py
@@ -9,7 +9,7 @@ import sys
 from . import pretty_print_graphql
 
 
-def main():
+def main() -> None:
     """Read a GraphQL query from standard input, and output it pretty-printed to standard output."""
     query = " ".join(sys.stdin.readlines())
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,118 @@
+[mypy]
+python_version = 3.8
+no_implicit_optional = True
+strict_optional = True
+warn_redundant_casts = True
+check_untyped_defs = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+disallow_untyped_decorators = True
+warn_unused_ignores = True
+
+
+# Rule relaxations for specific GraphQL compiler modules that need it.
+# TODO: let's all work to reduce this list and eliminate it entirely over time
+# Please keep the list in sorted order by module name
+
+[mypy-graphql_compiler.ast_manipulation.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.compiler.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.compiler.ir_lowering_common.*]
+check_untyped_defs = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+
+[mypy-graphql_compiler.cost_estimation.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+disallow_untyped_decorators = False
+
+[mypy-graphql_compiler.macros.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.query_formatting.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.query_pagination.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.schema.*]
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.schema_generation.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.schema_transformation.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.*]
+check_untyped_defs = False
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+disallow_untyped_decorators = False
+warn_unused_ignores = False
+
+[mypy-graphql_compiler.tool.*]
+disallow_untyped_calls = False
+
+
+# Configuration for 3rd party dependencies
+# Please keep the list in sorted order by module name
+
+[mypy-arrow.*]
+ignore_missing_imports = True
+
+[mypy-cached_property.*]
+ignore_missing_imports = True
+
+[mypy-funcy.*]
+ignore_missing_imports = True
+
+[mypy-neo4j.*]
+ignore_missing_imports = True
+
+[mypy-parameterized.*]
+ignore_missing_imports = True
+
+[mypy-pyorient.*]
+ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-redisgraph.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+[mypy-snapshottest.*]
+ignore_missing_imports = True
+
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,3 @@ lines_after_imports = 2
 force_sort_within_sections = 1
 force_grid_wrap = 0
 combine_as_imports = True
-
-[mypy]
-ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup
 #  #single-sourcing-the-version
 
 
-def read_file(filename):
+def read_file(filename: str) -> str:
     """Read package file as text to get name and version."""
     # intentionally *not* adding an encoding option to open
     # see here:
@@ -20,7 +20,7 @@ def read_file(filename):
         return f.read()
 
 
-def find_version():
+def find_version() -> str:
     """Only define version in one place."""
     version_file = read_file("__init__.py")
     version_match = re.search(r'^__version__ = ["\']([^"\']*)["\']', version_file, re.M)
@@ -29,7 +29,7 @@ def find_version():
     raise RuntimeError("Unable to find version string.")
 
 
-def find_name():
+def find_name() -> str:
     """Only define name in one place."""
     name_file = read_file("__init__.py")
     name_match = re.search(r'^__package_name__ = ["\']([^"\']*)["\']', name_file, re.M)
@@ -38,7 +38,7 @@ def find_name():
     raise RuntimeError("Unable to find name string.")
 
 
-def find_long_description():
+def find_long_description() -> str:
     """Return the content of the README.rst file."""
     return read_file("../README.rst")
 


### PR DESCRIPTION
This is close to the strictest mypy configuration that currently passes. Honorable mentions to the `compiler.ir_lowering_common` and `post_processing` modules for passing all mypy checks in their entirety; all other modules have varying degrees of rule relaxations.

This setup should ensure that our typing effort does not significantly regress by virtue of people forgetting to add appropriate type hints. Over time, we should work to reduce and eventually eliminate all the rule relaxations, ideally on a module-by-module basis so that we can strengthen the checks as early as possible and limit the chances of a regression.

The setup currently also includes import exemptions for all modules that do not ship with baked-in type hints and are also lacking type stubs. Hopefully we'll also be able to reduce that list over time, though we have significantly less control in that area.