### PR TITLE
Annotate functions in tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -24,3 +24,6 @@ exclude_lines =
 
     # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
+
+    # Don't complain if ellipsis never gets executed
+    grep -r "^[ ]*\.\.\.$"

--- a/.coveragerc
+++ b/.coveragerc
@@ -26,4 +26,4 @@ exclude_lines =
     if __name__ == .__main__.:
 
     # Don't complain if ellipsis never gets executed
-    grep -r "^[ ]*\.\.\.$"
+    ^[ ]*\.\.\.$

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -79,7 +79,8 @@ Renaming constraints:
   being renamed or suppressed.
 """
 from collections import namedtuple
-from typing import AbstractSet, Any, Dict, List, Optional, Protocol, Set, Tuple, Union, cast
+import sys
+from typing import AbstractSet, Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 from graphql import (
     DocumentNode,
@@ -109,6 +110,16 @@ from .utils import (
     get_query_type_name,
     type_name_is_valid,
 )
+
+
+# We prefer the explicit sys.version_info check instead of the more common try-except ImportError
+# approach, because at the moment mypy seems to have an easier time with the sys.version_info check:
+# https://github.com/python/mypy/issues/1393
+if sys.version_info[:2] >= (3, 8):
+    # Protocol was only added to typing in Python 3.8
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 
 RenamedSchemaDescriptor = namedtuple(

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -79,7 +79,6 @@ Renaming constraints:
   being renamed or suppressed.
 """
 from collections import namedtuple
