### PR TITLE
Upgrade typing_copilot and enforce tightest possible mypy.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,11 +32,12 @@ nosetests.xml
 *.egg-info
 *.egg-ignore
 
-# Any IDE-generated files (pycharm, Sublime)
+# Any IDE-generated files (pycharm, Sublime, VSCode)
 .idea
 .idea/
 .idea/*
 *.sublime-*
+.vscode/
 
 # Sphinx docs
 tools/sphinx_docgen/docs_rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
     script:
       - pipenv run ./scripts/copyright_line_check.sh
       - pipenv run ./scripts/lint.sh
+  - name: "typing_copilot check for tightest possible mypy.ini file"
+    python: "3.8"
+    script:
+      - pipenv run typing_copilot tighten --error-if-can-tighten
   - name: "Python 3.6 unit tests"
     python: "3.6"
     script:

--- a/Pipfile
+++ b/Pipfile
@@ -28,9 +28,7 @@ pylint = ">=2.4.4,<2.5"
 pytest = ">=5.1.3,<6"
 pytest-cov = ">=2.6.1,<3"
 snapshottest = ">=0.5.1,<1"
-
-# TODO: Relax this dependency and add Python >= 3.7 bound when we switch to using Poetry.
-typing-copilot = "==0.4.0"
+typing-copilot = {version = "==0.4.0", markers = "python_version >= '3.7'"}
 
 # TODO: add dependency on https://github.com/dropbox/sqlalchemy-stubs and corresponding mypy plugin
 #       when we can make everything type-check correctly with it.

--- a/Pipfile
+++ b/Pipfile
@@ -30,7 +30,7 @@ pytest-cov = ">=2.6.1,<3"
 snapshottest = ">=0.5.1,<1"
 
 # TODO: Relax this dependency and add Python >= 3.7 bound when we switch to using Poetry.
-typing-copilot = "==0.2.0"
+typing-copilot = "==0.4.0"
 
 # TODO: add dependency on https://github.com/dropbox/sqlalchemy-stubs and corresponding mypy plugin
 #       when we can make everything type-check correctly with it.

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "13fe50b3a49f20b32177a322235bfdc36064fc95ae62a64b9b6e51ace196c73d"
+            "sha256": "a79f29098e2422d5462fbf19543820337480c187eb848d565e9f78903ab97063"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -570,11 +570,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:2594e8fdb06fef91552f86f4fd3a244d148ab24b66042036e64f29a291515048",
-                "sha256:2df50d16b45b977217e02cba6c8422aaddb859f3d0570a88e09b00eafae89c6e"
+                "sha256:307543fe65c0947b126e83dd5a61bd8acbd84abec11f43caebaf5534cbc17998",
+                "sha256:926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.7.0"
+            "version": "==2.7.1"
         },
         "pylint": {
             "hashes": [
@@ -819,11 +819,11 @@
         },
         "typing-copilot": {
             "hashes": [
-                "sha256:007bc248759f20beebaec4354f2b62e17fda983373b07208ddef701a2d0a258a",
-                "sha256:0e29f3577a595d91a670e997ee612649a784f05d06d72a61c09249446c80a191"
+                "sha256:3c7516f2ded57c27b03eb2f83c59c10113d8f58b7358b8cbfba015665a263551",
+                "sha256:a1b3872fcda6b35402e6cb09b9f4b468bf69182f635b94e01de3dfe2ea911307"
             ],
             "index": "pypi",
-            "version": "==0.2.0"
+            "version": "==0.4.0"
         },
         "typing-extensions": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a79f29098e2422d5462fbf19543820337480c187eb848d565e9f78903ab97063"
+            "sha256": "93c3c5d34c9404030f8b4eba5cb8607a74ed127b17f6fa4b50bb940c67bc35d2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,10 +26,11 @@
         },
         "funcy": {
             "hashes": [
-                "sha256:75ee84c3b446f92e68a857c2267b15a1b49c631c9d5a87a5f063cd2d6761a5c4"
+                "sha256:65b746fed572b392d886810a98d56939c6e0d545abb750527a717c21ced21008",
+                "sha256:c247c3d085e03a89974e0c9e8331e9a79db3768a263556ba896d6c92d665bba2"
             ],
             "index": "pypi",
-            "version": "==1.14"
+            "version": "==1.15"
         },
         "graphql-compiler": {
             "editable": true,
@@ -823,6 +824,7 @@
                 "sha256:a1b3872fcda6b35402e6cb09b9f4b468bf69182f635b94e01de3dfe2ea911307"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==0.4.0"
         },
         "typing-extensions": {


### PR DESCRIPTION
Use the new `typing_copilot tighten --error-if-can-tighten` command in `typing_copilot==0.4.0` to assert that the `mypy.ini` file is the tightest supported configuration for the code.

This completes our "ratchet" mechanism for type coverage:
- We started with the tightest supported `mypy` configuration via `typing_copilot init`.
- Regressions in type coverage are prevented by running `mypy` with the current `mypy.ini` config.
- Any time a tighter `mypy` configuration becomes available (e.g. when we type-hint more files), running `typing_copilot tighten` will update the `mypy.ini` to produce it.
- On CI, `typing_copilot tighten --error-if-can-tighten` will guarantee that we don't ever miss an opportunity to tighten our `mypy` configuration.