### PR TITLE
Fix schema comparison test helper

### DIFF
--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -571,16 +571,14 @@ def compare_schema_texts_order_independently(
     sorted_received_schema_text = _lexicographic_sort_schema_text(received_schema_text)
     msg = "\n{}\n\n!=\n\n{}".format(sorted_expected_schema_text, sorted_received_schema_text)
     compare_ignoring_whitespace(
-        test_case,
-        sorted_expected_schema_text,
-        sorted_received_schema_text,
-        msg
+        test_case, sorted_expected_schema_text, sorted_received_schema_text, msg
     )
 
 
 def get_schema() -> GraphQLSchema:
     """Get a schema object for testing."""
     return build_schema(SCHEMA_TEXT)
+
 
 def get_type_equivalence_hints() -> TypeEquivalenceHintsType:
     """Get the default type_equivalence_hints used for testing."""

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -558,7 +558,7 @@ def compare_ignoring_whitespace(
     test_case.assertEqual(transform(expected), transform(received), msg=msg)
 
 
-def _lexicographic_sort_schema_text(schema_text: str):
+def _lexicographic_sort_schema_text(schema_text: str) -> str:
     """Sort the schema types and fields in a lexicographic order."""
     return print_schema(lexicographic_sort_schema(build_schema(schema_text)))
 

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -7,10 +7,9 @@ import re
 from typing import Dict, List, Optional, Set, Tuple, Union, cast
 from unittest import TestCase
 
-from graphql import GraphQLList, parse
+from graphql import GraphQLList, build_schema, lexicographic_sort_schema, print_schema
 from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType, GraphQLUnionType
 from graphql.type.schema import GraphQLSchema
-from graphql.utilities.build_ast_schema import build_ast_schema
 from pyorient.orient import OrientDB
 import six
 import sqlalchemy
@@ -559,24 +558,29 @@ def compare_ignoring_whitespace(
     test_case.assertEqual(transform(expected), transform(received), msg=msg)
 
 
+def _lexicographic_sort_schema_text(schema_text: str):
+    """Sort the schema types and fields in a lexicographic order."""
+    return print_schema(lexicographic_sort_schema(build_schema(schema_text)))
+
+
 def compare_schema_texts_order_independently(
     test_case: TestCase, expected_schema_text: str, received_schema_text: str,
 ) -> None:
     """Compare expected and received schema texts, ignoring order of definitions."""
-    expected_schema_blocks = expected_schema_text.split("\n\n")
-    received_schema_blocks = expected_schema_text.split("\n\n")
-
-    # This is the preferred order-independent comparison method in Python:
-    # https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertCountEqual
-    test_case.assertCountEqual(expected_schema_blocks, received_schema_blocks)
+    sorted_expected_schema_text = _lexicographic_sort_schema_text(expected_schema_text)
+    sorted_received_schema_text = _lexicographic_sort_schema_text(received_schema_text)
+    msg = "\n{}\n\n!=\n\n{}".format(sorted_expected_schema_text, sorted_received_schema_text)
+    compare_ignoring_whitespace(
+        test_case,
+        sorted_expected_schema_text,
+        sorted_received_schema_text,
+        msg
+    )
 
 
 def get_schema() -> GraphQLSchema:
     """Get a schema object for testing."""
-    ast = parse(SCHEMA_TEXT)
-    schema = build_ast_schema(ast)
-    return schema
-
+    return build_schema(SCHEMA_TEXT)
 
 def get_type_equivalence_hints() -> TypeEquivalenceHintsType:
     """Get the default type_equivalence_hints used for testing."""


### PR DESCRIPTION
The schema comparison test helper was buggy. It was not using the "received_schema_text" at all. When I changed the function to use "received_schema_text", I got some errors. So I had to re-implement the schema comparison.

The reason that this didn't fail linting was because we have the unused-argument pylint disabled. I did not enable it because the comment below was quite discouraging and because it would involve a lot of work / pylint disable comments.
```
    # unused-argument,         # needs some cleanup and per-line suppression,
                                             # buggy / unclear how to suppress only a single function
```
Here are some of the errors that you get when you re-enable it. 
```
************* Module graphql_compiler.compiler.compiler_entities
build/lib/graphql_compiler/compiler/compiler_entities.py:134:27: W0613: Unused argument 'visitor_fn' (unused-argument)
************* Module graphql_compiler.compiler.compiler_frontend
build/lib/graphql_compiler/compiler/compiler_frontend.py:266:4: W0613: Unused argument 'schema' (unused-argument)
build/lib/graphql_compiler/compiler/compiler_frontend.py:266:12: W0613: Unused argument 'current_schema_type' (unused-argument)
build/lib/graphql_compiler/compiler/compiler_frontend.py:266:33: W0613: Unused argument 'ast' (unused-argument)
************* Module graphql_compiler.compiler.cypher_query
build/lib/graphql_compiler/compiler/cypher_query.py:58:38: W0613: Unused argument 'query_metadata_table' (unused-argument)
build/lib/graphql_compiler/compiler/cypher_query.py:177:61: W0613: Unused argument 'type_equivalence_hints' (unused-argument)
************* Module graphql_compiler.compiler.emit_cypher
build/lib/graphql_compiler/compiler/emit_cypher.py:255:22: W0613: Unused argument 'schema_info' (unused-argument)
************* Module graphql_compiler.compiler.emit_gremlin
build/lib/graphql_compiler/compiler/emit_gremlin.py:10:22: W0613: Unused argument 'schema_info' (unused-argument)
************* Module graphql_compiler.compiler.emit_match
build/lib/graphql_compiler/compiler/emit_match.py:258:22: W0613: Unused argument 'schema_info' (unused-argument)
************* Module graphql_compiler.compiler.filters
build/lib/graphql_compiler/compiler/filters.py:864:61: W0613: Unused argument 'location' (unused-argument)
build/lib/graphql_compiler/compiler/filters.py:864:71: W0613: Unused argument 'context' (unused-argument)
build/lib/graphql_compiler/compiler/filters.py:897:65: W0613: Unused argument 'location' (unused-argument)
build/lib/graphql_compiler/compiler/filters.py:897:75: W0613: Unused argument 'context' (unused-argument)
************* Module graphql_compiler.compiler.ir_lowering_common.common
build/lib/graphql_compiler/compiler/ir_lowering_common/common.py:124:34: W0613: Unused argument 'query_metadata_table' (unused-argument)
************* Module graphql_compiler.compiler.ir_lowering_cypher.ir_lowering
build/lib/graphql_compiler/compiler/ir_lowering_cypher/ir_lowering.py:28:65: W0613: Unused argument 'type_equivalence_hints' (unused-argument)
************* Module graphql_compiler.compiler.ir_lowering_match
build/lib/graphql_compiler/compiler/ir_lowering_match/__init__.py:46:13: W0613: Unused argument 'schema_info' (unused-argument)
************* Module graphql_compiler.compiler.ir_lowering_sql
build/lib/graphql_compiler/compiler/ir_lowering_sql/__init__.py:10:54: W0613: Unused argument 'query_metadata_table' (unused-argument)
************* Module graphql_compiler.compiler.workarounds.orientdb_query_execution
build/lib/graphql_compiler/compiler/workarounds/orientdb_query_execution.py:239:33: W0613: Unused argument 'coerced_locations' (unused-argument)
************* Module graphql_compiler.cost_estimation.analysis
build/lib/graphql_compiler/cost_estimation/analysis.py:248:4: W0613: Unused argument 'parameters' (unused-argument)
************* Module graphql_compiler.cost_estimation.statistics
build/lib/graphql_compiler/cost_estimation/statistics.py:62:14: W0613: Unused argument 'vertex_source_class_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:62:40: W0613: Unused argument 'edge_class_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:62:57: W0613: Unused argument 'vertex_target_class_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:87:46: W0613: Unused argument 'vertex_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:87:59: W0613: Unused argument 'field_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:103:34: W0613: Unused argument 'vertex_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:103:47: W0613: Unused argument 'field_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:118:30: W0613: Unused argument 'vertex_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:118:48: W0613: Unused argument 'field_name' (unused-argument)
build/lib/graphql_compiler/cost_estimation/statistics.py:118:65: W0613: Unused argument 'value' (unused-argument)
************* Module graphql_compiler.macros.macro_edge.ast_traversal
build/lib/graphql_compiler/macros/macro_edge/ast_traversal.py:96:22: W0613: Unused argument 'ast' (unused-argument)
************* Module graphql_compiler.query_formatting.graphql_formatting
build/lib/graphql_compiler/query_formatting/graphql_formatting.py:32:0: W0613: Unused argument 'args' (unused-argument)
************* Module graphql_compiler.schema_generation.orientdb.schema_properties
build/lib/graphql_compiler/schema_generation/orientdb/schema_properties.py:132:34: W0613: Unused argument 'property_name' (unused-argument)
build/lib/graphql_compiler/schema_generation/orientdb/schema_properties.py:150:30: W0613: Unused argument 'property_name' (unused-argument)
************* Module graphql_compiler.schema_generation.sqlalchemy.sqlalchemy_reflector
build/lib/graphql_compiler/schema_generation/sqlalchemy/sqlalchemy_reflector.py:80:30: W0613: Unused argument 'table_name' (unused-argument)
************* Module graphql_compiler.schema_transformation.rename_query
build/lib/graphql_compiler/schema_transformation/rename_query.py:91:0: W0613: Unused argument 'args' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_query.py:100:34: W0613: Unused argument 'node' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_query.py:100:0: W0613: Unused argument 'args' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_query.py:104:34: W0613: Unused argument 'node' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_query.py:104:0: W0613: Unused argument 'args' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_query.py:108:0: W0613: Unused argument 'args' (unused-argument)
************* Module graphql_compiler.schema_transformation.rename_schema
build/lib/graphql_compiler/schema_transformation/rename_schema.py:566:26: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:566:36: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:566:49: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:566:66: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:605:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:606:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:607:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:608:8: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:635:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:636:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:637:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:638:8: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:690:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:691:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:692:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:693:8: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:700:8: W0613: Unused argument 'node' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:701:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:702:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:703:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:704:8: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:712:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:713:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:714:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:715:8: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:744:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:745:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:746:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:747:8: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:795:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:796:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:797:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:798:8: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:808:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:809:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:810:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:811:8: W0613: Unused argument 'ancestors' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:821:8: W0613: Unused argument 'key' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:822:8: W0613: Unused argument 'parent' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:823:8: W0613: Unused argument 'path' (unused-argument)
build/lib/graphql_compiler/schema_transformation/rename_schema.py:824:8: W0613: Unused argument 'ancestors' (unused-argument)
************* Module graphql_compiler.schema_transformation.split_query
build/lib/graphql_compiler/schema_transformation/split_query.py:773:0: W0613: Unused argument 'args' (unused-argument)
build/lib/graphql_compiler/schema_transformation/split_query.py:778:0: W0613: Unused argument 'args' (unused-argument)
************* Module graphql_compiler.schema_transformation.utils
build/lib/graphql_compiler/schema_transformation/utils.py:313:0: W0613: Unused argument 'args' (unused-argument)
build/lib/graphql_compiler/schema_transformation/utils.py:318:0: W0613: Unused argument 'args' (unused-argument)
build/lib/graphql_compiler/schema_transformation/utils.py:420:0: W0613: Unused argument 'args' (unused-argument)
************* Module graphql_compiler.tests.schema_transformation_tests.test_rename_schema
build/lib/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py:774:31: W0613: Unused argument 'default' (unused-argument)
```
