### PR TITLE
Transfer custom scalar code from PR #884

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -304,12 +304,12 @@ def _ensure_no_unsupported_scalar_operations(
     unsupported_scalar_operations = {}  # Map scalars to value to be renamed.
     for scalar_name in custom_scalar_names:
         if renamings.get(scalar_name, scalar_name) != scalar_name:
-            # renamings.get(scalar, scalar) returns something that is not scalar iff it attempts to
-            # do something with the scalar (i.e. renaming or suppressing it)
+            # renamings.get(scalar_name, scalar_name) returns something that is not scalar iff it
+            # attempts to do something with the scalar (i.e. renaming or suppressing it)
             unsupported_scalar_operations[scalar_name] = renamings[scalar_name]
     for builtin_scalar_name in builtin_scalar_type_names:
         if renamings.get(builtin_scalar_name, builtin_scalar_name) != builtin_scalar_name:
-            # Check that built-in scalar types rename unchanged during renaming.
+            # Check that built-in scalar types remain unchanged during renaming.
             unsupported_scalar_operations[builtin_scalar_name] = renamings[builtin_scalar_name]
     if unsupported_scalar_operations:
         raise NotImplementedError(
@@ -547,8 +547,8 @@ class RenameSchemaTypesVisitor(Visitor):
 
         # Renaming conflict arises when two types with different names in the original schema have
         # the same name in the new schema. There are two ways to produce this conflict:
-        # * when neither type is a custom scalar
-        # * when one type is a custom scalar and the other is not
+        # 1. when neither type is a custom scalar
+        # 2. when one type is a custom scalar and the other is not
         #
         # If neither type is a custom scalar, then desired_type_name will be in
         # self.reverse_name_map (because self.reverse_name_map records all non-scalar types in

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -558,9 +558,10 @@ class RenameSchemaTypesVisitor(Visitor):
             # If neither type is a custom scalar, the two type names in the original schema are
             # name_string and self.reverse_name_map[new_name_string].
             # If one of the types is a custom scalar, it won't appear in self.reverse_name_map
-            # because custom scalar renaming has not been implemented yet. Since this renaming has
-            # not been implemented yet, we know for sure that the scalar's name is new_name_string.
-            # So, in either case, the two types in the original schema will be named name_string and
+            # because custom scalar renaming has not been implemented yet and self.reverse_name_map
+            # does not include scalars. Since this renaming has not been implemented yet, we know
+            # for sure that the scalar's name is new_name_string.
+            # In either case, the two types in the original schema will be named name_string and
             # conflictingly_renamed_type_name.
             conflictingly_renamed_type_name = self.reverse_name_map.get(
                 new_name_string, new_name_string

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -77,7 +77,7 @@ _alphanumeric_and_underscore = frozenset(six.text_type(string.ascii_letters + st
 
 # String representations for the GraphQL built-in scalar types
 # pylint produces a false positive-- see issue here: https://github.com/PyCQA/pylint/issues/3743
-builtin_scalar_types = frozenset(specified_scalar_types.keys())  # pylint: disable=no-member
+builtin_scalar_type_names = frozenset(specified_scalar_types.keys())  # pylint: disable=no-member
 
 
 def check_schema_identifier_is_valid(identifier):
@@ -149,12 +149,12 @@ def get_custom_scalar_names(schema):
         Set[str], set of names of scalars used in the schema
     """
     type_map = schema.type_map
-    scalars = {
+    custom_scalar_names = {
         type_name
         for type_name, type_object in six.iteritems(type_map)
-        if isinstance(type_object, GraphQLScalarType) and type_name not in builtin_scalar_types
+        if isinstance(type_object, GraphQLScalarType) and type_name not in builtin_scalar_type_names
     }
-    return scalars
+    return custom_scalar_names
 
 
 def try_get_ast_by_name_and_type(asts, target_name, target_type):

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -2,7 +2,7 @@
 from copy import copy
 import string
 
-from graphql import build_ast_schema
+from graphql import build_ast_schema, specified_scalar_types
 from graphql.language.ast import FieldNode, InlineFragmentNode, NameNode
 from graphql.language.visitor import Visitor, visit
 from graphql.type.definition import GraphQLScalarType
@@ -75,6 +75,11 @@ class CascadingSuppressionError(SchemaTransformError):
 _alphanumeric_and_underscore = frozenset(six.text_type(string.ascii_letters + string.digits + "_"))
 
 
+# String representations for the GraphQL built-in scalar types
+# pylint produces a false positive-- see issue here: https://github.com/PyCQA/pylint/issues/3743
+builtin_scalar_types = frozenset(specified_scalar_types.keys())  # pylint: disable=no-member
+
+
 def check_schema_identifier_is_valid(identifier):
     """Check if input is a valid identifier, made of alphanumeric and underscore characters.
 
@@ -131,11 +136,10 @@ def get_query_type_name(schema):
     return schema.query_type.name
 
 
-def get_scalar_names(schema):
-    """Get names of all scalars used in the input schema.
+def get_custom_scalar_names(schema):
+    """Get names of all custom scalars used in the input schema.
 
-    Includes all user defined scalars, as well as any builtin scalars used in the schema; excludes
-    builtin scalars not used in the schema.
+    Includes all user defined scalars; excludes builtin scalars.
 
     Note: If the user defined a scalar that shares its name with a builtin introspection type
     (such as __Schema, __Directive, etc), it will not be listed in type_map and thus will not
@@ -148,7 +152,7 @@ def get_scalar_names(schema):
     scalars = {
         type_name
         for type_name, type_object in six.iteritems(type_map)
-        if isinstance(type_object, GraphQLScalarType)
+        if isinstance(type_object, GraphQLScalarType) and type_name not in builtin_scalar_types
     }
     return scalars
 

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -13,7 +13,8 @@ from ...schema_transformation.utils import (
     InvalidTypeNameError,
     SchemaNameConflictError,
     SchemaTransformError,
-    get_scalar_names,
+    builtin_scalar_types,
+    get_custom_scalar_names,
 )
 from .input_schema_strings import InputSchemaStrings as ISS
 
@@ -772,7 +773,7 @@ class TestRenameSchema(unittest.TestCase):
                 self.schema = schema
 
             def get(self, key, default=None):
-                if key in get_scalar_names(self.schema):
+                if key in get_custom_scalar_names(self.schema) or key in builtin_scalar_types:
                     # Making an exception for scalar types because renaming and suppressing them
                     # hasn't been implemented yet
                     return key

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -13,7 +13,7 @@ from ...schema_transformation.utils import (
     InvalidTypeNameError,
     SchemaNameConflictError,
     SchemaTransformError,
-    builtin_scalar_types,
+    builtin_scalar_type_names,
     get_custom_scalar_names,
 )
 from .input_schema_strings import InputSchemaStrings as ISS
@@ -773,7 +773,7 @@ class TestRenameSchema(unittest.TestCase):
                 self.schema = schema
 
             def get(self, key, default=None):
-                if key in get_custom_scalar_names(self.schema) or key in builtin_scalar_types:
+                if key in get_custom_scalar_names(self.schema) or key in builtin_scalar_type_names:
                     # Making an exception for scalar types because renaming and suppressing them
                     # hasn't been implemented yet
                     return key


### PR DESCRIPTION
Originally the code treated non-scalar renaming to a name that a scalar already uses as a special case. This case was treated differently from, for instance, 2 object types renamed to the same thing.

For example, renaming Foo -> USER_DEFINED_SCALAR when there's already a scalar named USER_DEFINED_SCALAR gets treated differently from renaming Foo and Bar both to Baz.

However, since it's (eventually) going to be fine to rename/ suppress scalars, it makes more sense to not draw that distinction but rather draw the line between "this renaming would work if not for this other type or renaming resulting in conflict" vs. "this renaming tries to rename Dog to String which is never allowed because String is a built-in scalar type." This PR reflects the change.