### PR TITLE
Fix recurse duplication bug

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1026,7 +1026,7 @@ class CompilationState(object):
             # will not be discarded when the recursive cte is joined to the rest of the query.
             # The SQL database could do this predicate pushdown itself, but most implementations
             # don't.
-            # This optimization is absolutely necessary for queries with strong filters before
+            # This optimization is absolutely necessary for queries with highly selective filters before
             # the recursion. It improves performance by a factor of the filter selectivity,
             # which can go up to 1 million times in common queries.
             base = base.where(

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1028,7 +1028,7 @@ class CompilationState(object):
             # don't.
             # This optimization is absolutely necessary for queries with highly selective filters before
             # the recursion. It improves performance by a factor of the filter selectivity,
-            # which can go up to 1 million times in common queries.
+            # which can be 1 million times or more in common queries.
             base = base.where(
                 base_alias.c[primary_key].in_(sqlalchemy.select([previous_alias.c[primary_key]]))
             )

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -133,7 +133,7 @@ def _find_used_columns(
 
     # Columns used in the base case of CTE recursions should be made available from parent scope
     # TODO(bojanserafimov): Some of these are no longer needed, since we don't select from
-    #                       the base cete, but only semijoin to its primary key now.
+    #                       the base cte, but only semijoin to its primary key now.
     for location, _ in ir.query_metadata_table.registered_locations:
         for recurse_info in ir.query_metadata_table.get_recurse_infos(location):
             traversal = f"{recurse_info.edge_direction}_{recurse_info.edge_name}"

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1017,16 +1017,15 @@ class CompilationState(object):
 
         # The base of the recursive CTE selects all needed columns and sets the depth to 0
         base_alias = self._current_alias.alias()
-        base = (
-            sqlalchemy.select(
-                [base_alias.c[col].label(col) for col in used_columns]
-                + [base_alias.c[primary_key].label(CTE_KEY_NAME), literal_0.label(CTE_DEPTH_NAME),]
-            )
-            .where(
+        base = sqlalchemy.select(
+            [base_alias.c[col].label(col) for col in used_columns]
+            + [base_alias.c[primary_key].label(CTE_KEY_NAME), literal_0.label(CTE_DEPTH_NAME),]
+        )
+        if self._recurse_needs_cte:
+            base = base.where(
                 base_alias.c[primary_key].in_(sqlalchemy.select([previous_alias.c[primary_key]]))
             )
-            .cte(recursive=True)
-        )
+        base = base.cte(recursive=True)
 
         # The recursive step selects all needed columns, increments the depth, and joins to the base
         step = self._current_alias.alias()

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1027,7 +1027,7 @@ class CompilationState(object):
             # The SQL database could do this predicate pushdown itself, but most implementations
             # don't.
             # This optimization is absolutely necessary for queries with highly selective filters before
-            # the recursion. It improves performance by a factor of the filter selectivity,
+            # the recursion. It improves performance by a factor of (1 / filter selectivity),
             # which can be 1 million times or more in common queries.
             base = base.where(
                 base_alias.c[primary_key].in_(sqlalchemy.select([previous_alias.c[primary_key]]))

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1014,10 +1014,13 @@ class CompilationState(object):
         used_columns = sorted(self._used_columns[self._current_location.query_path])
 
         # The base of the recursive CTE selects all needed columns and sets the depth to 0
+        base_alias = self._current_alias.alias()
         base = sqlalchemy.select(
-            [previous_alias.c[col].label(col) for col in used_columns]
-            + [previous_alias.c[primary_key].label(CTE_KEY_NAME), literal_0.label(CTE_DEPTH_NAME),]
-        ).cte(recursive=True)
+            [base_alias.c[col].label(col) for col in used_columns]
+            + [base_alias.c[primary_key].label(CTE_KEY_NAME), literal_0.label(CTE_DEPTH_NAME),]
+        ).where(base_alias.c[primary_key].in_(
+            sqlalchemy.select([previous_alias.c[primary_key]])
+        )).cte(recursive=True)
 
         # The recursive step selects all needed columns, increments the depth, and joins to the base
         step = self._current_alias.alias()

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -998,7 +998,7 @@ class CompilationState(object):
         edge = self._sql_schema_info.join_descriptors[self._current_classname][vertex_field]
         primary_key = self._get_current_primary_key_name("@recurse")
 
-        # Wrap the query so far into a cte if it would speed up the recursive query.
+        # Wrap the query so far into a CTE if it would speed up the recursive query.
         if self._recurse_needs_cte:
             self._wrap_into_cte()
 
@@ -1023,11 +1023,11 @@ class CompilationState(object):
         )
         if self._recurse_needs_cte:
             # Optimization: Only compute the recursion for the valid starting points -- ones that
-            # will not be discarded when the recursive cte is joined to the rest of the query.
+            # will not be discarded when the recursive CTE is joined to the rest of the query.
             # The SQL database could do this predicate pushdown itself, but most implementations
             # don't.
-            # This optimization is absolutely necessary for queries with highly selective filters before
-            # the recursion. It improves performance by a factor of (1 / filter selectivity),
+            # This optimization is absolutely necessary for queries with highly selective filters
+            # before the recursion. It improves performance by a factor of (1 / filter selectivity),
             # which can be 1 million times or more in common queries.
             base = base.where(
                 base_alias.c[primary_key].in_(sqlalchemy.select([previous_alias.c[primary_key]]))

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -557,9 +557,20 @@ class IntegrationTests(TestCase):
 
     @integration_fixtures
     def test_recurse_duplication_regression(self) -> None:
+        # Regression test for the following bug:
+        # https://github.com/kensho-technologies/graphql-compiler/pull/887
+
         parameters: Dict[str, Any] = {}
         # (query, expected_results) pairs. All of them running with the same parameters.
-        # The queries are ran in the order specified here.
+        #
+        # The queries are ran in the order specified here. The last query checks that a
+        # many-to-one traversal before recursion does not cause duplicate results to appear.
+        # The preceding queries help justify the expected result of the last query in
+        # a more readable way, and guard against changes in the test data:
+        # - If the test data changes and breaks the last test, the preceding tests
+        #   will point out that this is not a bug in recursion, but a change in data.
+        # - If the test data changes, the last test passes, but it no longer serves as
+        #   a good regression test for this bug, the preceding tests will fail.
         queries: List[Tuple[str, List[Dict[str, Any]]]] = [
             # Query 1: Get all parents
             (

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -557,7 +557,7 @@ class IntegrationTests(TestCase):
 
     @integration_fixtures
     def test_recurse_duplication_regression(self) -> None:
-        parameters = {}
+        parameters: Dict[str, Any] = {}
         # (query, expected_results) pairs. All of them running with the same parameters.
         # The queries are ran in the order specified here.
         queries: List[Tuple[str, List[Dict[str, Any]]]] = [
@@ -573,10 +573,10 @@ class IntegrationTests(TestCase):
                     }
                 }""",
                 [
-                    {'animal': 'Animal 1', 'father': 'Animal 1'},
-                    {'animal': 'Animal 2', 'father': 'Animal 1'},
-                    {'animal': 'Animal 3', 'father': 'Animal 1'},
-                    {'animal': 'Animal 4', 'father': 'Animal 3'},
+                    {"animal": "Animal 1", "father": "Animal 1"},
+                    {"animal": "Animal 2", "father": "Animal 1"},
+                    {"animal": "Animal 3", "father": "Animal 1"},
+                    {"animal": "Animal 4", "father": "Animal 3"},
                 ],
             ),
             # Query 2: Get all grandparents
@@ -593,10 +593,10 @@ class IntegrationTests(TestCase):
                     }
                 }""",
                 [
-                    {'animal': 'Animal 1', 'grandfather': 'Animal 1'},
-                    {'animal': 'Animal 2', 'grandfather': 'Animal 1'},
-                    {'animal': 'Animal 3', 'grandfather': 'Animal 1'},
-                    {'animal': 'Animal 4', 'grandfather': 'Animal 1'},
+                    {"animal": "Animal 1", "grandfather": "Animal 1"},
+                    {"animal": "Animal 2", "grandfather": "Animal 1"},
+                    {"animal": "Animal 3", "grandfather": "Animal 1"},
+                    {"animal": "Animal 4", "grandfather": "Animal 1"},
                 ],
             ),
             # Query 3: Use recursion to get self, parent and grandparent
@@ -611,18 +611,18 @@ class IntegrationTests(TestCase):
                     }
                 }""",
                 [
-                    {'animal': 'Animal 1', 'ancestor': 'Animal 1'},  # self
-                    {'animal': 'Animal 1', 'ancestor': 'Animal 1'},  # parent
-                    {'animal': 'Animal 1', 'ancestor': 'Animal 1'},  # grandparent
-                    {'animal': 'Animal 2', 'ancestor': 'Animal 2'},  # self
-                    {'animal': 'Animal 2', 'ancestor': 'Animal 1'},  # parent
-                    {'animal': 'Animal 2', 'ancestor': 'Animal 1'},  # grandparent
-                    {'animal': 'Animal 3', 'ancestor': 'Animal 3'},  # self
-                    {'animal': 'Animal 3', 'ancestor': 'Animal 1'},  # parent
-                    {'animal': 'Animal 3', 'ancestor': 'Animal 1'},  # grandparent
-                    {'animal': 'Animal 4', 'ancestor': 'Animal 4'},  # self
-                    {'animal': 'Animal 4', 'ancestor': 'Animal 3'},  # parent
-                    {'animal': 'Animal 4', 'ancestor': 'Animal 1'},  # grandparent
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # self
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # parent
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # grandparent
+                    {"animal": "Animal 2", "ancestor": "Animal 2"},  # self
+                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # parent
+                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # grandparent
+                    {"animal": "Animal 3", "ancestor": "Animal 3"},  # self
+                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # parent
+                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # grandparent
+                    {"animal": "Animal 4", "ancestor": "Animal 4"},  # self
+                    {"animal": "Animal 4", "ancestor": "Animal 3"},  # parent
+                    {"animal": "Animal 4", "ancestor": "Animal 1"},  # grandparent
                 ],
             ),
             # Query 4: Unfold recursion to omit self
@@ -644,29 +644,26 @@ class IntegrationTests(TestCase):
                     }
                 }""",
                 [
-                    {'animal': 'Animal 1', "ancestor": "Animal 1"}, # parent
-                    {'animal': 'Animal 1', "ancestor": "Animal 1"}, # grandparent
-                    {'animal': 'Animal 1', "ancestor": "Animal 1"}, # parent (duplicate)
-                    {'animal': 'Animal 1', "ancestor": "Animal 1"}, # grandparent(duplicate)
-                    {'animal': 'Animal 1', "ancestor": "Animal 1"}, # parent (duplicate)
-                    {'animal': 'Animal 1', "ancestor": "Animal 1"}, # grandparent (duplicate)
-
-                    {'animal': 'Animal 2', "ancestor": "Animal 1"}, # parent
-                    {'animal': 'Animal 2', "ancestor": "Animal 1"}, # grandparent
-                    {'animal': 'Animal 2', "ancestor": "Animal 1"}, # parent (duplicate)
-                    {'animal': 'Animal 2', "ancestor": "Animal 1"}, # grandparent (duplicate)
-                    {'animal': 'Animal 2', "ancestor": "Animal 1"}, # parent (duplicate)
-                    {'animal': 'Animal 2', "ancestor": "Animal 1"}, # grandparent (duplicate)
-
-                    {'animal': 'Animal 3', "ancestor": "Animal 1"}, # parent
-                    {'animal': 'Animal 3', "ancestor": "Animal 1"}, # grandparent
-                    {'animal': 'Animal 3', "ancestor": "Animal 1"}, # parent (duplicate)
-                    {'animal': 'Animal 3', "ancestor": "Animal 1"}, # grandparent (duplicate)
-                    {'animal': 'Animal 3', "ancestor": "Animal 1"}, # parent (duplicate)
-                    {'animal': 'Animal 3', "ancestor": "Animal 1"}, # grandparent (duplicate)
-
-                    {'animal': 'Animal 4', "ancestor": "Animal 1"}, # parent
-                    {'animal': 'Animal 4', "ancestor": "Animal 3"}, # grandparent
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # parent
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # grandparent
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # parent (duplicate)
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # grandparent(duplicate)
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # parent (duplicate)
+                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # grandparent (duplicate)
+                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # parent
+                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # grandparent
+                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # parent (duplicate)
+                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # grandparent (duplicate)
+                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # parent (duplicate)
+                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # grandparent (duplicate)
+                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # parent
+                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # grandparent
+                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # parent (duplicate)
+                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # grandparent (duplicate)
+                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # parent (duplicate)
+                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # grandparent (duplicate)
+                    {"animal": "Animal 4", "ancestor": "Animal 1"},  # parent
+                    {"animal": "Animal 4", "ancestor": "Animal 3"},  # grandparent
                 ],
             ),
         ]

