### PR TITLE
Add typing_extensions as a conditional dependency.

### DIFF
--- a/graphql_compiler/compiler/ir_lowering_common/common.py
+++ b/graphql_compiler/compiler/ir_lowering_common/common.py
@@ -3,9 +3,8 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import six
-from typing_extensions import TypedDict
 
-from ...compiler.compiler_entities import BasicBlockT
+from ...typedefs import TypedDict
 from ..blocks import (
     BasicBlock,
     ConstructResult,
@@ -18,6 +17,7 @@ from ..blocks import (
     Traverse,
     Unfold,
 )
+from ..compiler_entities import BasicBlockT
 from ..expressions import (
     BinaryComposition,
     ContextField,

--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -4,10 +4,15 @@ from typing import Union
 from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
 
 
+# The below code is an import shim for TypedDict: we don't want to conditionally import it from
+# every file that needs it. Instead, we conditionally import it here and then import from this file
+# in every other location where this is needed.
+#
+# Hence, the "unused import" warnings on TypedDict here are false-positives.
 try:
-    from typing import TypedDict
+    from typing import TypedDict  # noqa  # pylint: disable=unused-import
 except ImportError:  # TypedDict was only added to typing in Python 3.8
-    from typing_extensions import TypedDict
+    from typing_extensions import TypedDict  # noqa  # pylint: disable=unused-import
 
 
 # The compiler's supported GraphQL types for query arguments. The GraphQL type of a query argument

--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -4,6 +4,12 @@ from typing import Union
 from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
 
 
+try:
+    from typing import TypedDict
+except ImportError:  # TypedDict was only added to typing in Python 3.8
+    from typing_extensions import TypedDict
+
+
 # The compiler's supported GraphQL types for query arguments. The GraphQL type of a query argument
 # is the type of the field that the argument references. Not to be confused with the GraphQLArgument
 # class in the GraphQL core library.

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,10 @@ setup(
         "sqlalchemy>=1.3.0,<2",
         "cached-property>=1.5.1,<2",
     ],
-    extras_require={':python_version<"3.7"': ["dataclasses>=0.7"]},
+    extras_require={
+        ':python_version<"3.7"': ["dataclasses>=0.7,<1"],
+        ':python_version<"3.8"': ["typing-extensions>=3.7.4.2,<4"],
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Topic :: Database :: Front-Ends",


### PR DESCRIPTION
In compiler/ir_lowering_common/common.py we import `from typing_extensions import TypedDict`. However, `TypedDict` exists in the standard `typing` library as of Python 3.8: https://docs.python.org/3/library/typing.html#typing.TypedDict

Before that version, it has to be used from `typing_extensions`, but `typing_extensions` was not declared as a package dependency in such Python versions.

To resolve, adding a conditional import to the top-level typedefs.py file, and a conditional installation of typing_extensions for Python versions prior to 3.8.