### PR TITLE
Annotate simple test methods to return None.

### DIFF
--- a/graphql_compiler/tests/schema_generation_tests/test_orientdb_schema_generation.py
+++ b/graphql_compiler/tests/schema_generation_tests/test_orientdb_schema_generation.py
@@ -160,7 +160,7 @@ ARBITRARY_CONCRETE_NON_GRAPH_CLASS = {
 
 
 class GraphqlSchemaGenerationTests(unittest.TestCase):
-    def test_parsed_vertex(self):
+    def test_parsed_vertex(self) -> None:
         schema_data = [
             BASE_VERTEX,
             ENTITY,
@@ -168,7 +168,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         schema_graph = get_orientdb_schema_graph(schema_data, [])
         self.assertTrue(schema_graph.get_element_by_class_name("Entity").is_vertex)
 
-    def test_parsed_edge(self):
+    def test_parsed_edge(self) -> None:
         schema_data = [
             BASE_EDGE,
             BASE_VERTEX,
@@ -180,12 +180,12 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         schema_graph = get_orientdb_schema_graph(schema_data, [])
         self.assertTrue(schema_graph.get_element_by_class_name("Person_LivesIn").is_edge)
 
-    def test_parsed_non_graph_class(self):
+    def test_parsed_non_graph_class(self) -> None:
         schema_data = [EXTERNAL_SOURCE]
         schema_graph = get_orientdb_schema_graph(schema_data, [])
         self.assertTrue(schema_graph.get_element_by_class_name("ExternalSource").is_non_graph)
 
-    def test_no_superclass(self):
+    def test_no_superclass(self) -> None:
         schema_data = [BASE_VERTEX]
         schema_graph = get_orientdb_schema_graph(schema_data, [])
         self.assertEqual(
@@ -193,7 +193,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
             schema_graph.get_superclass_set(ORIENTDB_BASE_VERTEX_CLASS_NAME),
         )
 
-    def test_parsed_superclass_field(self):
+    def test_parsed_superclass_field(self) -> None:
         schema_data = [
             BASE_EDGE,
             BASE_VERTEX,
@@ -208,7 +208,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
             schema_graph.get_superclass_set("Person_LivesIn"),
         )
 
-    def test_parsed_superclasses_field(self):
+    def test_parsed_superclasses_field(self) -> None:
         schema_data = [
             BASE_VERTEX,
             ENTITY,
@@ -218,7 +218,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
             {"Entity", ORIENTDB_BASE_VERTEX_CLASS_NAME}, schema_graph.get_superclass_set("Entity")
         )
 
-    def test_parsed_property(self):
+    def test_parsed_property(self) -> None:
         schema_data = [
             BASE_VERTEX,
             ENTITY,
@@ -227,7 +227,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         name_property = schema_graph.get_element_by_class_name("Entity").properties["name"]
         self.assertTrue(is_same_type(name_property.type, GraphQLString))
 
-    def test_native_orientdb_collection_property(self):
+    def test_native_orientdb_collection_property(self) -> None:
         schema_data = [
             BASE_VERTEX,
             ENTITY,
@@ -238,7 +238,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         self.assertTrue(is_same_type(alias_property.type, GraphQLList(GraphQLString)))
         self.assertEqual(alias_property.default, set())
 
-    def test_class_collection_property(self):
+    def test_class_collection_property(self) -> None:
         schema_data = [
             BASE_VERTEX,
             DATA_POINT,
@@ -255,7 +255,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         )
         self.assertEqual(friends_property.default, list())
 
-    def test_link_parsing(self):
+    def test_link_parsing(self) -> None:
         schema_data = [
             BASE_EDGE,
             BASE_VERTEX,
@@ -269,7 +269,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         self.assertEqual(person_lives_in_edge.base_in_connection, "Person")
         self.assertEqual(person_lives_in_edge.base_out_connection, "Location")
 
-    def test_parsed_class_fields(self):
+    def test_parsed_class_fields(self) -> None:
         schema_data = [
             BASE_EDGE,
             BASE_VERTEX,
@@ -282,7 +282,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         person_lives_in_edge = schema_graph.get_element_by_class_name("Person_LivesIn")
         self.assertEqual(PERSON_LIVES_IN_EDGE["customFields"], person_lives_in_edge.class_fields)
 
-    def test_type_equivalence_dicts(self):
+    def test_type_equivalence_dicts(self) -> None:
         schema_data = [
             BASE_EDGE,
             BASE_VERTEX,
@@ -322,7 +322,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         self.assertTrue(is_same_type(baby.fields["out_Person_LivesIn"].type, location_list_type))
         self.assertTrue(is_same_type(location.fields["in_Person_LivesIn"].type, union_list_type))
 
-    def test_filter_type_equivalences_with_no_edges(self):
+    def test_filter_type_equivalences_with_no_edges(self) -> None:
         schema_data = [
             BASE_VERTEX,
             BABY,
@@ -338,7 +338,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         person_subclass_set = schema_graph.get_subclass_set("Person")
         self.assertIsNone(schema.get_type(_get_union_type_name(person_subclass_set)))
 
-    def test_edge_inheritance(self):
+    def test_edge_inheritance(self) -> None:
         schema_data = [
             BASE_EDGE,
             BABY_LIVES_IN_EDGE,
@@ -354,7 +354,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         baby_lives_in_edge = schema_graph.get_element_by_class_name("Baby_LivesIn")
         self.assertEqual("Baby", baby_lives_in_edge.base_in_connection)
 
-    def test_ignore_properties_with_invalid_name_warning(self):
+    def test_ignore_properties_with_invalid_name_warning(self) -> None:
         schema_data = [
             BASE_VERTEX,
             CLASS_WITH_INVALID_PROPERTY_NAME,
@@ -363,7 +363,7 @@ class GraphqlSchemaGenerationTests(unittest.TestCase):
         with pytest.warns(UserWarning):
             get_graphql_schema_from_orientdb_schema_data(schema_data)
 
-    def test_include_non_graph_classes_in_graphql_schema(self):
+    def test_include_non_graph_classes_in_graphql_schema(self) -> None:
         non_graph_classes_to_include = [
             ABSTRACT_NON_GRAPH_CLASS_WITH_ONLY_VERTEX_CONCRETE_SUBCLASSES,
         ]

--- a/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
+++ b/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
@@ -97,35 +97,35 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
             graphql_schema, type_equivalence_hints, dialect, vertex_name_to_table, join_descriptors
         )
 
-    def test_table_vertex_representation(self):
+    def test_table_vertex_representation(self) -> None:
         self.assertIsInstance(self.schema_info.schema.get_type("Table1"), GraphQLObjectType)
 
-    def test_table_vertex_representation_with_non_default_name(self):
+    def test_table_vertex_representation_with_non_default_name(self) -> None:
         self.assertIsInstance(
             self.schema_info.schema.get_type("ArbitraryObjectName"), GraphQLObjectType
         )
 
-    def test_represent_supported_fields(self):
+    def test_represent_supported_fields(self) -> None:
         table1_graphql_object = self.schema_info.schema.get_type("Table1")
         self.assertEqual(
             table1_graphql_object.fields["column_with_supported_type"].type, GraphQLString
         )
 
-    def test_ignored_fields_not_supported(self):
+    def test_ignored_fields_not_supported(self) -> None:
         table1_graphql_object = self.schema_info.schema.get_type("Table1")
         self.assertTrue("column_with_non_supported_type" not in table1_graphql_object.fields)
 
-    def test_warn_when_type_is_not_supported(self):
+    def test_warn_when_type_is_not_supported(self) -> None:
         with pytest.warns(Warning):
             try_get_graphql_scalar_type("binary", LargeBinary())
 
-    def test_support_sql_tz_naive_datetime_types(self):
+    def test_support_sql_tz_naive_datetime_types(self) -> None:
         column_name = "tz_naive_datetime"
         tz_naive_types = (DateTime(timezone=False), TIMESTAMP(timezone=False))
         for sql_type in tz_naive_types:
             self.assertEqual(GraphQLDateTime, try_get_graphql_scalar_type(column_name, sql_type))
 
-    def test_do_not_support_sql_tz_aware_datetime_types(self):
+    def test_do_not_support_sql_tz_aware_datetime_types(self) -> None:
         column_name = "tz_aware_datetime"
         tz_aware_types = (DateTime(timezone=True), TIMESTAMP(timezone=True))
         for sql_type in tz_aware_types:
@@ -133,11 +133,11 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
                 graphql_type = try_get_graphql_scalar_type(column_name, sql_type)
             self.assertIsNone(graphql_type)
 
-    def test_mssql_scalar_type_representation(self):
+    def test_mssql_scalar_type_representation(self) -> None:
         table1_graphql_object = self.schema_info.schema.get_type("Table1")
         self.assertEqual(table1_graphql_object.fields["column_with_mssql_type"].type, GraphQLInt)
 
-    def test_direct_sql_edge_representation(self):
+    def test_direct_sql_edge_representation(self) -> None:
         table1_graphql_object = self.schema_info.schema.get_type("Table1")
         arbitrarily_named_graphql_object = self.schema_info.schema.get_type("ArbitraryObjectName")
         self.assertEqual(
@@ -147,7 +147,7 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
             arbitrarily_named_graphql_object.fields["in_test_edge"].type.of_type.name, "Table1"
         )
 
-    def test_get_join_descriptors(self):
+    def test_get_join_descriptors(self) -> None:
         expected_join_descriptors = {
             "Table1": {
                 "out_test_edge": DirectJoinDescriptor("source_column", "destination_column")
@@ -158,7 +158,7 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
         }
         self.assertEqual(expected_join_descriptors, self.schema_info.join_descriptors)
 
-    def test_basic_index_generation_from_primary_key(self):
+    def test_basic_index_generation_from_primary_key(self) -> None:
         indexes = self.schema_graph.get_all_indexes_for_class("Table1")
         self.assertIn(
             IndexDefinition(
@@ -172,7 +172,7 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
             indexes,
         )
 
-    def test_index_generation_from_multi_column_primary_key(self):
+    def test_index_generation_from_multi_column_primary_key(self) -> None:
         indexes = self.schema_graph.get_all_indexes_for_class("TableWithMultiplePrimaryKeyColumns")
         self.assertEqual(
             {
@@ -188,11 +188,11 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
             indexes,
         )
 
-    def test_index_generation_from_primary_key_with_an_unsupported_column_type(self):
+    def test_index_generation_from_primary_key_with_an_unsupported_column_type(self) -> None:
         indexes = self.schema_graph.get_all_indexes_for_class("TableWithNonSupportedPrimaryKeyType")
         self.assertEqual(frozenset(), indexes)
 
-    def test_index_generation_from_unique_constraint(self):
+    def test_index_generation_from_unique_constraint(self) -> None:
         indexes = self.schema_graph.get_all_indexes_for_class("Table1")
         self.assertIn(
             IndexDefinition(
@@ -209,7 +209,7 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
 
 @pytest.mark.filterwarnings("ignore: Ignored .* edges implied by composite foreign keys.*")
 class SQLAlchemyForeignKeyEdgeGenerationTests(unittest.TestCase):
-    def test_edge_generation_from_foreign_keys(self):
+    def test_edge_generation_from_foreign_keys(self) -> None:
         metadata = MetaData()
 
         table1 = Table(
@@ -242,7 +242,7 @@ class SQLAlchemyForeignKeyEdgeGenerationTests(unittest.TestCase):
             },
         )
 
-    def test_warning_for_ignored_foreign_keys(self):
+    def test_warning_for_ignored_foreign_keys(self) -> None:
         metadata = MetaData()
 
         table1 = Table(
@@ -281,7 +281,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
     def setUp(self):
         self.vertex_name_to_table = _get_test_vertex_name_to_table()
 
-    def test_reference_to_non_existent_source_vertex(self):
+    def test_reference_to_non_existent_source_vertex(self) -> None:
         direct_edges = {
             "invalid_source_vertex": DirectEdgeDescriptor(
                 "InvalidVertexName", "source_column", "ArbitraryObjectName", "destination_column"
@@ -290,7 +290,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
         with self.assertRaises(InvalidSQLEdgeError):
             get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
-    def test_reference_to_non_existent_destination_vertex(self):
+    def test_reference_to_non_existent_destination_vertex(self) -> None:
         direct_edges = {
             "invalid_source_vertex": DirectEdgeDescriptor(
                 "Table1", "source_column", "InvalidVertexName", "destination_column"
@@ -299,7 +299,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
         with self.assertRaises(InvalidSQLEdgeError):
             get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
-    def test_reference_to_non_existent_source_column(self):
+    def test_reference_to_non_existent_source_column(self) -> None:
         direct_edges = {
             "invalid_source_vertex": DirectEdgeDescriptor(
                 "Table1", "invalid_column_name", "ArbitraryObjectName", "destination_column"
@@ -308,7 +308,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
         with self.assertRaises(InvalidSQLEdgeError):
             get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
-    def test_reference_to_non_existent_destination_column(self):
+    def test_reference_to_non_existent_destination_column(self) -> None:
         direct_edges = {
             "invalid_destination_column": DirectEdgeDescriptor(
                 "Table1", "source_column", "ArbitraryObjectName", "invalid_column_name"
@@ -317,7 +317,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
         with self.assertRaises(InvalidSQLEdgeError):
             get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
-    def test_missing_primary_key(self):
+    def test_missing_primary_key(self) -> None:
         table_without_primary_key = Table(
             "TableWithoutPrimaryKey", MetaData(), Column("arbitrary_column", String()),
         )
@@ -325,7 +325,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
         with self.assertRaises(MissingPrimaryKeyError):
             get_sqlalchemy_schema_info(faulty_vertex_name_to_table, {}, dialect())
 
-    def test_missing_multiple_primary_keys(self):
+    def test_missing_multiple_primary_keys(self) -> None:
         metadata: MetaData = MetaData()
         table_without_primary_key: Table = Table(
             "TableWithoutPrimaryKey", metadata, Column("arbitrary_column", String()),

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -13,7 +13,8 @@ from ...schema_transformation.utils import (
     InvalidTypeNameError,
     SchemaNameConflictError,
     SchemaTransformError,
-    get_scalar_names,
+    builtin_scalar_type_names,
+    get_custom_scalar_names,
 )
 from .input_schema_strings import InputSchemaStrings as ISS
 
@@ -772,7 +773,7 @@ class TestRenameSchema(unittest.TestCase):
                 self.schema = schema
 
             def get(self, key, default=None):
-                if key in get_scalar_names(self.schema):
+                if key in get_custom_scalar_names(self.schema) or key in builtin_scalar_type_names:
                     # Making an exception for scalar types because renaming and suppressing them
                     # hasn't been implemented yet
                     return key

--- a/graphql_compiler/tests/test_end_to_end.py
+++ b/graphql_compiler/tests/test_end_to_end.py
@@ -366,7 +366,7 @@ class QueryFormattingTests(unittest.TestCase):
         )
         self.assertEqual(datetime.datetime(2014, 2, 5, 3, 20, 55), value)
 
-    def test_deserialize_lists(self):
+    def test_deserialize_lists(self) -> None:
         # Non-collection
         with self.assertRaises(GraphQLInvalidArgumentError):
             deserialize_argument("numbers", GraphQLList(GraphQLInt), 1)

--- a/graphql_compiler/tests/test_global_utils.py
+++ b/graphql_compiler/tests/test_global_utils.py
@@ -5,7 +5,7 @@ from ..global_utils import assert_set_equality
 
 
 class GlobalUtilTests(unittest.TestCase):
-    def test_assert_equality(self):
+    def test_assert_equality(self) -> None:
         # Matching sets
         assert_set_equality({"a", "b"}, {"a", "b"})
 

--- a/graphql_compiler/tests/test_sqlalchemy_extensions.py
+++ b/graphql_compiler/tests/test_sqlalchemy_extensions.py
@@ -14,7 +14,7 @@ class CommonIrLoweringTests(unittest.TestCase):
         self.maxDiff = None
         self.sql_schema_info = get_sqlalchemy_schema_info()
 
-    def test_print_query_mssql_basic(self):
+    def test_print_query_mssql_basic(self) -> None:
         query = sqlalchemy.select([self.sql_schema_info.vertex_name_to_table["Animal"].c.name])
         text = print_sqlalchemy_query_string(query, mssql.dialect())
         expected_text = """
@@ -23,7 +23,7 @@ class CommonIrLoweringTests(unittest.TestCase):
         """
         compare_sql(self, expected_text, text)
 
-    def test_print_query_mssql_string_argument(self):
+    def test_print_query_mssql_string_argument(self) -> None:
         animal = self.sql_schema_info.vertex_name_to_table["Animal"].alias()
         query = sqlalchemy.select([animal.c.name]).where(
             animal.c.name == sqlalchemy.bindparam("name", expanding=False)
@@ -36,7 +36,7 @@ class CommonIrLoweringTests(unittest.TestCase):
         """
         compare_sql(self, expected_text, text)
 
-    def test_print_query_mssql_list_argument(self):
+    def test_print_query_mssql_list_argument(self) -> None:
         animal = self.sql_schema_info.vertex_name_to_table["Animal"].alias()
         query = sqlalchemy.select([animal.c.name]).where(
             animal.c.name.in_(sqlalchemy.bindparam("names", expanding=True))

--- a/graphql_compiler/tests/test_subclass.py
+++ b/graphql_compiler/tests/test_subclass.py
@@ -12,7 +12,7 @@ class SubclassTests(unittest.TestCase):
         """Initialize the test schema once for all tests."""
         self.schema = get_schema()
 
-    def test_compute_subclass_sets(self):
+    def test_compute_subclass_sets(self) -> None:
         type_equivalence_hints = {
             self.schema.get_type("Event"): self.schema.get_type(
                 "Union__BirthEvent__Event__FeedingEvent"

--- a/graphql_compiler/tests/test_testing_invariants.py
+++ b/graphql_compiler/tests/test_testing_invariants.py
@@ -21,7 +21,7 @@ class TestingInvariants(unittest.TestCase):
             if input_name not in IGNORED_FUNCTIONS
         }
 
-    def test_ir_generation_test_invariants(self):
+    def test_ir_generation_test_invariants(self) -> None:
         # Importing IrGenerationTests globally would expose them to py.test a second time.
         # We import them here so that these tests are not run again.
         from .test_ir_generation import IrGenerationTests
@@ -35,7 +35,7 @@ class TestingInvariants(unittest.TestCase):
                     )
                 )
 
-    def test_compiler_test_invariants(self):
+    def test_compiler_test_invariants(self) -> None:
         # Importing CompilerTests globally would expose them to py.test a second time.
         # We import them here so that these tests are not run again.
         from .test_compiler import CompilerTests

--- a/mypy.ini
+++ b/mypy.ini
@@ -230,8 +230,10 @@ disallow_untyped_decorators = False
 disallow_untyped_defs = False
 
 [mypy-graphql_compiler.tests.schema_generation_tests.*]
-disallow_incomplete_defs = False
 disallow_untyped_calls = False
+
+[mypy-graphql_compiler.tests.schema_generation_tests.test_sqlalchemy_schema_generation.*]
+disallow_incomplete_defs = False
 disallow_untyped_defs = False
 
 [mypy-graphql_compiler.tests.schema_transformation_tests.example_schema.*]
@@ -310,16 +312,8 @@ disallow_untyped_defs = False
 [mypy-graphql_compiler.tests.test_emit_output.*]
 disallow_untyped_calls = False
 
-[mypy-graphql_compiler.tests.test_end_to_end.*]
-disallow_incomplete_defs = False
-disallow_untyped_defs = False
-
 [mypy-graphql_compiler.tests.test_explain_info.*]
 disallow_untyped_calls = False
-
-[mypy-graphql_compiler.tests.test_global_utils.*]
-disallow_incomplete_defs = False
-disallow_untyped_defs = False
 
 [mypy-graphql_compiler.tests.test_graphql_pretty_print.*]
 disallow_untyped_calls = False


### PR DESCRIPTION
No complex changes, just adding `-> None` after a test function definition in a bunch of places.