-import sys
 from typing import AbstractSet, Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 from graphql import (
@@ -96,6 +95,7 @@ from graphql.language.visitor import IDLE, REMOVE, Visitor, VisitorAction, visit
 import six
 
 from ..ast_manipulation import get_ast_with_non_null_and_list_stripped
+from ..typedefs import Protocol
 from .utils import (
     CascadingSuppressionError,
     InvalidTypeNameError,
@@ -110,16 +110,6 @@ from .utils import (
     get_query_type_name,
     type_name_is_valid,
 )
-
-
-# We prefer the explicit sys.version_info check instead of the more common try-except ImportError
-# approach, because at the moment mypy seems to have an easier time with the sys.version_info check:
-# https://github.com/python/mypy/issues/1393
-if sys.version_info[:2] >= (3, 8):
-    # Protocol was only added to typing in Python 3.8
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 
 
 RenamedSchemaDescriptor = namedtuple(

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -79,7 +79,7 @@ Renaming constraints:
   being renamed or suppressed.
 """
 from collections import namedtuple
-from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Set, Tuple, Union, cast
+from typing import AbstractSet, Any, Dict, List, Optional, Protocol, Set, Tuple, Union, cast
 
 from graphql import (
     DocumentNode,
@@ -127,9 +127,13 @@ RenamedSchemaDescriptor = namedtuple(
 VisitorReturnType = Union[Node, VisitorAction]
 
 
-def rename_schema(
-    schema_ast: DocumentNode, renamings: Mapping[str, Optional[str]]
-) -> RenamedSchemaDescriptor:
+class RenamingMapping(Protocol):
+    def get(self, key: str, default: Optional[str]) -> Optional[str]:
+        """Define mapping for renaming object."""
+        ...
+
+
+def rename_schema(schema_ast: DocumentNode, renamings: RenamingMapping) -> RenamedSchemaDescriptor:
     """Create a RenamedSchemaDescriptor; rename/suppress types and root type fields using renamings.
 
     Any type, interface, enum, or fields of the root type/query type whose name
@@ -203,7 +207,7 @@ def rename_schema(
 
 def _validate_renamings(
     schema_ast: DocumentNode,
-    renamings: Mapping[str, Optional[str]],
+    renamings: RenamingMapping,
     query_type: str,
     custom_scalar_names: AbstractSet[str],
 ) -> None:
@@ -236,7 +240,7 @@ def _validate_renamings(
 
 
 def _ensure_no_cascading_type_suppressions(
-    schema_ast: DocumentNode, renamings: Mapping[str, Optional[str]], query_type: str
+    schema_ast: DocumentNode, renamings: RenamingMapping, query_type: str
 ) -> None:
     """Check for fields with suppressed types or unions whose members were all suppressed."""
     visitor = CascadingSuppressionCheckVisitor(renamings, query_type)
@@ -281,7 +285,7 @@ def _ensure_no_cascading_type_suppressions(
 
 def _ensure_no_unsupported_operations(
     schema_ast: DocumentNode,
-    renamings: Mapping[str, Optional[str]],
+    renamings: RenamingMapping,
     custom_scalar_names: AbstractSet[str],
 ) -> None:
     """Check for unsupported renaming or suppression operations."""
@@ -290,20 +294,26 @@ def _ensure_no_unsupported_operations(
 
 
 def _ensure_no_unsupported_scalar_operations(
-    renamings: Mapping[str, Optional[str]],
+    renamings: RenamingMapping,
     custom_scalar_names: AbstractSet[str],
 ) -> None:
     """Check for unsupported scalar operations."""
     unsupported_scalar_operations = {}  # Map scalars to value to be renamed.
     for scalar_name in custom_scalar_names:
-        if renamings.get(scalar_name, scalar_name) != scalar_name:
-            # renamings.get(scalar_name, scalar_name) returns something that is not scalar iff it
-            # attempts to do something with the scalar (i.e. renaming or suppressing it)
-            unsupported_scalar_operations[scalar_name] = renamings[scalar_name]
+        possibly_renamed_scalar_name = renamings.get(scalar_name, scalar_name)
+        # renamings.get(scalar_name, scalar_name) returns something that is not scalar iff it
+        # attempts to do something with the scalar (i.e. renaming or suppressing it)
+        if possibly_renamed_scalar_name != scalar_name:
+            unsupported_scalar_operations[scalar_name] = possibly_renamed_scalar_name
     for builtin_scalar_name in builtin_scalar_type_names:
-        if renamings.get(builtin_scalar_name, builtin_scalar_name) != builtin_scalar_name:
+        possibly_renamed_builtin_scalar_name = renamings.get(
+            builtin_scalar_name, builtin_scalar_name
+        )
+        if possibly_renamed_builtin_scalar_name != builtin_scalar_name:
             # Check that built-in scalar types remain unchanged during renaming.
-            unsupported_scalar_operations[builtin_scalar_name] = renamings[builtin_scalar_name]
+            unsupported_scalar_operations[
+                builtin_scalar_name
+            ] = possibly_renamed_builtin_scalar_name
     if unsupported_scalar_operations:
         raise NotImplementedError(
             f"Scalar renaming and suppression is not implemented yet, but renamings attempted to "
@@ -313,7 +323,7 @@ def _ensure_no_unsupported_scalar_operations(
 
 
 def _ensure_no_unsupported_suppressions(
-    schema_ast: DocumentNode, renamings: Mapping[str, Optional[str]]
+    schema_ast: DocumentNode, renamings: RenamingMapping
 ) -> None:
     """Confirm renamings contains no enums, interfaces, or interface implementation suppressions."""
     visitor = SuppressionNotImplementedVisitor(renamings)
@@ -356,7 +366,7 @@ def _ensure_no_unsupported_suppressions(
 
 def _rename_and_suppress_types(
     schema_ast: DocumentNode,
-    renamings: Mapping[str, Optional[str]],
+    renamings: RenamingMapping,
     query_type: str,
     custom_scalar_names: AbstractSet[str],
 ) -> Tuple[DocumentNode, Dict[str, str]]:
@@ -401,7 +411,7 @@ def _rename_and_suppress_types(
 
 
 def _rename_and_suppress_query_type_fields(
-    schema_ast: DocumentNode, renamings: Mapping[str, Optional[str]], query_type: str
+    schema_ast: DocumentNode, renamings: RenamingMapping, query_type: str
 ) -> DocumentNode:
     """Rename or suppress all fields of the query type.
 
@@ -506,7 +516,7 @@ class RenameSchemaTypesVisitor(Visitor):
 
     def __init__(
         self,
-        renamings: Mapping[str, Optional[str]],
+        renamings: RenamingMapping,
         query_type: str,
         custom_scalar_names: AbstractSet[str],
     ) -> None:
@@ -639,7 +649,7 @@ class RenameSchemaTypesVisitor(Visitor):
 
 
 class RenameQueryTypeFieldsVisitor(Visitor):
-    def __init__(self, renamings: Mapping[str, Optional[str]], query_type: str) -> None:
+    def __init__(self, renamings: RenamingMapping, query_type: str) -> None:
         """Create a visitor for renaming or suppressing fields of the query type in a schema AST.
 
         Args:
@@ -727,7 +737,7 @@ class CascadingSuppressionCheckVisitor(Visitor):
     fields_to_suppress: Dict[str, Dict[str, str]]
     union_types_to_suppress: List[UnionTypeDefinitionNode]
 
-    def __init__(self, renamings: Mapping[str, Optional[str]], query_type: str) -> None:
+    def __init__(self, renamings: RenamingMapping, query_type: str) -> None:
         """Create a visitor to check that suppression does not cause an illegal state.
 
         Args:
@@ -836,7 +846,7 @@ class SuppressionNotImplementedVisitor(Visitor):
     unsupported_interface_suppressions: Set[str]
     unsupported_interface_implementation_suppressions: Set[str]
 
-    def __init__(self, renamings: Mapping[str, Optional[str]]) -> None:
+    def __init__(self, renamings: RenamingMapping) -> None:
         """Confirm renamings does not attempt to suppress enum/interface/interface implementation.
 
         Args:

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -1,7 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from ast import literal_eval
 from textwrap import dedent
-from typing import Dict, Set
+from typing import Dict, Set, Optional, Mapping
 import unittest
 
 from graphql import GraphQLSchema, build_ast_schema, parse
@@ -109,26 +109,26 @@ def check_rename_conflict_error_message(
 
 
 class TestRenameSchema(unittest.TestCase):
-    def test_rename_visitor_type_coverage(self):
+    def test_rename_visitor_type_coverage(self) -> None:
         """Check that all types are covered without overlap."""
         type_sets = [
             RenameSchemaTypesVisitor.noop_types,
             RenameSchemaTypesVisitor.rename_types,
         ]
         all_types = {snake_to_camel(node_type) + "Node" for node_type in QUERY_DOCUMENT_KEYS}
-        type_sets_union = set()
+        type_sets_union: Set[str] = set()
         for type_set in type_sets:
             self.assertTrue(type_sets_union.isdisjoint(type_set))
             type_sets_union.update(type_set)
         self.assertEqual(all_types, type_sets_union)
 
-    def test_no_rename(self):
+    def test_no_rename(self) -> None:
         renamed_schema = rename_schema(parse(ISS.basic_schema), {})
 
         self.assertEqual(ISS.basic_schema, print_ast(renamed_schema.schema_ast))
         self.assertEqual({}, renamed_schema.reverse_name_map)
 
-    def test_basic_rename(self):
+    def test_basic_rename(self) -> None:
         renamed_schema = rename_schema(parse(ISS.basic_schema), {"Human": "NewHuman"})
         renamed_schema_string = dedent(
             """\
@@ -150,7 +150,7 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({"NewHuman": "Human"}, renamed_schema.reverse_name_map)
 
-    def test_type_directive_same_name(self):
+    def test_type_directive_same_name(self) -> None:
         # Types, fields, and directives have different namespaces, so this schema and renaming are
         # both valid and the renaming only affects the object type.
         renamed_schema = rename_schema(
@@ -176,17 +176,17 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({"NewStitch": "stitch"}, renamed_schema.reverse_name_map)
 
-    def test_original_unmodified_rename(self):
+    def test_original_unmodified_rename(self) -> None:
         original_ast = parse(ISS.basic_schema)
         rename_schema(original_ast, {"Human": "NewHuman"})
         self.assertEqual(original_ast, parse(ISS.basic_schema))
 
-    def test_original_unmodified_suppress(self):
+    def test_original_unmodified_suppress(self) -> None:
         original_ast = parse(ISS.multiple_objects_schema)
         rename_schema(original_ast, {"Human": None})
         self.assertEqual(original_ast, parse(ISS.multiple_objects_schema))
 
-    def test_basic_suppress(self):
+    def test_basic_suppress(self) -> None:
         renamed_schema = rename_schema(parse(ISS.multiple_objects_schema), {"Human": None})
         renamed_schema_string = dedent(
             """\
@@ -211,7 +211,7 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({}, renamed_schema.reverse_name_map)
 
-    def test_multiple_type_suppress(self):
+    def test_multiple_type_suppress(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.multiple_objects_schema), {"Human": None, "Droid": None}
         )
@@ -233,7 +233,7 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({}, renamed_schema.reverse_name_map)
 
-    def test_swap_rename(self):
+    def test_swap_rename(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.multiple_objects_schema), {"Human": "Droid", "Droid": "Human"}
         )
@@ -265,7 +265,7 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({"Human": "Droid", "Droid": "Human"}, renamed_schema.reverse_name_map)
 
-    def test_rename_into_suppressed(self):
+    def test_rename_into_suppressed(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.multiple_objects_schema), {"Human": None, "Droid": "Human"}
         )
@@ -292,7 +292,7 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({"Human": "Droid"}, renamed_schema.reverse_name_map)
 
-    def test_cyclic_rename(self):
+    def test_cyclic_rename(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.multiple_objects_schema), {"Human": "Droid", "Droid": "Dog", "Dog": "Human"}
         )
@@ -326,7 +326,7 @@ class TestRenameSchema(unittest.TestCase):
             {"Dog": "Droid", "Human": "Dog", "Droid": "Human"}, renamed_schema.reverse_name_map
         )
 
-    def test_enum_rename(self):
+    def test_enum_rename(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.enum_schema), {"Droid": "NewDroid", "Height": "NewHeight"}
         )
@@ -355,11 +355,11 @@ class TestRenameSchema(unittest.TestCase):
             {"NewDroid": "Droid", "NewHeight": "Height"}, renamed_schema.reverse_name_map
         )
 
-    def test_enum_suppression(self):
+    def test_enum_suppression(self) -> None:
         with self.assertRaises(NotImplementedError):
             rename_schema(parse(ISS.multiple_enums_schema), {"Size": None})
 
-    def test_interface_rename(self):
+    def test_interface_rename(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.interface_schema), {"Kid": "NewKid", "Character": "NewCharacter"}
         )
@@ -388,25 +388,25 @@ class TestRenameSchema(unittest.TestCase):
             {"NewKid": "Kid", "NewCharacter": "Character"}, renamed_schema.reverse_name_map
         )
 
-    def test_suppress_interface_implementation(self):
+    def test_suppress_interface_implementation(self) -> None:
         with self.assertRaises(NotImplementedError):
             rename_schema(parse(ISS.various_types_schema), {"Giraffe": None})
 
-    def test_suppress_all_implementations_but_not_interface(self):
+    def test_suppress_all_implementations_but_not_interface(self) -> None:
         with self.assertRaises(NotImplementedError):
             rename_schema(parse(ISS.various_types_schema), {"Giraffe": None, "Human": None})
 
-    def test_suppress_interface_but_not_implementations(self):
+    def test_suppress_interface_but_not_implementations(self) -> None:
         with self.assertRaises(NotImplementedError):
             rename_schema(parse(ISS.various_types_schema), {"Character": None})
 
-    def test_suppress_interface_and_all_implementations(self):
+    def test_suppress_interface_and_all_implementations(self) -> None:
         with self.assertRaises(NotImplementedError):
             rename_schema(
                 parse(ISS.various_types_schema), {"Giraffe": None, "Character": None, "Human": None}
             )
 
-    def test_multiple_interfaces_rename(self):
+    def test_multiple_interfaces_rename(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.multiple_interfaces_schema),
             {"Human": "NewHuman", "Character": "NewCharacter", "Creature": "Creature"},
@@ -442,21 +442,21 @@ class TestRenameSchema(unittest.TestCase):
             {"NewHuman": "Human", "NewCharacter": "Character"}, renamed_schema.reverse_name_map
         )
 
-    def test_scalar_rename(self):
+    def test_scalar_rename(self) -> None:
         with self.assertRaises(NotImplementedError):
             rename_schema(
                 parse(ISS.scalar_schema),
                 {"Date": "NewDate"},
             )
 
-    def test_builtin_rename(self):
+    def test_builtin_rename(self) -> None:
         with self.assertRaises(NotImplementedError):
             rename_schema(
                 parse(ISS.list_schema),
                 {"String": "NewString"},
             )
 
-    def test_union_rename(self):
+    def test_union_rename(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.union_schema), {"HumanOrDroid": "NewHumanOrDroid", "Droid": "NewDroid"}
         )
@@ -488,7 +488,7 @@ class TestRenameSchema(unittest.TestCase):
             renamed_schema.reverse_name_map,
         )
 
-    def test_entire_union_suppress(self):
+    def test_entire_union_suppress(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.union_schema), {"HumanOrDroid": None, "Droid": "NewDroid"}
         )
