### PR TITLE
Add Literal to typing import shim, change to mypy-friendly approach.

### DIFF
--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -6,7 +6,7 @@ from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
 
 
 # The below code is an import shim for TypedDict and Literal: we don't want to conditionally import
-# then from every file that needs them. Instead, we conditionally import them here and then import
+# them from every file that needs them. Instead, we conditionally import them here and then import
 # from this file in every other location where they are needed.
 #
 # We prefer the explicit sys.version_info check instead of the more common try-except ImportError

--- a/graphql_compiler/typedefs.py
+++ b/graphql_compiler/typedefs.py
@@ -1,18 +1,24 @@
 # Copyright 2020-present Kensho Technologies, LLC.
+import sys
 from typing import Union
 
 from graphql import GraphQLList, GraphQLNonNull, GraphQLScalarType
 
 
-# The below code is an import shim for TypedDict: we don't want to conditionally import it from
-# every file that needs it. Instead, we conditionally import it here and then import from this file
-# in every other location where this is needed.
+# The below code is an import shim for TypedDict and Literal: we don't want to conditionally import
+# then from every file that needs them. Instead, we conditionally import them here and then import
+# from this file in every other location where they are needed.
 #
-# Hence, the "unused import" warnings on TypedDict here are false-positives.
-try:
-    from typing import TypedDict  # noqa  # pylint: disable=unused-import
-except ImportError:  # TypedDict was only added to typing in Python 3.8
-    from typing_extensions import TypedDict  # noqa  # pylint: disable=unused-import
+# We prefer the explicit sys.version_info check instead of the more common try-except ImportError
+# approach, because at the moment mypy seems to have an easier time with the sys.version_info check:
+# https://github.com/python/mypy/issues/1393
+#
+# Hence, the "unused import" warnings here are false-positives.
+if sys.version_info[:2] >= (3, 8):
+    # TypedDict and Literal were only added to typing in Python 3.8
+    from typing import Literal, TypedDict  # noqa  # pylint: disable=unused-import
+else:
+    from typing_extensions import Literal, TypedDict  # noqa  # pylint: disable=unused-import
 
 
 # The compiler's supported GraphQL types for query arguments. The GraphQL type of a query argument


### PR DESCRIPTION
Without the `sys.version_info` check, this used to require a `type: ignore` due to the following problem:
https://twitter.com/PredragGruevski/status/1308085206285529089?s=20

Mypy tracking issue for the import error approach is here: https://github.com/python/mypy/issues/1393

For our needs, `sys.version_info` is an acceptable solution for Python import shims.