### PR TITLE
Move rename scalar error check

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -303,7 +303,7 @@ def _ensure_no_unsupported_scalar_operations(
     for scalar in scalars:
         if renamings.get(scalar, scalar) != scalar:
             # Then it either attempts to rename or suppress the scalar.
-            unsupported_scalar_operations[scalar] = renamings.get(scalar)
+            unsupported_scalar_operations[scalar] = renamings[scalar]
     if unsupported_scalar_operations != {}:
         raise NotImplementedError(
             f"Scalar renaming and suppression is not implemented yet, but renamings attempted to "
@@ -497,7 +497,7 @@ class RenameSchemaTypesVisitor(Visitor):
         # reverse_name_map contains all non-suppressed types, including those that were unchanged
         self.query_type = query_type
         self.scalar_types = frozenset(scalar_types)
-        
+
         # pylint produces a false positive-- see issue here:
         # https://github.com/PyCQA/pylint/issues/3743
         self.builtin_types = frozenset(specified_scalar_types.keys())  # pylint: disable=no-member

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -239,11 +239,11 @@ def _validate_renamings(
         - NotImplementedError if renamings attempts to suppress an enum, an interface, or a type
           implementing an interface
     """
-    _check_for_cascading_type_suppression(schema_ast, renamings, query_type)
-    _check_for_unsupported_operation(schema_ast, renamings, scalars)
+    _ensure_no_cascading_type_suppressions(schema_ast, renamings, query_type)
+    _ensure_no_unsupported_operations(schema_ast, renamings, scalars)
 
 
-def _check_for_cascading_type_suppression(
+def _ensure_no_cascading_type_suppressions(
     schema_ast: DocumentNode, renamings: Mapping[str, Optional[str]], query_type: str
 ) -> None:
     """Check for fields with suppressed types or unions whose members were all suppressed."""
@@ -287,15 +287,15 @@ def _check_for_cascading_type_suppression(
         raise CascadingSuppressionError("\n".join(error_message_components))
 
 
-def _check_for_unsupported_operation(
+def _ensure_no_unsupported_operations(
     schema_ast: DocumentNode, renamings: Mapping[str, Optional[str]], scalars: AbstractSet[str],
 ) -> None:
     """Check for unsupported renaming or suppression operations."""
-    _check_for_unsupported_scalar_operation(renamings, scalars)
-    _ensure_no_unsupported_suppression(schema_ast, renamings)
+    _ensure_no_unsupported_scalar_operations(renamings, scalars)
+    _ensure_no_unsupported_suppressions(schema_ast, renamings)
 
 
-def _check_for_unsupported_scalar_operation(
+def _ensure_no_unsupported_scalar_operations(
     renamings: Mapping[str, Optional[str]], scalars: AbstractSet[str],
 ) -> None:
     """Check for unsupported scalar operations."""
@@ -312,7 +312,7 @@ def _check_for_unsupported_scalar_operation(
         )
 
 
-def _ensure_no_unsupported_suppression(
+def _ensure_no_unsupported_suppressions(
     schema_ast: DocumentNode, renamings: Mapping[str, Optional[str]]
 ) -> None:
     """Confirm renamings contains no enums, interfaces, or interface implementation suppressions."""

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -497,9 +497,10 @@ class RenameSchemaTypesVisitor(Visitor):
         # reverse_name_map contains all non-suppressed types, including those that were unchanged
         self.query_type = query_type
         self.scalar_types = frozenset(scalar_types)
-        self.builtin_types = frozenset(specified_scalar_types.keys())  # pylint: disable=no-member
+        
         # pylint produces a false positive-- see issue here:
         # https://github.com/PyCQA/pylint/issues/3743
+        self.builtin_types = frozenset(specified_scalar_types.keys())  # pylint: disable=no-member
 
     def _rename_or_suppress_or_ignore_name_and_add_to_record(
         self, node: RenameTypesT

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -497,7 +497,7 @@ class RenameSchemaTypesVisitor(Visitor):
         # reverse_name_map contains all non-suppressed types, including those that were unchanged
         self.query_type = query_type
         self.scalar_types = frozenset(scalar_types)
-        self.builtin_types = frozenset(specified_scalar_types.keys())  # pylint: disable=E1101
+        self.builtin_types = frozenset(specified_scalar_types.keys())  # pylint: disable=no-member
         # pylint produces a false positive-- see issue here:
         # https://github.com/PyCQA/pylint/issues/3743
 

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -84,6 +84,7 @@ from graphql import (
     ObjectTypeDefinitionNode,
     UnionTypeDefinitionNode,
     build_ast_schema,
+    specified_scalar_types,
 )
 from graphql.language.visitor import IDLE, REMOVE, Visitor, VisitorAction, visit
 import six
@@ -209,7 +210,10 @@ def rename_schema(
 
 
 def _validate_renamings(
-    schema_ast: DocumentNode, renamings: Mapping[str, Optional[str]], query_type: str, scalars: AbstractSet[str],
+    schema_ast: DocumentNode,
+    renamings: Mapping[str, Optional[str]],
+    query_type: str,
+    scalars: AbstractSet[str],
 ) -> None:
     """Validate the renamings argument before attempting to rename the schema.
 
@@ -493,7 +497,9 @@ class RenameSchemaTypesVisitor(Visitor):
         # reverse_name_map contains all non-suppressed types, including those that were unchanged
         self.query_type = query_type
         self.scalar_types = frozenset(scalar_types)
-        self.builtin_types = frozenset({"String", "Int", "Float", "Boolean", "ID"})
+        self.builtin_types = frozenset(specified_scalar_types.keys())  # pylint: disable=E1101
+        # pylint produces a false positive-- see issue here:
+        # https://github.com/PyCQA/pylint/issues/3743
 
     def _rename_or_suppress_or_ignore_name_and_add_to_record(
         self, node: RenameTypesT

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -302,9 +302,10 @@ def _ensure_no_unsupported_scalar_operations(
     unsupported_scalar_operations = {}  # Map scalars to value to be renamed.
     for scalar in scalars:
         if renamings.get(scalar, scalar) != scalar:
-            # Then it either attempts to rename or suppress the scalar.
+            # renamings.get(scalar, scalar) returns something that is not scalar iff it attempts to
+            # do something with the scalar (i.e. renaming or suppressing it)
             unsupported_scalar_operations[scalar] = renamings[scalar]
-    if unsupported_scalar_operations != {}:
+    if unsupported_scalar_operations:
         raise NotImplementedError(
             f"Scalar renaming and suppression is not implemented yet, but renamings attempted to "
             f"modify the following scalars: {unsupported_scalar_operations}. To fix this, remove "

--- a/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
+++ b/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
@@ -333,45 +333,6 @@ class InputSchemaStrings(object):
     """
     )
 
-    multiple_scalars_schema = dedent(
-        """\
-        schema {
-          query: SchemaQuery
-        }
-
-        scalar Date
-
-        scalar DateTime
-
-        scalar Decimal
-
-        enum Height {
-          TALL
-          SHORT
-        }
-
-        interface Character {
-          id: String
-        }
-
-        type Human implements Character {
-          id: String
-          name: String
-          birthday: Date
-        }
-
-        type Giraffe implements Character {
-          id: String
-          height: Height
-        }
-
-        type SchemaQuery {
-          Human: Human
-          Giraffe: Giraffe
-        }
-    """
-    )
-
     same_field_schema = dedent(
         """\
         schema {

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -775,7 +775,7 @@ class TestRenameSchema(unittest.TestCase):
                     # specified_scalar_types is a FrozenDict whose keys are built-in scalar type
                     # names (e.g. "String")
                     return key  # Making an exception for Date and all built-in scalar types because
-                    # they are scalars and renaming/ suppressing hasn't been implemented yet
+                    # they are scalars and renaming and suppressing them hasn't been implemented yet
                 return "New" + key
 
         renamed_schema = rename_schema(parse(ISS.various_types_schema), PrefixNewDict())

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -334,10 +334,7 @@ class TestRenameSchema(unittest.TestCase):
     def test_builtin_rename(self):
         with self.assertRaises(NotImplementedError):
             rename_schema(
-                parse(ISS.list_schema),
-                {
-                    "String": "NewString"
-                },
+                parse(ISS.list_schema), {"String": "NewString"},
             )
 
     def test_union_rename(self):
@@ -771,7 +768,12 @@ class TestRenameSchema(unittest.TestCase):
     def test_rename_using_dict_like_prefixer_class(self):
         class PrefixNewDict(object):
             def get(self, key, default=None):
-                if key == "Date" or key in specified_scalar_types.keys():
+                if key == "Date" or key in specified_scalar_types:  # pylint: disable=E1135
+                    # pylint produces a false positive when checking for membership for
+                    # specified_scalar_types-- see issue here:
+                    # https://github.com/PyCQA/pylint/issues/3743
+                    # specified_scalar_types is a FrozenDict whose keys are built-in scalar type
+                    # names (e.g. "String")
                     return key  # Making an exception for Date and all built-in scalar types because
                     # they are scalars and renaming/ suppressing hasn't been implemented yet
                 return "New" + key


### PR DESCRIPTION
Previously, renamings would silently ignore any attempts to rename scalars (whether user-defined or built-in scalar types)