### PR TITLE
Use graphql.GraphQLError as base exception and remove mirror exception class. 

### DIFF
--- a/graphql_compiler/exceptions.py
+++ b/graphql_compiler/exceptions.py
@@ -1,6 +1,5 @@
 # Copyright 2017-present Kensho Technologies, LLC.
-class GraphQLError(Exception):
-    """Generic error when processing GraphQL."""
+from graphql import GraphQLError
 
 
 class GraphQLParsingError(GraphQLError):

--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -92,7 +92,7 @@ def validate_argument_type(name: str, expected_type: QueryArgumentGraphQLType, v
             try:
                 decimal.Decimal(value)
             except decimal.InvalidOperation as e:
-                raise GraphQLInvalidArgumentError(e)
+                raise GraphQLInvalidArgumentError(str(e))
     elif is_same_type(GraphQLDate, stripped_type):
         # Datetimes pass as instances of date. We want to explicitly only allow dates.
         if isinstance(value, datetime.datetime) or not isinstance(value, datetime.date):
@@ -100,14 +100,14 @@ def validate_argument_type(name: str, expected_type: QueryArgumentGraphQLType, v
         try:
             GraphQLDate.serialize(value)
         except ValueError as e:
-            raise GraphQLInvalidArgumentError(e)
+            raise GraphQLInvalidArgumentError(str(e))
     elif is_same_type(GraphQLDateTime, stripped_type):
         if not isinstance(value, (datetime.date, arrow.Arrow)):
             _raise_invalid_type_error(name, (datetime.date, arrow.Arrow), value)
         try:
             GraphQLDateTime.serialize(value)
         except ValueError as e:
-            raise GraphQLInvalidArgumentError(e)
+            raise GraphQLInvalidArgumentError(str(e))
     elif isinstance(stripped_type, GraphQLList):
         if not isinstance(value, list):
             _raise_invalid_type_error(name, (list,), value)

--- a/graphql_compiler/query_formatting/gremlin_formatting.py
+++ b/graphql_compiler/query_formatting/gremlin_formatting.py
@@ -62,7 +62,7 @@ def _safe_gremlin_date(value):
     try:
         serialized_value = GraphQLDate.serialize(value)
     except ValueError as e:
-        raise GraphQLInvalidArgumentError(e)
+        raise GraphQLInvalidArgumentError(str(e))
 
     return _safe_gremlin_string(serialized_value)
 
@@ -72,7 +72,7 @@ def _safe_gremlin_datetime(value):
     try:
         serialized_value = GraphQLDateTime.serialize(value)
     except ValueError as e:
-        raise GraphQLInvalidArgumentError(e)
+        raise GraphQLInvalidArgumentError(str(e))
 
     return _safe_gremlin_string(serialized_value)
 

--- a/graphql_compiler/query_formatting/match_formatting.py
+++ b/graphql_compiler/query_formatting/match_formatting.py
@@ -34,7 +34,7 @@ def _safe_match_date(value):
     try:
         serialized_value = GraphQLDate.serialize(value)
     except ValueError as e:
-        raise GraphQLInvalidArgumentError(e)
+        raise GraphQLInvalidArgumentError(str(e))
 
     return _safe_match_string(serialized_value)
 
@@ -44,7 +44,7 @@ def _safe_match_datetime(value):
     try:
         serialized_value = GraphQLDateTime.serialize(value)
     except ValueError as e:
-        raise GraphQLInvalidArgumentError(e)
+        raise GraphQLInvalidArgumentError(str(e))
 
     return _safe_match_string(serialized_value)
 

--- a/graphql_compiler/query_formatting/representations.py
+++ b/graphql_compiler/query_formatting/representations.py
@@ -49,4 +49,4 @@ def coerce_to_decimal(value):
         try:
             return decimal.Decimal(value)
         except decimal.InvalidOperation as e:
-            raise GraphQLInvalidArgumentError(e)
+            raise GraphQLInvalidArgumentError(str(e))


### PR DESCRIPTION
It is bug prone to have a mirror `GraphQLError` class in the graphql compiler library.