### PR TITLE
Enable check_untyped_defs for the OrientDB schema_graph_builder.py file.

### DIFF
--- a/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
+++ b/graphql_compiler/schema_generation/orientdb/schema_graph_builder.py
@@ -1,5 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from itertools import chain
+from typing import Dict, Set
 
 from funcy.py3 import lsplit
 from graphql.type import GraphQLList, GraphQLObjectType
@@ -460,7 +461,7 @@ def _validate_link_definition(
 
 def _get_end_direction_to_superclasses(link_property_definitions):
     """Return the set of superclasses that classes at each edge end must inherit from."""
-    links = {
+    links: Dict[str, Set[str]] = {
         EDGE_SOURCE_PROPERTY_NAME: set(),
         EDGE_DESTINATION_PROPERTY_NAME: set(),
     }

--- a/mypy.ini
+++ b/mypy.ini
@@ -182,9 +182,6 @@ disallow_untyped_defs = False
 disallow_untyped_calls = False
 disallow_untyped_defs = False
 
-[mypy-graphql_compiler.schema_generation.orientdb.schema_graph_builder.*]
-check_untyped_defs = False
-
 [mypy-graphql_compiler.schema_generation.schema_graph.*]
 check_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
Mypy's `check_untyped_defs` check being disabled is bad because it essentially acts as a `type: ignore` over the entire untyped definition block — it can hide type errors that could have been caught purely by inference from typed code used in the untyped context.

Whenever I have a few minutes to spare between meetings, I've made it a habit to eliminate such rule suppressions from our codebase 😄   It only takes a few minutes, but makes a huge difference over time!