### PR TITLE
Change parse function type hint for consistency.

### DIFF
--- a/graphql_compiler/schema/__init__.py
+++ b/graphql_compiler/schema/__init__.py
@@ -296,7 +296,7 @@ def _serialize_date(value: Any) -> str:
     return value.isoformat()
 
 
-def _parse_date_value(value: str) -> date:
+def _parse_date_value(value: Any) -> date:
     """Deserialize a Date object from its proper ISO-8601 representation."""
     return arrow.get(value, "YYYY-MM-DD").date()
 


### PR DESCRIPTION
The GraphQL library adopts `Any` as the type hint for the value-parsing functions on types, so we'll follow suit.