--- a/graphql_compiler/tests/integration_tests/test_backends_integration.py
+++ b/graphql_compiler/tests/integration_tests/test_backends_integration.py
@@ -626,11 +626,6 @@ class IntegrationTests(TestCase):
                 ],
             ),
             # Query 4: Unfold recursion to omit self
-            #
-            #  XXX: This output is incorrect. I'm just showing the current output. Results
-            #       are duplicated. This is because the starting point for the recursive
-            #       cte is a column of the base cte that repeats. Notice that the number
-            #       of duplicates corresponds to the number of siblings of the root animal.
             (
                 """
                 {
@@ -646,22 +641,10 @@ class IntegrationTests(TestCase):
                 [
                     {"animal": "Animal 1", "ancestor": "Animal 1"},  # parent
                     {"animal": "Animal 1", "ancestor": "Animal 1"},  # grandparent
-                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # parent (duplicate)
-                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # grandparent(duplicate)
-                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # parent (duplicate)
-                    {"animal": "Animal 1", "ancestor": "Animal 1"},  # grandparent (duplicate)
                     {"animal": "Animal 2", "ancestor": "Animal 1"},  # parent
                     {"animal": "Animal 2", "ancestor": "Animal 1"},  # grandparent
-                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # parent (duplicate)
-                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # grandparent (duplicate)
-                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # parent (duplicate)
-                    {"animal": "Animal 2", "ancestor": "Animal 1"},  # grandparent (duplicate)
                     {"animal": "Animal 3", "ancestor": "Animal 1"},  # parent
                     {"animal": "Animal 3", "ancestor": "Animal 1"},  # grandparent
-                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # parent (duplicate)
-                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # grandparent (duplicate)
-                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # parent (duplicate)
-                    {"animal": "Animal 3", "ancestor": "Animal 1"},  # grandparent (duplicate)
                     {"animal": "Animal 4", "ancestor": "Animal 1"},  # parent
                     {"animal": "Animal 4", "ancestor": "Animal 3"},  # grandparent
                 ],

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2319,8 +2319,6 @@ class CompilerTests(unittest.TestCase):
                     0 AS __cte_depth
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_2]
-                WHERE
-                    [Animal_2].uuid IN (SELECT [Animal_1].uuid FROM db_1.schema_1.[Animal] AS [Animal_1])
                 UNION ALL
                 SELECT
                     [Animal_3].name AS name,
@@ -2357,8 +2355,6 @@ class CompilerTests(unittest.TestCase):
                     0 AS __cte_depth
                 FROM
                     schema_1."Animal" AS "Animal_2"
-                WHERE
-                    "Animal_2".uuid IN (SELECT "Animal_1".uuid FROM schema_1."Animal" AS "Animal_1")
                 UNION ALL
                 SELECT
                     "Animal_3".name AS name,
@@ -2865,8 +2861,6 @@ class CompilerTests(unittest.TestCase):
                     0 AS __cte_depth
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_2]
-                WHERE
-                    [Animal_2].uuid IN (SELECT [Animal_1].uuid FROM db_1.schema_1.[Animal] AS [Animal_1])
                 UNION ALL
                 SELECT
                     [Animal_3].color AS color,
@@ -2902,8 +2896,6 @@ class CompilerTests(unittest.TestCase):
                     0 AS __cte_depth
                 FROM
                     schema_1."Animal" AS "Animal_2"
-                WHERE
-                    "Animal_2".uuid IN (SELECT "Animal_1".uuid FROM schema_1."Animal" AS "Animal_1")
                 UNION ALL
                 SELECT
                     "Animal_3".color AS color,
@@ -2926,7 +2918,6 @@ class CompilerTests(unittest.TestCase):
             WHERE
                 anon_1.color = %(wanted)s
         """
-        # TODO(bojanserafimov): Should we semijoin if there's no base cte? Seems incorrect.
         check_test_data(
             self,
             test_data,
@@ -5468,8 +5459,6 @@ class CompilerTests(unittest.TestCase):
                 0 AS __cte_depth
             FROM
                 db_1.schema_1.[Animal] AS [Animal_2]
-            WHERE
-                [Animal_2].uuid IN (SELECT [Animal_1].uuid FROM db_1.schema_1.[Animal] AS [Animal_1])
             UNION ALL
             SELECT
                 [Animal_3].lives_in AS lives_in,
@@ -9726,7 +9715,8 @@ class CompilerTests(unittest.TestCase):
                     0 AS __cte_depth
                 FROM
                     schema_1."Animal" AS "Animal_3"
-                WHERE "Animal_3".uuid IN (SELECT anon_1."Animal_in_Animal_ParentOf__uuid" FROM anon_1)
+                WHERE "Animal_3".uuid IN (
+                    SELECT anon_1."Animal_in_Animal_ParentOf__uuid" FROM anon_1)
                 UNION ALL
                 SELECT
                     "Animal_4".name AS name,

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2312,25 +2312,28 @@ class CompilerTests(unittest.TestCase):
         expected_mssql = """
             WITH anon_1(name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    [Animal_1].name AS name,
-                    [Animal_1].parent AS parent,
-                    [Animal_1].uuid AS uuid,
-                    [Animal_1].uuid AS __cte_key,
+                    [Animal_2].name AS name,
+                    [Animal_2].parent AS parent,
+                    [Animal_2].uuid AS uuid,
+                    [Animal_2].uuid AS __cte_key,
                     0 AS __cte_depth
                 FROM
-                    db_1.schema_1.[Animal] AS [Animal_1]
+                    db_1.schema_1.[Animal] AS [Animal_2]
+                WHERE
+                    [Animal_2].uuid IN (SELECT [Animal_1].uuid FROM db_1.schema_1.[Animal] AS [Animal_1])
                 UNION ALL
-                    SELECT
-                        [Animal_2].name AS name,
-                        [Animal_2].parent AS parent,
-                        [Animal_2].uuid AS uuid,
-                        anon_1.__cte_key AS __cte_key,
-                        anon_1.__cte_depth + 1 AS __cte_depth
-                    FROM
-                        anon_1
-                        JOIN db_1.schema_1.[Animal] AS [Animal_2]
-                            ON anon_1.uuid = [Animal_2].parent
-                    WHERE anon_1.__cte_depth < 1
+                SELECT
+                    [Animal_3].name AS name,
+                    [Animal_3].parent AS parent,
+                    [Animal_3].uuid AS uuid,
+                    anon_1.__cte_key AS __cte_key,
+                    anon_1.__cte_depth + 1 AS __cte_depth
+                FROM
+                    anon_1
+                    JOIN db_1.schema_1.[Animal] AS [Animal_3]
+                        ON anon_1.uuid = [Animal_3].parent
+                WHERE
+                    anon_1.__cte_depth < 1
             )
             SELECT
                 anon_1.name AS relation_name
@@ -2347,25 +2350,27 @@ class CompilerTests(unittest.TestCase):
         expected_postgresql = """
             WITH RECURSIVE anon_1(name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    "Animal_1".name AS name,
-                    "Animal_1".parent AS parent,
-                    "Animal_1".uuid AS uuid,
-                    "Animal_1".uuid AS __cte_key,
+                    "Animal_2".name AS name,
+                    "Animal_2".parent AS parent,
+                    "Animal_2".uuid AS uuid,
+                    "Animal_2".uuid AS __cte_key,
                     0 AS __cte_depth
                 FROM
-                    schema_1."Animal" AS "Animal_1"
+                    schema_1."Animal" AS "Animal_2"
+                WHERE
+                    "Animal_2".uuid IN (SELECT "Animal_1".uuid FROM schema_1."Animal" AS "Animal_1")
                 UNION ALL
-                    SELECT
-                        "Animal_2".name AS name,
-                        "Animal_2".parent AS parent,
-                        "Animal_2".uuid AS uuid,
-                        anon_1.__cte_key AS __cte_key,
-                        anon_1.__cte_depth + 1 AS __cte_depth
-                    FROM
-                        anon_1
-                        JOIN schema_1."Animal" AS "Animal_2"
-                            ON anon_1.uuid = "Animal_2".parent
-                    WHERE anon_1.__cte_depth < 1
+                SELECT
+                    "Animal_3".name AS name,
+                    "Animal_3".parent AS parent,
+                    "Animal_3".uuid AS uuid,
+                    anon_1.__cte_key AS __cte_key,
+                    anon_1.__cte_depth + 1 AS __cte_depth
+                FROM
+                    anon_1
+                    JOIN schema_1."Animal" AS "Animal_3"
+                        ON anon_1.uuid = "Animal_3".parent
+                WHERE anon_1.__cte_depth < 1
             )
             SELECT
                 anon_1.name AS relation_name
@@ -2403,29 +2408,30 @@ class CompilerTests(unittest.TestCase):
                     [Animal_1].name = :animal_name),
             anon_1(color, name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    anon_2.[Animal__color] AS color,
-                    anon_2.[Animal__name] AS name,
-                    anon_2.[Animal__parent] AS parent,
-                    anon_2.[Animal__uuid] AS uuid,
-                    anon_2.[Animal__uuid] AS __cte_key,
-                    0 AS __cte_depth
-                FROM
-                    anon_2
-                UNION ALL
-                SELECT
                     [Animal_2].color AS color,
                     [Animal_2].name AS name,
                     [Animal_2].parent AS parent,
                     [Animal_2].uuid AS uuid,
+                    [Animal_2].uuid AS __cte_key,
+                    0 AS __cte_depth
+                FROM
+                    db_1.schema_1.[Animal] AS [Animal_2]
+                WHERE
+                    [Animal_2].uuid IN (SELECT anon_2.[Animal__uuid] FROM anon_2)
+                UNION ALL
+                SELECT
+                    [Animal_3].color AS color,
+                    [Animal_3].name AS name,
+                    [Animal_3].parent AS parent,
+                    [Animal_3].uuid AS uuid,
                     anon_1.__cte_key AS __cte_key,
                     anon_1.__cte_depth + 1 AS __cte_depth
                 FROM
                     anon_1
-                    JOIN db_1.schema_1.[Animal] AS [Animal_2]
-                        ON anon_1.uuid = [Animal_2].parent
+                JOIN db_1.schema_1.[Animal] AS [Animal_3] ON
+                    anon_1.uuid = [Animal_3].parent
                 WHERE
-                    anon_1.__cte_depth < 1
-            )
+                    anon_1.__cte_depth < 1)
             SELECT
                 anon_1.color AS animal_color,
                 anon_1.name AS relation_name
