### PR TITLE
Type hint exported compiler frontend functions

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -1102,10 +1102,9 @@ def ast_to_ir(
     """Convert the given GraphQL AST object into compiler IR, using the given schema object.
 
     Args:
-        schema: GraphQL schema object, created using the GraphQL library
-        ast: AST object to be compiled to IR
-        type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
-                                Used as a workaround for GraphQL's lack of support for
+        schema: schema object created using the GraphQL library for which the query must be valid
+        ast: query in AST form to transform into compiler IR
+        type_equivalence_hints: optional, used as a workaround for GraphQL's lack of support for
                                 inheritance across "types" (i.e. non-interfaces), as well as a
                                 workaround for Gremlin's total lack of inheritance-awareness.
                                 The key-value pairs in the dict specify that the "key" type
@@ -1150,10 +1149,9 @@ def graphql_to_ir(
     """Convert the given GraphQL string into compiler IR, using the given schema object.
 
     Args:
-        schema: GraphQL schema object, created using the GraphQL library
-        graphql_string: string containing the GraphQL to compile to compiler IR
-        type_equivalence_hints: optional dict of GraphQL interface or type -> GraphQL union.
-                                Used as a workaround for GraphQL's lack of support for
+        schema: schema object created using the GraphQL library for which the query must be valid
+        graphql_string: GraphQL query to transform into compiler IR
+        type_equivalence_hints: optional, used as a workaround for GraphQL's lack of support for
                                 inheritance across "types" (i.e. non-interfaces), as well as a
                                 workaround for Gremlin's total lack of inheritance-awareness.
                                 The key-value pairs in the dict specify that the "key" type
@@ -1169,7 +1167,7 @@ def graphql_to_ir(
                                 *****
 
     Returns:
-        IrAndMetadata for the given schema and graphql_string
+        IrAndMetadata for the given schema and GraphQL query string
 
     Raises flavors of GraphQLError in the following cases:
         - if the query is invalid GraphQL (GraphQLParsingError);

--- a/graphql_compiler/tests/test_explain_info.py
+++ b/graphql_compiler/tests/test_explain_info.py
@@ -30,7 +30,7 @@ class ExplainInfoTests(unittest.TestCase):
         self,
         graphql_test: Callable[[], test_input_data.CommonTestData],
         expected_filter_list: List[Tuple[BaseLocation, List[FilterInfo]]],
-        expected_recurse_list: List[Tuple[Location, List[RecurseInfo]]],
+        expected_recurse_list: List[Tuple[BaseLocation, List[RecurseInfo]]],
         expected_output_list: List[Tuple[str, OutputInfo]],
     ) -> None:
         """Verify query produces expected explain infos."""

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -1,5 +1,6 @@
 # Copyright 2017-present Kensho Technologies, LLC.
 import string
+from typing import cast
 import unittest
 
 from graphql import parse
@@ -8,6 +9,7 @@ import six
 
 from ..compiler.compiler_frontend import graphql_to_ir
 from ..exceptions import GraphQLCompilationError, GraphQLParsingError, GraphQLValidationError
+from ..schema import TypeEquivalenceHintsType
 from .test_helpers import get_schema
 
 
@@ -1462,10 +1464,15 @@ class IrGenerationErrorTests(unittest.TestCase):
                 }
             }
         }"""
-        invalid_type_equivalence_hints = {
+        invalid_type_equivalence_hint_data = {
             "Event": "Union__BirthEvent__Event__FeedingEvent",
             "BirthEvent": "Union__BirthEvent__Event__FeedingEvent",
         }
+
+        invalid_type_equivalence_hints: TypeEquivalenceHintsType = cast(TypeEquivalenceHintsType, {
+            self.schema.get_type(key): self.schema.get_type(value)
+            for key, value in invalid_type_equivalence_hint_data.items()
+        })
         with self.assertRaises(TypeError):
             graphql_to_ir(
                 self.schema,

--- a/graphql_compiler/tests/test_ir_generation_errors.py
+++ b/graphql_compiler/tests/test_ir_generation_errors.py
@@ -1469,10 +1469,13 @@ class IrGenerationErrorTests(unittest.TestCase):
             "BirthEvent": "Union__BirthEvent__Event__FeedingEvent",
         }
 
-        invalid_type_equivalence_hints: TypeEquivalenceHintsType = cast(TypeEquivalenceHintsType, {
-            self.schema.get_type(key): self.schema.get_type(value)
-            for key, value in invalid_type_equivalence_hint_data.items()
-        })
+        invalid_type_equivalence_hints: TypeEquivalenceHintsType = cast(
+            TypeEquivalenceHintsType,
+            {
+                self.schema.get_type(key): self.schema.get_type(value)
+                for key, value in invalid_type_equivalence_hint_data.items()
+            },
+        )
         with self.assertRaises(TypeError):
             graphql_to_ir(
                 self.schema,

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,9 +19,6 @@ check_untyped_defs = False
 disallow_untyped_calls = False
 disallow_untyped_defs = False
 
-[mypy-graphql_compiler.compiler.common.*]
-disallow_untyped_calls = False
-
 [mypy-graphql_compiler.compiler.compiler_frontend.*]
 check_untyped_defs = False
 disallow_untyped_calls = False
@@ -198,10 +195,6 @@ disallow_untyped_calls = False
 check_untyped_defs = False
 disallow_untyped_defs = False
 
-[mypy-graphql_compiler.schema_transformation.merge_schemas.*]
-check_untyped_defs = False
-disallow_untyped_defs = False
-
 [mypy-graphql_compiler.schema_transformation.rename_query.*]
 disallow_untyped_defs = False
 
@@ -297,9 +290,6 @@ disallow_untyped_defs = False
 [mypy-graphql_compiler.tests.test_emit_output.*]
 disallow_untyped_calls = False
 
-[mypy-graphql_compiler.tests.test_explain_info.*]
-disallow_untyped_calls = False
-
 [mypy-graphql_compiler.tests.test_graphql_pretty_print.*]
 disallow_untyped_calls = False
 
@@ -312,9 +302,6 @@ check_untyped_defs = False
 disallow_incomplete_defs = False
 disallow_untyped_calls = False
 disallow_untyped_defs = False
-
-[mypy-graphql_compiler.tests.test_ir_generation_errors.*]
-disallow_untyped_calls = False
 
 [mypy-graphql_compiler.tests.test_ir_lowering.*]
 check_untyped_defs = False


### PR DESCRIPTION
Add minimal type hints for `compiler_frontend.py` and fix broken type hints elsewhere. Then, constrict `mypy.ini` to the strictest configuration that passes.