@@ -518,7 +518,7 @@ class TestRenameSchema(unittest.TestCase):
             renamed_schema.reverse_name_map,
         )
 
-    def test_union_member_suppress(self):
+    def test_union_member_suppress(self) -> None:
         renamed_schema = rename_schema(parse(ISS.union_schema), {"Droid": None})
         renamed_schema_string = dedent(
             """\
@@ -543,7 +543,7 @@ class TestRenameSchema(unittest.TestCase):
             renamed_schema.reverse_name_map,
         )
 
-    def test_list_rename(self):
+    def test_list_rename(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.list_schema),
             {
@@ -593,7 +593,7 @@ class TestRenameSchema(unittest.TestCase):
             renamed_schema.reverse_name_map,
         )
 
-    def test_non_null_rename(self):
+    def test_non_null_rename(self) -> None:
         renamed_schema = rename_schema(parse(ISS.non_null_schema), {"Dog": "NewDog"})
         renamed_schema_string = dedent(
             """\
@@ -619,7 +619,7 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({"NewDog": "Dog"}, renamed_schema.reverse_name_map)
 
-    def test_non_null_suppress(self):
+    def test_non_null_suppress(self) -> None:
         renamed_schema = rename_schema(parse(ISS.non_null_schema), {"Dog": None})
         renamed_schema_string = dedent(
             """\
@@ -639,7 +639,7 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({}, renamed_schema.reverse_name_map)
 
-    def test_directive_rename(self):
+    def test_directive_rename(self) -> None:
         renamed_schema = rename_schema(
             parse(ISS.directive_schema),
             {
@@ -676,7 +676,7 @@ class TestRenameSchema(unittest.TestCase):
             {"NewHuman": "Human", "NewDroid": "Droid"}, renamed_schema.reverse_name_map
         )
 
-    def test_query_type_field_argument(self):
+    def test_query_type_field_argument(self) -> None:
         schema_string = dedent(
             """\
             schema {
@@ -711,7 +711,7 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({"NewHuman": "Human"}, renamed_schema.reverse_name_map)
 
-    def test_clashing_type_rename(self):
+    def test_clashing_type_rename(self) -> None:
         schema_string = dedent(
             """\
             schema {
@@ -739,7 +739,7 @@ class TestRenameSchema(unittest.TestCase):
             check_rename_conflict_error_message({"Human": {"Human1", "Human2"}}, {}, e.exception)
         )
 
-    def test_clashing_type_single_rename(self):
+    def test_clashing_type_single_rename(self) -> None:
         schema_string = dedent(
             """\
             schema {
@@ -767,7 +767,7 @@ class TestRenameSchema(unittest.TestCase):
             check_rename_conflict_error_message({"Human": {"Human", "Human2"}}, {}, e.exception)
         )
 
-    def test_clashing_type_one_unchanged_rename(self):
+    def test_clashing_type_one_unchanged_rename(self) -> None:
         schema_string = dedent(
             """\
             schema {
@@ -795,7 +795,7 @@ class TestRenameSchema(unittest.TestCase):
             check_rename_conflict_error_message({"Human": {"Human", "Human2"}}, {}, e.exception)
         )
 
-    def test_clashing_scalar_type_rename(self):
+    def test_clashing_scalar_type_rename(self) -> None:
         schema_string = dedent(
             """\
             schema {
@@ -820,7 +820,7 @@ class TestRenameSchema(unittest.TestCase):
             check_rename_conflict_error_message({"SCALAR": {"SCALAR", "Human"}}, {}, e.exception)
         )
 
-    def test_builtin_type_conflict_rename(self):
+    def test_builtin_type_conflict_rename(self) -> None:
         schema_string = dedent(
             """\
             schema {
@@ -841,7 +841,7 @@ class TestRenameSchema(unittest.TestCase):
             rename_schema(parse(schema_string), {"Human": "String"})
         self.assertTrue(check_rename_conflict_error_message({}, {"Human": "String"}, e.exception))
 
-    def test_multiple_naming_conflicts(self):
+    def test_multiple_naming_conflicts(self) -> None:
         schema_string = dedent(
             """\
             schema {
@@ -874,11 +874,11 @@ class TestRenameSchema(unittest.TestCase):
             )
         )
 
-    def test_illegal_rename_start_with_number(self):
+    def test_illegal_rename_start_with_number(self) -> None:
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "0Human"})
 
-    def test_illegal_rename_contains_illegal_char(self):
+    def test_illegal_rename_contains_illegal_char(self) -> None:
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "Human!"})
         with self.assertRaises(InvalidTypeNameError):
@@ -886,19 +886,19 @@ class TestRenameSchema(unittest.TestCase):
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "H.uman"})
 