@@ -2464,26 +2470,28 @@ class CompilerTests(unittest.TestCase):
                     [Animal_1].name = :animal_name),
             anon_1(name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    anon_2.[Animal__name] AS name,
-                    anon_2.[Animal__parent] AS parent,
-                    anon_2.[Animal__uuid] AS uuid,
-                    anon_2.[Animal__uuid] AS __cte_key,
-                    0 AS __cte_depth
-                FROM
-                    anon_2
-                UNION ALL
-                SELECT
                     [Animal_2].name AS name,
                     [Animal_2].parent AS parent,
                     [Animal_2].uuid AS uuid,
+                    [Animal_2].uuid AS __cte_key,
+                    0 AS __cte_depth
+                FROM
+                    db_1.schema_1.[Animal] AS [Animal_2]
+                WHERE
+                    [Animal_2].uuid IN (SELECT anon_2.[Animal__uuid] FROM anon_2)
+                UNION ALL
+                SELECT
+                    [Animal_3].name AS name,
+                    [Animal_3].parent AS parent,
+                    [Animal_3].uuid AS uuid,
                     anon_1.__cte_key AS __cte_key,
                     anon_1.__cte_depth + 1 AS __cte_depth
                 FROM
-                    anon_1 JOIN db_1.schema_1.[Animal] AS [Animal_2]
-                        ON anon_1.uuid = [Animal_2].parent
+                    anon_1
+                    JOIN db_1.schema_1.[Animal] AS [Animal_3]
+                        ON anon_1.uuid = [Animal_3].parent
                 WHERE
-                    anon_1.__cte_depth < 1
-            )
+                    anon_1.__cte_depth < 1)
             SELECT
                 anon_1.name AS relation_name
             FROM
