### PR TITLE
Make some analysis fields private

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -404,15 +404,15 @@ class QueryPlanningAnalysis:
         return ir_and_metadata.query_metadata_table
 
     @cached_property
-    def types(self) -> Dict[VertexPath, Union[GraphQLObjectType, GraphQLInterfaceType]]:
+    def _types(self) -> Dict[VertexPath, Union[GraphQLObjectType, GraphQLInterfaceType]]:
         """Find the type at each VertexPath."""
         return get_types(self.metadata_table)
 
     @cached_property
-    def classes_with_missing_counts(self) -> Set[str]:
+    def _classes_with_missing_counts(self) -> Set[str]:
         """Return classes that don't have count statistics."""
         classes_with_missing_counts = set()
-        for vertex_path, vertex_type in self.types.items():
+        for vertex_path, vertex_type in self._types.items():
             if self.schema_info.statistics.get_class_count(vertex_type.name) is None:
                 classes_with_missing_counts.add(vertex_type.name)
             if len(vertex_path) > 1:
@@ -430,60 +430,60 @@ class QueryPlanningAnalysis:
         )
 
     @cached_property
-    def filters(self) -> Dict[VertexPath, Set[FilterInfo]]:
+    def _filters(self) -> Dict[VertexPath, Set[FilterInfo]]:
         """Get the filters at each VertexPath."""
         return get_filters(self.metadata_table)
 
     @cached_property
-    def fold_scope_roots(self) -> Dict[VertexPath, VertexPath]:
+    def _fold_scope_roots(self) -> Dict[VertexPath, VertexPath]:
         """Map each VertexPath in the query that's inside a fold to the VertexPath of the fold."""
         return get_fold_scope_roots(self.metadata_table)
 
     @cached_property
-    def single_field_filters(self) -> Dict[PropertyPath, Set[FilterInfo]]:
+    def _single_field_filters(self) -> Dict[PropertyPath, Set[FilterInfo]]:
         """Find the single field filters for each field. Filters like name_or_alias are excluded."""
-        return get_single_field_filters(self.filters)
+        return get_single_field_filters(self._filters)
 
     @cached_property
-    def fields_eligible_for_pagination(self) -> Set[PropertyPath]:
+    def _fields_eligible_for_pagination(self) -> Set[PropertyPath]:
         """Return all the fields we can consider for pagination."""
         return get_fields_eligible_for_pagination(
-            self.schema_info, self.types, self.single_field_filters, self.fold_scope_roots,
+            self.schema_info, self._types, self._single_field_filters, self._fold_scope_roots,
         )
 
     @cached_property
-    def field_value_intervals(self) -> Dict[PropertyPath, Interval[Any]]:
+    def _field_value_intervals(self) -> Dict[PropertyPath, Interval[Any]]:
         """Return the field value intervals for this query."""
         return get_field_value_intervals(
             self.schema_info,
-            self.types,
-            self.single_field_filters,
+            self._types,
+            self._single_field_filters,
             self.ast_with_parameters.parameters,
         )
 
     @cached_property
-    def selectivities(self) -> Dict[VertexPath, Selectivity]:
+    def _selectivities(self) -> Dict[VertexPath, Selectivity]:
         """Get the combined selectivities of filters at each vertex."""
         return get_selectivities(
-            self.schema_info, self.types, self.filters, self.ast_with_parameters.parameters
+            self.schema_info, self._types, self._filters, self.ast_with_parameters.parameters
         )
 
     @cached_property
-    def distinct_result_set_estimates(self) -> Dict[VertexPath, float]:
+    def _distinct_result_set_estimates(self) -> Dict[VertexPath, float]:
         """Return the distinct result set estimates for this query."""
         return get_distinct_result_set_estimates(
-            self.schema_info, self.types, self.selectivities, self.ast_with_parameters.parameters
+            self.schema_info, self._types, self._selectivities, self.ast_with_parameters.parameters
         )
 
     @cached_property
