### PR TITLE
Add types to subclass.py module

### DIFF
--- a/graphql_compiler/compiler/subclass.py
+++ b/graphql_compiler/compiler/subclass.py
@@ -1,9 +1,15 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType, GraphQLUnionType
+from typing import Dict, Optional, Set
+
+from graphql import GraphQLInterfaceType, GraphQLObjectType, GraphQLSchema, GraphQLUnionType
 import six
 
+from ..schema.typedefs import TypeEquivalenceHintsType
 
-def compute_subclass_sets(schema, type_equivalence_hints=None):
+
+def compute_subclass_sets(
+    schema: GraphQLSchema, type_equivalence_hints: Optional[TypeEquivalenceHintsType] = None
+) -> Dict[str, Set[str]]:
     """Return a dict mapping class names to the set of its subclass names.
 
     A class here means an object type or interface.

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -872,9 +872,10 @@ def generate_schema(
 def get_empty_test_macro_registry() -> MacroRegistry:
     """Return a MacroRegistry with appropriate type_equivalence_hints and subclass_set."""
     schema = get_schema()
-    type_equivalence_hints = cast(TypeEquivalenceHintsType, {
-        schema.get_type("Event"): schema.get_type("Union__BirthEvent__Event__FeedingEvent"),
-    })
+    type_equivalence_hints = cast(
+        TypeEquivalenceHintsType,
+        {schema.get_type("Event"): schema.get_type("Union__BirthEvent__Event__FeedingEvent"),},
+    )
     subclass_sets = compute_subclass_sets(schema, type_equivalence_hints)
     macro_registry = create_macro_registry(schema, type_equivalence_hints, subclass_sets)
     return macro_registry

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from inspect import getmembers, isfunction
 from pprint import pformat
 import re
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union, cast
 from unittest import TestCase
 
 from graphql import GraphQLList, parse
@@ -872,9 +872,9 @@ def generate_schema(
 def get_empty_test_macro_registry() -> MacroRegistry:
     """Return a MacroRegistry with appropriate type_equivalence_hints and subclass_set."""
     schema = get_schema()
-    type_equivalence_hints = {
+    type_equivalence_hints = cast(TypeEquivalenceHintsType, {
         schema.get_type("Event"): schema.get_type("Union__BirthEvent__Event__FeedingEvent"),
-    }
+    })
     subclass_sets = compute_subclass_sets(schema, type_equivalence_hints)
     macro_registry = create_macro_registry(schema, type_equivalence_hints, subclass_sets)
     return macro_registry

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,8 +9,10 @@ disallow_untyped_calls = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
 disallow_untyped_decorators = True
-warn_unused_ignores = True
 ignore_missing_imports = False
+
+# mypy-copilot: disabled as mypy only reports it if other checks pass
+warn_unused_ignores = False
 
 
 # First party per-module rule relaxations
@@ -107,9 +109,6 @@ disallow_untyped_defs = False
 
 [mypy-graphql_compiler.compiler.sqlalchemy_extensions.*]
 check_untyped_defs = False
-disallow_untyped_defs = False
-
-[mypy-graphql_compiler.compiler.subclass.*]
 disallow_untyped_defs = False
 
 [mypy-graphql_compiler.compiler.validation.*]
@@ -226,44 +225,197 @@ check_untyped_defs = False
 check_untyped_defs = False
 
 [mypy-graphql_compiler.schema_transformation.*]
+disallow_untyped_calls = False
+
+[mypy-graphql_compiler.schema_transformation.make_query_plan.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.schema_transformation.merge_schemas.*]
+check_untyped_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.schema_transformation.rename_query.*]
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.schema_transformation.split_query.*]
+check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.schema_transformation.utils.*]
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.conftest.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.integration_tests.test_backends_integration.*]
+check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.schema_generation_tests.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.schema_transformation_tests.example_schema.*]
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.schema_transformation_tests.test_check_schema_valid.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.schema_transformation_tests.test_make_query_plan.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.schema_transformation_tests.test_merge_schemas.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.schema_transformation_tests.test_rename_query.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.schema_transformation_tests.test_rename_schema.*]
 check_untyped_defs = False
 disallow_incomplete_defs = False
 disallow_untyped_calls = False
 disallow_untyped_defs = False
 
-[mypy-graphql_compiler.tests.*]
+[mypy-graphql_compiler.tests.schema_transformation_tests.test_split_query.*]
 disallow_incomplete_defs = False
 disallow_untyped_calls = False
 disallow_untyped_defs = False
 
-[mypy-graphql_compiler.tests.integration_tests.*]
+[mypy-graphql_compiler.tests.snapshot_tests.test_cost_estimation.*]
 check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
 disallow_untyped_decorators = False
+disallow_untyped_defs = False
 
-[mypy-graphql_compiler.tests.schema_transformation_tests.*]
+[mypy-graphql_compiler.tests.snapshot_tests.test_cost_estimation_analysis.*]
 check_untyped_defs = False
-
-[mypy-graphql_compiler.tests.snapshot_tests.*]
-check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
 disallow_untyped_decorators = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.snapshot_tests.test_orientdb_match_query.*]
+disallow_incomplete_defs = False
+disallow_untyped_decorators = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.snapshot_tests.test_query_pagination.*]
+check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+disallow_untyped_defs = False
 
 [mypy-graphql_compiler.tests.test_compiler.*]
 check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
 
-[mypy-graphql_compiler.tests.test_data_tools.*]
+[mypy-graphql_compiler.tests.test_data_tools.data_tool.*]
 check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_emit_output.*]
+disallow_untyped_calls = False
+
+[mypy-graphql_compiler.tests.test_end_to_end.*]
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_explain_info.*]
+disallow_untyped_calls = False
+
+[mypy-graphql_compiler.tests.test_global_utils.*]
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_graphql_pretty_print.*]
+disallow_untyped_calls = False
+
+[mypy-graphql_compiler.tests.test_helpers.*]
+disallow_untyped_calls = False
+disallow_untyped_defs = False
 
 [mypy-graphql_compiler.tests.test_ir_generation.*]
 check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_ir_generation_errors.*]
+disallow_untyped_calls = False
 
 [mypy-graphql_compiler.tests.test_ir_lowering.*]
 check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
 
 [mypy-graphql_compiler.tests.test_macro_expansion.*]
+disallow_untyped_calls = False
 disallow_untyped_decorators = False
+
+[mypy-graphql_compiler.tests.test_macro_expansion_errors.*]
+disallow_untyped_calls = False
+
+[mypy-graphql_compiler.tests.test_macro_schema.*]
+disallow_untyped_calls = False
+
+[mypy-graphql_compiler.tests.test_macro_validation.*]
+disallow_untyped_calls = False
 
 [mypy-graphql_compiler.tests.test_post_processing.*]
 check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_safe_match_and_gremlin.*]
+disallow_untyped_calls = False
+
+[mypy-graphql_compiler.tests.test_schema.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_schema_fingerprint.*]
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_sqlalchemy_extensions.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_subclass.*]
+check_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.tests.test_testing_invariants.*]
+disallow_incomplete_defs = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
 
 [mypy-graphql_compiler.tool.*]
 disallow_untyped_calls = False


### PR DESCRIPTION
`typing-copilot` had a bug in the submodule detection code, and wasn't actually properly generating the "real" strictest config — hence the increased size of the `mypy.ini` in this PR.