@@ -2849,34 +2857,36 @@ class CompilerTests(unittest.TestCase):
         expected_mssql = """
             WITH anon_1(color, name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    [Animal_1].color AS color,
-                    [Animal_1].name AS name,
-                    [Animal_1].parent AS parent,
-                    [Animal_1].uuid AS uuid,
-                    [Animal_1].uuid AS __cte_key,
-                    0 AS __cte_depth
-                FROM
-                    db_1.schema_1.[Animal] AS [Animal_1]
-                UNION ALL
-                SELECT
                     [Animal_2].color AS color,
                     [Animal_2].name AS name,
                     [Animal_2].parent AS parent,
                     [Animal_2].uuid AS uuid,
+                    [Animal_2].uuid AS __cte_key,
+                    0 AS __cte_depth
+                FROM
+                    db_1.schema_1.[Animal] AS [Animal_2]
+                WHERE
+                    [Animal_2].uuid IN (SELECT [Animal_1].uuid FROM db_1.schema_1.[Animal] AS [Animal_1])
+                UNION ALL
+                SELECT
+                    [Animal_3].color AS color,
+                    [Animal_3].name AS name,
+                    [Animal_3].parent AS parent,
+                    [Animal_3].uuid AS uuid,
                     anon_1.__cte_key AS __cte_key,
                     anon_1.__cte_depth + 1 AS __cte_depth
                 FROM
                     anon_1
-                    JOIN db_1.schema_1.[Animal] AS [Animal_2]
-                        ON anon_1.uuid = [Animal_2].parent
-                WHERE anon_1.__cte_depth < 3
-            )
+                JOIN db_1.schema_1.[Animal] AS [Animal_3] ON
+                    anon_1.uuid = [Animal_3].parent
+                WHERE
+                    anon_1.__cte_depth < 3)
             SELECT
                 anon_1.name AS relation_name
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
-                JOIN anon_1
-                    ON [Animal_1].uuid = anon_1.__cte_key
+                JOIN anon_1 ON
+                    [Animal_1].uuid = anon_1.__cte_key
             WHERE
                 anon_1.color = :wanted
         """