-    def pagination_capacities(self) -> Dict[PropertyPath, int]:
+    def _pagination_capacities(self) -> Dict[PropertyPath, int]:
         """Return the pagination capacities for this query."""
         return get_pagination_capacities(
             self.schema_info,
-            self.types,
-            self.fields_eligible_for_pagination,
-            self.field_value_intervals,
-            self.distinct_result_set_estimates,
+            self._types,
+            self._fields_eligible_for_pagination,
+            self._field_value_intervals,
+            self._distinct_result_set_estimates,
         )
 
 

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -79,10 +79,10 @@ def paginate_query_ast(
 
     # See if we can and should split the query
     num_pages = 1
-    if query_analysis.classes_with_missing_counts:
+    if query_analysis._classes_with_missing_counts:
         advisories += tuple(
             MissingClassCount(class_name)
-            for class_name in query_analysis.classes_with_missing_counts
+            for class_name in query_analysis._classes_with_missing_counts
         )
     else:
         result_size = query_analysis.cardinality_estimate

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -136,7 +136,7 @@ def get_pagination_plan(
     # Get the pagination capacity
     vertex_path = (root_node,)
     property_path = PropertyPath(vertex_path, pagination_field)
-    capacity = query_analysis.pagination_capacities.get(property_path)
+    capacity = query_analysis._pagination_capacities.get(property_path)
     # If the pagination capacity is None, then there must be no quantiles for this property.
     if capacity is None:
         ideal_min_num_quantiles_per_page = 5

--- a/graphql_compiler/query_pagination/query_parameterizer.py
+++ b/graphql_compiler/query_pagination/query_parameterizer.py
@@ -86,7 +86,7 @@ def _is_new_filter_stronger(
     Returns:
         whether the old filter can be removed with no change in query meaning.
     """
-    vertex_type = query_analysis.types[property_path.vertex_path].name
+    vertex_type = query_analysis._types[property_path.vertex_path].name
     new_int_value = convert_field_value_to_int(
         query_analysis.schema_info, vertex_type, property_path.field_name, new_filter_value,
     )

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -49,7 +49,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             }""",
             {"uuid_min": "80000000-0000-0000-0000-000000000000",},
         )
-        intervals = analyze_query_string(schema_info, query).field_value_intervals
+        intervals = analyze_query_string(schema_info, query)._field_value_intervals
         expected_intervals = {
             (("Animal",), "uuid"): Interval(
                 lower_bound="80000000-0000-0000-0000-000000000001", upper_bound=None
@@ -90,7 +90,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {"uuid": "80000000-0000-0000-0000-000000000000",},
         )
 
-        estimates = analyze_query_string(schema_info, query).distinct_result_set_estimates
+        estimates = analyze_query_string(schema_info, query)._distinct_result_set_estimates
         expected_estimates = {
             ("Animal",): 1,
             ("Animal", "out_Animal_ParentOf"): 1000,
@@ -127,7 +127,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {"uuid_min": "80000000-0000-0000-0000-000000000000",},
         )
 
-        capacities = analyze_query_string(schema_info, query).pagination_capacities
+        capacities = analyze_query_string(schema_info, query)._pagination_capacities
         expected_capacities = {(("Animal",), "uuid"): 500}
         self.assertEqual(expected_capacities, capacities)
 
@@ -161,7 +161,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {"uuid": "80000000-0000-0000-0000-000000000000",},
         )
 
-        capacities = analyze_query_string(schema_info, query).pagination_capacities
+        capacities = analyze_query_string(schema_info, query)._pagination_capacities
         expected_capacities = {(("Animal",), "uuid"): 1}
         self.assertEqual(expected_capacities, capacities)
 
@@ -206,7 +206,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
                 ("Animal",): Selectivity(kind="absolute", value=1.0),
                 ("Animal", "out_Animal_ParentOf"): Selectivity(kind="fractional", value=0.5),
             },
-            analyze_query_string(schema_info, query).selectivities,
+            analyze_query_string(schema_info, query)._selectivities,
         )
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
@@ -241,7 +241,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {},
         )
 
-        capacities = analyze_query_string(schema_info, query).pagination_capacities
+        capacities = analyze_query_string(schema_info, query)._pagination_capacities
         expected_capacities = {
             (("Species",), "limbs"): 100,
             (("Species",), "uuid"): 1000,
@@ -281,7 +281,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {"limbs_min": 10,},
         )
 
-        capacities = analyze_query_string(schema_info, query).pagination_capacities
+        capacities = analyze_query_string(schema_info, query)._pagination_capacities
         expected_capacities = {
             (("Species",), "limbs"): 91,
             (("Species",), "uuid"): 905,
@@ -326,14 +326,14 @@ class CostEstimationAnalysisTests(unittest.TestCase):
                 ("Animal",): graphql_schema.get_type("Animal"),
                 ("Animal", "out_Animal_ParentOf"): graphql_schema.get_type("Animal"),
             },
-            analysis.types,
+            analysis._types,
         )
 
         self.assertEqual(
-            {("Animal", "out_Animal_ParentOf"): ("Animal",)}, analysis.fold_scope_roots
+            {("Animal", "out_Animal_ParentOf"): ("Animal",)}, analysis._fold_scope_roots
         )
 
-        self.assertEqual({(("Animal",), "uuid"): 1000,}, analysis.pagination_capacities)
+        self.assertEqual({(("Animal",), "uuid"): 1000,}, analysis._pagination_capacities)
 
     @pytest.mark.usefixtures("snapshot_orientdb_client")
     def test_eligible_fields(self) -> None:
@@ -371,7 +371,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
             {},
         )
         analysis = analyze_query_string(schema_info, query)
-        eligible_fields = analysis.fields_eligible_for_pagination
+        eligible_fields = analysis._fields_eligible_for_pagination
         expected_eligible_fields = {
             (("Animal",), "uuid"),
             (("Animal",), "birthday"),
@@ -413,7 +413,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
         }""",
             {"animal_name": "Joe",},
         )
-        estimates = analyze_query_string(schema_info, query).distinct_result_set_estimates
+        estimates = analyze_query_string(schema_info, query)._distinct_result_set_estimates
         expected_estimates = {
             ("Animal",): 1.0,
             ("Animal", "in_Animal_ParentOf"): 1000.0,


### PR DESCRIPTION
Exploring ways to add `QueryPlanningAnalysis` to the public api. Not intending to merge this PR, just making inline comments to start discussion.

We can't just make `QueryPlanningAnalysis` public as is, because then any function signature change would need a compiler major version bump if we were to respect semver. Fields like `pagination_capactiy` are not stable yet, so that's a risky move.

So I've made most fields private, only leaving public the fields that are already public in some way, or we intend to make public for sure. This created uses of private fields outside of this class. I address each problem separately with inline comments.

I argue that the `QueryPlanningAnalysis` class is still effective, even after half its fields are marked private. The main goal is to avoid recomputation of analysis that many of our passes require, and that's still possible. The class is even more effective now that we can avoid recomputation even among public library api calls.

It's worth noting that now plumbing of analysis becomes a bit more tedious: A function either:
- Uses only public analysis passes, or
- Is one of the analysis passes

@obi1kenobi @MichaelaShtilmanMinkin thoughts?