-    def test_illegal_rename_to_double_underscore(self):
+    def test_illegal_rename_to_double_underscore(self) -> None:
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "__Human"})
 
-    def test_illegal_rename_to_reserved_name_type(self):
+    def test_illegal_rename_to_reserved_name_type(self) -> None:
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "__Type"})
 
-    def test_suppress_every_type(self):
+    def test_suppress_every_type(self) -> None:
         with self.assertRaises(SchemaTransformError):
             rename_schema(parse(ISS.basic_schema), {"Human": None})
 
-    def test_suppress_all_union_members(self):
+    def test_suppress_all_union_members(self) -> None:
         with self.assertRaises(CascadingSuppressionError):
             # Can't use ISS.union_schema here because suppressing all the members of the union would
             # mean suppressing every type in general, which means we couldn't be sure that
@@ -906,13 +906,13 @@ class TestRenameSchema(unittest.TestCase):
             # CascadingSuppressionError.
             rename_schema(parse(ISS.extended_union_schema), {"Human": None, "Droid": None})
 
-    def test_field_still_depends_on_suppressed_type(self):
+    def test_field_still_depends_on_suppressed_type(self) -> None:
         with self.assertRaises(CascadingSuppressionError):
             rename_schema(
                 parse(ISS.multiple_fields_schema), {"Dog": None}
             )  # The type named Human contains a field of type Dog.
 
