### PR TITLE
Fix broken internal links

### DIFF
--- a/docs/source/language_specification/query_directives.rst
+++ b/docs/source/language_specification/query_directives.rst
@@ -381,7 +381,7 @@ Allows filtering of the data to be returned, based on any of a set of
 filtering operations. Conceptually, it is the GraphQL equivalent of the
 SQL :code:`WHERE` keyword.
 
-See `Supported filtering operations <supported_filtering_operations>`__
+See :ref:`Supported filtering operations <supported_filtering_operations>`
 for details on the various types of filtering that the compiler
 currently supports. These operations are currently hardcoded in the
 compiler; in the future, we may enable the addition of custom filtering

--- a/docs/source/language_specification/schema_types.rst
+++ b/docs/source/language_specification/schema_types.rst
@@ -127,7 +127,7 @@ Lets go over a toy example of a GraphQL object type:
 
 Here are some of the details:
 
-- :code:`_x_count`: is a `meta field <meta_fields>`__. Meta fields are an advanced compiler
+- :code:`_x_count`: is a :ref:`meta field <meta_fields>`. Meta fields are an advanced compiler
   feature.
 - :code:`name` is a **property field** that represents concrete data.
 - :code:`in_Animal_PlaysWith` is a **vertex field** representing an inbound edge.


### PR DESCRIPTION
In a previous PR, I changed all internal links in Read the Docs to use the sphinx :ref: directive instead of using the native rst syntax for adding internal links. Using the :ref: directive has in mind two benefits:

1. If a :ref: link is invalid, CI fails because sphinx raises a warning if a :ref: link is invalid and we raise an error in CI if sphinx 
    raises any warnings. 
2. It is in some way simpler. The native syntax for specifying a link target is a bit complicated. To specify a link to a section called  
    "This  section" you would write `link to this section <#this-section>`__. This gets more complicated when you have symbols 
    like \#  already in the section title. For the :ref: directive, you instead explicitly add a globally unique label immediately 
    preceding  the  section like the one below and type :ref:`link to this section <some_label>`. (I am decently sure that sphinx 
    raises a warning if label targets are ambiguous).
```
.. _some_label
```

So anyways, while I was making this change I forgot to properly add the :ref: directive for these two internal links and I am adding them through this PR. (I checked and did not find are no other invalid internal links). 