@@ -2884,28 +2894,29 @@ class CompilerTests(unittest.TestCase):
         expected_postgresql = """
             WITH RECURSIVE anon_1(color, name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    "Animal_1".color AS color,
-                    "Animal_1".name AS name,
-                    "Animal_1".parent AS parent,
-                    "Animal_1".uuid AS uuid,
-                    "Animal_1".uuid AS __cte_key,
+                    "Animal_2".color AS color,
+                    "Animal_2".name AS name,
+                    "Animal_2".parent AS parent,
+                    "Animal_2".uuid AS uuid,
+                    "Animal_2".uuid AS __cte_key,
                     0 AS __cte_depth
                 FROM
-                    schema_1."Animal" AS "Animal_1"
+                    schema_1."Animal" AS "Animal_2"
+                WHERE
+                    "Animal_2".uuid IN (SELECT "Animal_1".uuid FROM schema_1."Animal" AS "Animal_1")
                 UNION ALL
-                    SELECT
-                        "Animal_2".color AS color,
-                        "Animal_2".name AS name,
-                        "Animal_2".parent AS parent,
-                        "Animal_2".uuid AS uuid,
-                        anon_1.__cte_key AS __cte_key,
-                        anon_1.__cte_depth + 1 AS __cte_depth
-                    FROM
-                        anon_1
-                        JOIN schema_1."Animal" AS "Animal_2"
-                            ON anon_1.uuid = "Animal_2".parent
-                    WHERE anon_1.__cte_depth < 3
-            )
+                SELECT
+                    "Animal_3".color AS color,
+                    "Animal_3".name AS name,
+                    "Animal_3".parent AS parent,
+                    "Animal_3".uuid AS uuid,
+                    anon_1.__cte_key AS __cte_key,
+                    anon_1.__cte_depth + 1 AS __cte_depth
+                FROM
+                    anon_1
+                    JOIN schema_1."Animal" AS "Animal_3"
+                        ON anon_1.uuid = "Animal_3".parent
+                WHERE anon_1.__cte_depth < 3)
             SELECT
                 anon_1.name AS relation_name
             FROM
@@ -2915,6 +2926,7 @@ class CompilerTests(unittest.TestCase):
             WHERE
                 anon_1.color = %(wanted)s
         """
