### PR TITLE
Remove unnecessary value list in null-related filters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1263,7 +1263,7 @@ Example Use
     {
         Animal {
             name @output(out_name: "animal_name")
-            color @filter(op_name: "is_null", value: [])
+            color @filter(op_name: "is_null")
         }
     }
 
@@ -1274,7 +1274,7 @@ Constraints and Rules
 ^^^^^^^^^^^^^^^^^^^^^
 
 -  Must be applied on a property field.
--  :code:`value` must be empty.
+-  :code:`value` must not appear in the filter (shown here) or be an empty list.
 
 is\_not\_null
 ~~~~~~~~~~~~~
@@ -1287,7 +1287,7 @@ Example Use
     {
         Animal {
             name @output(out_name: "animal_name")
-            color @filter(op_name: "is_not_null", value: [])
+            color @filter(op_name: "is_not_null")
         }
     }
 
@@ -1297,7 +1297,7 @@ Constraints and Rules
 ^^^^^^^^^^^^^^^^^^^^^
 
 -  Must be applied on a property field.
--  :code:`value` must be empty.
+-  :code:`value` must not appear in the filter (shown here) or be an empty list.
 
 Type coercions
 --------------

--- a/README.rst
+++ b/README.rst
@@ -1297,7 +1297,7 @@ Constraints and Rules
 ^^^^^^^^^^^^^^^^^^^^^
 
 -  Must be applied on a property field.
--  :code:`value` must not appear in the filter (shown here) or be an empty list.
+-  :code:`value` must either not appear in the filter (shown in the example) or be an empty list.
 
 Type coercions
 --------------

--- a/README.rst
+++ b/README.rst
@@ -1274,7 +1274,7 @@ Constraints and Rules
 ^^^^^^^^^^^^^^^^^^^^^
 
 -  Must be applied on a property field.
--  :code:`value` must not appear in the filter (shown here) or be an empty list.
+-  :code:`value` must either not appear in the filter (shown in the example) or be an empty list.
 
 is\_not\_null
 ~~~~~~~~~~~~~

--- a/docs/source/language_specification/query_directives.rst
+++ b/docs/source/language_specification/query_directives.rst
@@ -1135,7 +1135,7 @@ Example Use
     {
         Animal {
             name @output(out_name: "animal_name")
-            color @filter(op_name: "is_null", value: [])
+            color @filter(op_name: "is_null")
         }
     }
 
@@ -1159,7 +1159,7 @@ Example Use
     {
         Animal {
             name @output(out_name: "animal_name")
-            color @filter(op_name: "is_not_null", value: [])
+            color @filter(op_name: "is_not_null")
         }
     }
 

--- a/docs/source/language_specification/query_directives.rst
+++ b/docs/source/language_specification/query_directives.rst
@@ -1146,7 +1146,7 @@ Constraints and Rules
 ^^^^^^^^^^^^^^^^^^^^^
 
 -  Must be applied on a property field.
--  :code:`value` must be empty.
+-  :code:`value` must either not appear in the filter (shown in the example) or be an empty list.
 
 is\_not\_null
 ~~~~~~~~~~~~~
@@ -1169,4 +1169,4 @@ Constraints and Rules
 ^^^^^^^^^^^^^^^^^^^^^
 
 -  Must be applied on a property field.
--  :code:`value` must be empty.
+-  :code:`value` must either not appear in the filter (shown in the example) or be an empty list.


### PR DESCRIPTION
`value: []` used to be required but then we relaxed the @filter definition to allow it to not be present.