### PR TITLE
Type hint and convert namedtuple to dataclass in merge_schemas.py

### DIFF
--- a/graphql_compiler/schema_transformation/merge_schemas.py
+++ b/graphql_compiler/schema_transformation/merge_schemas.py
@@ -27,12 +27,13 @@ from graphql.language.ast import (
 )
 from graphql.language.printer import print_ast
 from graphql.pyutils import FrozenList
-from graphql.type import GraphQLInterfaceType, GraphQLObjectType, GraphQLSchema, GraphQLUnionType
+from graphql.type import GraphQLSchema
 import six
 
 from ..ast_manipulation import get_ast_with_non_null_stripped
 from ..compiler.helpers import INBOUND_EDGE_DIRECTION, OUTBOUND_EDGE_DIRECTION
 from ..compiler.subclass import compute_subclass_sets
+from ..schema.typedefs import TypeEquivalenceHintsType
 from .utils import (
     InvalidCrossSchemaEdgeError,
     SchemaMergeNameConflictError,
@@ -42,7 +43,7 @@ from .utils import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class MergedSchemaDescriptor:
     """Describes a merged schema."""
 
@@ -56,7 +57,7 @@ class MergedSchemaDescriptor:
     type_name_to_schema_id: Dict[str, str]
 
 
-@dataclass
+@dataclass(frozen=True)
 class FieldReference:
     """Describes a particular field, including the type and schema to which it belongs."""
 
@@ -70,7 +71,7 @@ class FieldReference:
     field_name: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class CrossSchemaEdgeDescriptor:
     """Describes an edge that spans two schema."""
 
@@ -88,11 +89,10 @@ class CrossSchemaEdgeDescriptor:
 
 
 def merge_schemas(
+    # OrderedDict is unsubscriptable (pylint E1136)
     schema_id_to_ast: "OrderedDict[str, DocumentNode]",
     cross_schema_edges: List[CrossSchemaEdgeDescriptor],
-    type_equivalence_hints: Optional[
-        Dict[Union[GraphQLInterfaceType, GraphQLObjectType], GraphQLUnionType]
-    ] = None,
+    type_equivalence_hints: Optional[TypeEquivalenceHintsType] = None,
 ) -> MergedSchemaDescriptor:
     """Merge all input schemas and add all cross-schema edges.
 
@@ -478,7 +478,7 @@ def _add_cross_schema_edges(
     type_name_to_schema_id: Dict[str, str],
     scalars: Set[str],
     cross_schema_edges: List[CrossSchemaEdgeDescriptor],
-    type_equivalence_hints: Dict[Union[GraphQLInterfaceType, GraphQLObjectType], GraphQLUnionType],
+    type_equivalence_hints: TypeEquivalenceHintsType,
     query_type: str,
 ) -> DocumentNode:
     """Add cross-schema edges into the schema AST.

--- a/graphql_compiler/schema_transformation/merge_schemas.py
+++ b/graphql_compiler/schema_transformation/merge_schemas.py
@@ -440,7 +440,7 @@ def _process_generic_type_definition(
 
     Args:
         generic_type: AST node representing the definition of a type.
-        schema_id: the identifier of the schema that this type came from.
+        schema_id: identifier of the schema that this type came from.
         existing_scalars: set of names of all existing scalars.
         type_name_to_schema_id: mapping names of types to the identifier of the schema that they
                                 came from.
@@ -633,7 +633,7 @@ def _check_cross_schema_edge_is_valid(
                  defined scalars.
         union_type_names: names of all union types in the merged schema, used for informative
                           error messages.
-        cross_schema_edge: the edge that we check the validity of.
+        cross_schema_edge: edge that we check the validity of.
 
     Raises:
         - InvalidCrossSchemaEdgeError if the cross-schema edge lies within one schema, refers
@@ -739,7 +739,7 @@ def _check_field_types_are_matching_scalars(
         type_name_to_definition: mapping name of types to their definitions.
         scalars: names of all scalars in the merged_schema, including both built in and user
                  defined scalars.
-        cross_schema_edge: the edge that we check the validity of.
+        cross_schema_edge: edge that we check the validity of.
 
     Raises:
         - InvalidCrossSchemaEdgeError if the cross-schema edge stitches together fields that are

--- a/graphql_compiler/tests/schema_transformation_tests/test_merge_schemas.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_merge_schemas.py
@@ -554,7 +554,13 @@ class TestMergeSchemasNoCrossSchemaEdges(unittest.TestCase):
             )
         with self.assertRaises(ValueError):
             merge_schemas(
-                OrderedDict([(42, parse(ISS.basic_schema)), ("enum", parse(ISS.enum_schema)),]), [],
+                OrderedDict(
+                    [
+                        (42, parse(ISS.basic_schema)),  # type: ignore
+                        ("enum", parse(ISS.enum_schema)),
+                    ]
+                ),
+                [],
             )
 
     def test_too_few_input_schemas(self):


### PR DESCRIPTION
The PR adds type hints and converts namedtuples to dataclasses. Also does a bit of documentation cleanup. 