+        # TODO(bojanserafimov): Should we semijoin if there's no base cte? Seems incorrect.
         check_test_data(
             self,
             test_data,
@@ -5446,28 +5458,31 @@ class CompilerTests(unittest.TestCase):
 
         expected_postgresql = SKIP_TEST
         expected_mssql = """
+
         WITH anon_1(lives_in, parent, uuid, __cte_key, __cte_depth) AS (
-            SELECT
-                [Animal_1].lives_in AS lives_in,
-                [Animal_1].parent AS parent,
-                [Animal_1].uuid AS uuid,
-                [Animal_1].uuid AS __cte_key,
-                0 AS __cte_depth
-            FROM
-                db_1.schema_1.[Animal] AS [Animal_1]
-            UNION ALL
             SELECT
                 [Animal_2].lives_in AS lives_in,
                 [Animal_2].parent AS parent,
                 [Animal_2].uuid AS uuid,
+                [Animal_2].uuid AS __cte_key,
+                0 AS __cte_depth
+            FROM
+                db_1.schema_1.[Animal] AS [Animal_2]
+            WHERE
+                [Animal_2].uuid IN (SELECT [Animal_1].uuid FROM db_1.schema_1.[Animal] AS [Animal_1])
+            UNION ALL
+            SELECT
+                [Animal_3].lives_in AS lives_in,
+                [Animal_3].parent AS parent,
+                [Animal_3].uuid AS uuid,
                 anon_1.__cte_key AS __cte_key,
                 anon_1.__cte_depth + 1 AS __cte_depth
             FROM
-                anon_1 JOIN db_1.schema_1.[Animal] AS [Animal_2]
-                    ON anon_1.uuid = [Animal_2].parent
+                anon_1
+            JOIN db_1.schema_1.[Animal] AS [Animal_3] ON
+                anon_1.uuid = [Animal_3].parent
             WHERE
-                anon_1.__cte_depth < 3
-        )
+                anon_1.__cte_depth < 3)
         SELECT
             [Animal_1].name AS animal_name,
             folded_subquery_1.fold_output_name AS homes_list
@@ -9653,25 +9668,28 @@ class CompilerTests(unittest.TestCase):
             ),
             anon_2(name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    anon_1.[Animal_in_Animal_ParentOf__name] AS name,
-                    anon_1.[Animal_in_Animal_ParentOf__parent] AS parent,
-                    anon_1.[Animal_in_Animal_ParentOf__uuid] AS uuid,
-                    anon_1.[Animal_in_Animal_ParentOf__uuid] AS __cte_key,
-                    0 AS __cte_depth
-                FROM
-                    anon_1
-                UNION ALL
-                SELECT
                     [Animal_3].name AS name,
                     [Animal_3].parent AS parent,
                     [Animal_3].uuid AS uuid,
+                    [Animal_3].uuid AS __cte_key,
+                    0 AS __cte_depth
+                FROM
+                    db_1.schema_1.[Animal] AS [Animal_3]
+                WHERE
+                    [Animal_3].uuid IN (SELECT anon_1.[Animal_in_Animal_ParentOf__uuid] FROM anon_1)
+                UNION ALL
+                SELECT
+                    [Animal_4].name AS name,
+                    [Animal_4].parent AS parent,
+                    [Animal_4].uuid AS uuid,
                     anon_2.__cte_key AS __cte_key,
                     anon_2.__cte_depth + 1 AS __cte_depth
                 FROM
                     anon_2
-                    JOIN db_1.schema_1.[Animal] AS [Animal_3]
-                        ON anon_2.uuid = [Animal_3].parent
-                    WHERE anon_2.__cte_depth < 3
+                    JOIN db_1.schema_1.[Animal] AS [Animal_4]
+                        ON anon_2.uuid = [Animal_4].parent
+                WHERE
+                    anon_2.__cte_depth < 3
             )
             SELECT
                 anon_1.[Animal_in_Animal_ParentOf__name] AS child_name,
@@ -9701,26 +9719,26 @@ class CompilerTests(unittest.TestCase):
             ),
             anon_2(name, parent, uuid, __cte_key, __cte_depth) AS (
                 SELECT
-                    anon_1."Animal_in_Animal_ParentOf__name" AS name,
-                    anon_1."Animal_in_Animal_ParentOf__parent" AS parent,
-                    anon_1."Animal_in_Animal_ParentOf__uuid" AS uuid,
-                    anon_1."Animal_in_Animal_ParentOf__uuid" AS __cte_key,
-                    0 AS __cte_depth
-                FROM
-                    anon_1
-                UNION ALL
-                SELECT
                     "Animal_3".name AS name,
                     "Animal_3".parent AS parent,
                     "Animal_3".uuid AS uuid,
+                    "Animal_3".uuid AS __cte_key,
+                    0 AS __cte_depth
+                FROM
+                    schema_1."Animal" AS "Animal_3"
+                WHERE "Animal_3".uuid IN (SELECT anon_1."Animal_in_Animal_ParentOf__uuid" FROM anon_1)
+                UNION ALL
+                SELECT
+                    "Animal_4".name AS name,
+                    "Animal_4".parent AS parent,
+                    "Animal_4".uuid AS uuid,
                     anon_2.__cte_key AS __cte_key,
                     anon_2.__cte_depth + 1 AS __cte_depth
                 FROM
                     anon_2
-                    JOIN schema_1."Animal" AS "Animal_3"
-                        ON anon_2.uuid = "Animal_3".parent
-                WHERE
-                    anon_2.__cte_depth < 3
+                    JOIN schema_1."Animal" AS "Animal_4"
+                        ON anon_2.uuid = "Animal_4".parent
+                WHERE anon_2.__cte_depth < 3
             )
             SELECT
                 anon_1."Animal_in_Animal_ParentOf__name" AS child_name,


### PR DESCRIPTION
Exposed and fix a duplication bug caused by `@recurse`.

Changes:
- Added integration test that used to fail
- Fixed implementation so test passes
- Fixed compiler tests to match output
- Optimization: Removed semi join when there's no base CTE (@obi1kenobi please double-check the correctness here)

Future PR:
- Since the new recurse implementation is simpler, see if any outputs we used to expose are now unused