-    def test_field_of_suppressed_type_in_suppressed_type(self):
+    def test_field_of_suppressed_type_in_suppressed_type(self) -> None:
         # The schema contains an object type that contains a field of the type Human. Normally,
         # suppressing the type named Human would cause a CascadingSuppressionError because the
         # resulting schema would still have fields of the type Human. Here, however, only the type
@@ -936,21 +936,31 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(renamed_schema_string, print_ast(renamed_schema.schema_ast))
         self.assertEqual({}, renamed_schema.reverse_name_map)
 
-    def test_field_in_list_still_depends_on_suppressed_type(self):
+    def test_field_in_list_still_depends_on_suppressed_type(self) -> None:
         with self.assertRaises(CascadingSuppressionError):
             rename_schema(parse(ISS.list_schema), {"Height": None})
 
-    def test_rename_using_dict_like_prefixer_class(self):
-        class PrefixNewDict(object):
+    def test_rename_using_dict_like_prefixer_class(self) -> None:
+        class PrefixNewDict(Mapping[str, Optional[str]]):
             def __init__(self, schema: GraphQLSchema):
                 self.schema = schema
 
-            def get(self, key, default=None):
+            def get(self, key: str, default=None) -> Optional[str]:
+                """Define mapping for renaming object."""
                 if key in get_custom_scalar_names(self.schema) or key in builtin_scalar_type_names:
                     # Making an exception for scalar types because renaming and suppressing them
                     # hasn't been implemented yet
                     return key
                 return "New" + key
