### PR TITLE
Update Read the Docs contributing documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -96,9 +96,10 @@ fashion by decorating with the :code:`@pytest.mark.slow` flag.
 Code of Conduct
 ---------------
 
-.. We use an external link that points to the ReadTheDocs webpage instead of an internal link below
-   since this file is also "included" in ReadTheDocs through the :include: directive and there is
-   no syntax for linking to another file that works in both "sphinx" and "native" reStructuredText.
+.. We use an external link that points to the Read the Docs webpage instead of an internal link
+   below since this file is also "included" in Read the Docs through the :include: directive and
+   there is no syntax for linking to another file that works in both "sphinx" and "native"
+   reStructuredText.
 
 This project adheres to the Contributor Covenant `code of
 conduct <https://graphql-compiler.readthedocs.io/en/latest/about/code_of_conduct.html>`__. By

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -148,7 +148,7 @@ documentation.
 We have taken measures so that the hosted documentation is updated, tested and monitored
 automatically. We configured a Github webhook so that the hosted documentation is updated
 every time the main branch gets updated, test the documentation during CI and configured Read the
-Docs to send notifications to graphql-compiler-maintainer@kensho.com in case there were any issues
+Docs to send notifications to graphql-compiler-maintainer@kensho.com in case there are any issues
 with building the documentation that were not caught during CI.
 
 Since Read the Docs does not currently `support Pipfiles

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -141,9 +141,14 @@ that your files start with a line like:
 Read the Docs
 -------------
 
-We are currently in the process of moving most of our documentation to
-Read the Docs, a web utility that makes it easy to view and present
+To host our documentation we use Read the Docs, a web utility that makes it easy to view and present
 documentation.
+
+We have taken measures so that the hosted documentation is updated, tested and monitored
+automatically. We configured a Github webhook so that the hosted documentation is updated
+every time the main branch gets updated, build and test the documentation during CI and
+configured Read the Docs to send notifications to graphql-compiler-maintainer@kensho.com in case
+there were any issues with building the documentation that were not caught during CI.
 
 Since Read the Docs does not currently `support Pipfiles
 <https://github.com/readthedocs/readthedocs.org/issues/3181>`__, we must keep the

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -147,9 +147,9 @@ documentation.
 
 We have taken measures so that the hosted documentation is updated, tested and monitored
 automatically. We configured a Github webhook so that the hosted documentation is updated
-every time the main branch gets updated, build and test the documentation during CI and
-configured Read the Docs to send notifications to graphql-compiler-maintainer@kensho.com in case
-there were any issues with building the documentation that were not caught during CI.
+every time the main branch gets updated, test the documentation during CI and configured Read the
+Docs to send notifications to graphql-compiler-maintainer@kensho.com in case there were any issues
+with building the documentation that were not caught during CI.
 
 Since Read the Docs does not currently `support Pipfiles
 <https://github.com/readthedocs/readthedocs.org/issues/3181>`__, we must keep the

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ and multiple `SQL <https://graphql-compiler.readthedocs.io/en/latest/supported_d
 database management systems, such as PostgreSQL, MSSQL and MySQL.
 
 For a detailed overview, see `our blog post <https://blog.kensho.com/compiled-graphql-as-a-database-query-language-72e106844282>`__.
-To get started, see `our ReadTheDocs documentation <https://graphql-compiler.readthedocs.io/en/latest/>`__.
+To get started, see `our Read the Docs documentation <https://graphql-compiler.readthedocs.io/en/latest/>`__.
 To contribute, please see `our contributing guide <https://graphql-compiler.readthedocs.io/en/latest/about/contributing.html>`__.
 
 Examples
@@ -29,7 +29,7 @@ Examples
 .. HACK: To avoid duplicating the end-to-end examples, we use the `include` restructured text
          directive. We add the comments below to mark the start and end of the text that the
          `include` directive has to copy. An alternative here would be to add an examples directory
-         and "include" the examples from there in both the README and ReadTheDocs. However, github
+         and "include" the examples from there in both the README and Read the Docs. However, github
          does not support the `include` directive: https://github.com/github/markup/issues/172
 
 OrientDB

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "GraphQL Compiler"
-# readthedocs uses the variable named copyright for the copyright message.
+# Read the Docs uses the variable named copyright for the copyright message.
 # pylint: disable=redefined-builtin
 copyright = "2017-present Kensho Technologies, LLC."
 # pylint: enable=redefined-builtin

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,7 +18,7 @@ GraphQL compiler
             this solution.
          -  Another way is to write "Home <index>" instead of "Home <self>". This is a hack
             that fixes the issue, but leads to some error messages that will be confusing for
-            GraphQL compiler Readthedocs contributors.
+            GraphQL compiler Read the Docs contributors.
 
 .. toctree::
    :hidden:
@@ -34,7 +34,7 @@ GraphQL compiler is a library that simplifies data querying and exploration by e
 simple query language to target multiple database backends. The query language is:
 
 .. EDUCATIONAL: The pattern below is what you would call a definition list in restructuredtext.
-   The "terms" get special rendering in the readthedocs html file.
+   The "terms" get special rendering in the Read the Docs html file.
 
 Written in valid GraphQL syntax
    Since it uses GraphQL syntax, the user get access to the entire GraphQL ecosystem,


### PR DESCRIPTION
I updated the Read the Docs contributing documentation since we are no longer in the "process of moving our documentation to Read the Docs". I also added some documentation to give contributors an understanding of how our documentation is tested, built and monitored. Finally, I fixed some grammar changing occurrences of "ReadTheDocs" or "readthedocs" to "Read the Docs" since that is the proper name of Read the Docs.