+
+            def __getitem__(self, key: str) -> Optional[str]:
+                return self.get(key)
+
+            def __iter__(self) -> None:
+                raise NotImplementedError("Mapping not iterable")
+
+            def __len__(self) -> None:
+                raise NotImplementedError("Mapping has no length")
 
         schema = parse(ISS.various_types_schema)
         renamed_schema = rename_schema(schema, PrefixNewDict(build_ast_schema(schema)))

--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -15,7 +15,7 @@ from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
 #
 # Hence, the "unused import" warnings here are false-positives.
 if sys.version_info[:2] >= (3, 8):
-    # TypedDict and Literal were only added to typing in Python 3.8
+    # These were only added to typing in Python 3.8
     from typing import Literal, TypedDict, Protocol  # noqa  # pylint: disable=unused-import
 else:
     from typing_extensions import (  # noqa  # pylint: disable=unused-import

--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -5,9 +5,9 @@ from typing import Union
 from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
 
 
-# The below code is an import shim for TypedDict and Literal: we don't want to conditionally import
-# them from every file that needs them. Instead, we conditionally import them here and then import
-# from this file in every other location where they are needed.
+# The below code is an import shim for libraries added in Python 3.8: we don't want to conditionally
+# import them from every file that needs them. Instead, we conditionally import them here and then
+# import from this file in every other location where they are needed.
 #
 # We prefer the explicit sys.version_info check instead of the more common try-except ImportError
 # approach, because at the moment mypy seems to have an easier time with the sys.version_info check:

--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -16,9 +16,13 @@ from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
 # Hence, the "unused import" warnings here are false-positives.
 if sys.version_info[:2] >= (3, 8):
     # TypedDict and Literal were only added to typing in Python 3.8
-    from typing import Literal, TypedDict  # noqa  # pylint: disable=unused-import
+    from typing import Literal, TypedDict, Protocol  # noqa  # pylint: disable=unused-import
 else:
-    from typing_extensions import Literal, TypedDict  # noqa  # pylint: disable=unused-import
+    from typing_extensions import (  # noqa  # pylint: disable=unused-import
+        Literal,
+        TypedDict,
+        Protocol,
+    )
 
 
 # The compiler's supported GraphQL types for query arguments. The GraphQL type of a query argument

--- a/mypy.ini
+++ b/mypy.ini
@@ -198,10 +198,6 @@ disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
-[mypy-graphql_compiler.schema_transformation.merge_schemas.*]
-check_untyped_defs = False
-disallow_untyped_defs = False
-
 [mypy-graphql_compiler.schema_transformation.rename_query.*]
 disallow_untyped_defs = False
 
@@ -251,10 +247,6 @@ disallow_untyped_defs = False
 disallow_incomplete_defs = False
 disallow_untyped_calls = False
 disallow_untyped_defs = False
-
-[mypy-graphql_compiler.tests.schema_transformation_tests.test_rename_schema.*]
-check_untyped_defs = False
-disallow_incomplete_defs = False
 
 [mypy-graphql_compiler.tests.schema_transformation_tests.test_split_query.*]
 disallow_incomplete_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -255,7 +255,6 @@ disallow_untyped_defs = False
 [mypy-graphql_compiler.tests.schema_transformation_tests.test_rename_schema.*]
 check_untyped_defs = False
 disallow_incomplete_defs = False
-disallow_untyped_defs = False
 
 [mypy-graphql_compiler.tests.schema_transformation_tests.test_split_query.*]
 disallow_incomplete_defs = False


### PR DESCRIPTION
Type-hinting PR described in #922 

Since `Mapping` is actually always iterable, even though what we really need for `renamings` is simply an object that implements the `get` method described in the code, I modified the code so that it permits non-iterable renamings to work.