### PR TITLE
Cleanup name conflict code

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -416,9 +416,9 @@ def _rename_and_suppress_types(
             f"start with double underscores. The following dictionary maps each type's original "
             f"name to what would be the new name: {visitor.invalid_type_names}"
         )
-    if visitor.name_conflicts or visitor.renamed_to_builtin_scalar_conflicts:
+    if visitor.type_name_conflicts or visitor.renamed_to_builtin_scalar_conflicts:
         raise SchemaRenameNameConflictError(
-            visitor.name_conflicts, visitor.renamed_to_builtin_scalar_conflicts
+            visitor.type_name_conflicts, visitor.renamed_to_builtin_scalar_conflicts
         )
     if isinstance(renamings, Iterable):
         # If renamings is iterable, then every renaming must be used and no renaming can map a
@@ -530,9 +530,9 @@ class RenameSchemaTypesVisitor(Visitor):
         }
     )
     # Collects naming conflict errors involving types that are not built-in scalar types. If
-    # renaming would result in multiple types being named "Foo", name_conflicts will map "Foo" to a
+    # renaming would result in multiple types being named "Foo", type_name_conflicts will map "Foo" to a
     # set containing the name of each such type
-    name_conflicts: Dict[str, Set[str]]
+    type_name_conflicts: Dict[str, Set[str]]
     # Collects naming conflict errors involving built-in scalar types. If renaming would rename a
     # type named "Foo" to "String", renamed_to_scalar_conflicts will map "Foo" to "String"
     renamed_to_builtin_scalar_conflicts: Dict[str, str]
@@ -567,7 +567,7 @@ class RenameSchemaTypesVisitor(Visitor):
         """
         self.renamings = renamings
         self.reverse_name_map = {}
-        self.name_conflicts = {}
+        self.type_name_conflicts = {}
         self.renamed_to_builtin_scalar_conflicts = {}
         self.invalid_type_names = {}
         self.query_type = query_type
@@ -648,9 +648,9 @@ class RenameSchemaTypesVisitor(Visitor):
 
             # Collect all types in the original schema that would be named desired_type_name in the
             # new schema
-            if desired_type_name not in self.name_conflicts:
-                self.name_conflicts[desired_type_name] = {conflictingly_renamed_type_name}
-            self.name_conflicts[desired_type_name].add(type_name)
+            if desired_type_name not in self.type_name_conflicts:
+                self.type_name_conflicts[desired_type_name] = {conflictingly_renamed_type_name}
+            self.type_name_conflicts[desired_type_name].add(type_name)
 
         if desired_type_name in builtin_scalar_type_names:
             self.renamed_to_builtin_scalar_conflicts[type_name] = desired_type_name

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -530,8 +530,8 @@ class RenameSchemaTypesVisitor(Visitor):
         }
     )
     # Collects naming conflict errors involving types that are not built-in scalar types. If
-    # renaming would result in multiple types being named "Foo", type_name_conflicts will map "Foo" to a
-    # set containing the name of each such type
+    # renaming would result in multiple types being named "Foo", type_name_conflicts will map "Foo"
+    # to a set containing the name of each such type
     type_name_conflicts: Dict[str, Set[str]]
     # Collects naming conflict errors involving built-in scalar types. If renaming would rename a
     # type named "Foo" to "String", renamed_to_scalar_conflicts will map "Foo" to "String"

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -68,47 +68,53 @@ class SchemaMergeNameConflictError(SchemaTransformError):
 class SchemaRenameNameConflictError(SchemaTransformError):
     """Raised when renaming causes name conflicts."""
 
-    name_conflicts: Dict[str, Set[str]]
+    type_name_conflicts: Dict[str, Set[str]]
     renamed_to_builtin_scalar_conflicts: Dict[str, str]
 
     def __init__(
         self,
-        name_conflicts: Dict[str, Set[str]],
+        type_name_conflicts: Dict[str, Set[str]],
         renamed_to_builtin_scalar_conflicts: Dict[str, str],
     ) -> None:
         """Record all renaming conflicts."""
-        if not name_conflicts and not renamed_to_builtin_scalar_conflicts:
+        if not type_name_conflicts and not renamed_to_builtin_scalar_conflicts:
             raise ValueError(
                 "Cannot raise SchemaRenameNameConflictError without at least one conflict, but "
-                "name_conflicts and renamed_to_builtin_scalar_conflicts arguments were both empty "
+                "type_name_conflicts and renamed_to_builtin_scalar_conflicts arguments were both empty "
                 "dictionaries."
             )
         super().__init__()
-        self.name_conflicts = name_conflicts
+        self.type_name_conflicts = type_name_conflicts
         self.renamed_to_builtin_scalar_conflicts = renamed_to_builtin_scalar_conflicts
 
     def __str__(self) -> str:
         """Explain renaming conflict and the fix."""
-        name_conflicts_message = ""
-        if self.name_conflicts:
-            name_conflicts_message = (
+        type_name_conflicts_message = ""
+        if self.type_name_conflicts:
+            sorted_type_name_conflicts = [(new_type_name, sorted(original_schema_type_names)) for new_type_name, original_schema_type_names in sorted(self.type_name_conflicts.items())]
+            type_name_conflicts_message = (
                 f"Applying the renaming would produce a schema in which multiple types have the "
-                f"same name, which is an illegal schema state. The name_conflicts dict describes "
-                f"these problems. For each key k in name_conflicts, name_conflicts[k] is the set "
-                f"of types in the original schema that get mapped to k in the new schema. To fix "
-                f"this, modify the renamings argument of rename_schema to ensure that no two types "
-                f"in the renamed schema have the same name. name_conflicts: {self.name_conflicts}"
+                f"same name, which is an illegal schema state. To fix this, modify the renamings "
+                f"argument of rename_schema to ensure that no two types in the renamed schema have "
+                f"the same name. The following is a list of tuples that describes what needs to be "
+                f"fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
+                f"where new_type_name is the type name that would appear in the new schema and "
+                f"original_schema_type_names is a list of types in the original schema that get "
+                f"mapped to new_type_name: {sorted_type_name_conflicts}"
             )
         renamed_to_builtin_scalar_conflicts_message = ""
         if self.renamed_to_builtin_scalar_conflicts:
+            sorted_renamed_to_builtin_scalar_conflicts = sorted(self.renamed_to_builtin_scalar_conflicts.items())
             renamed_to_builtin_scalar_conflicts_message = (
                 f"Applying the renaming would rename type(s) to a name already used by a built-in "
                 f"GraphQL scalar type. To fix this, ensure that no type name is mapped to a "
-                f"scalar's name. The following dict maps each to-be-renamed type to the scalar "
-                f"name it was mapped to: {self.renamed_to_builtin_scalar_conflicts}"
+                f"scalar's name. The following is a list of tuples that describes what needs to be "
+                f"fixed. Each tuple is of the form (type_name, scalar_name) where type_name is the "
+                f"original name of the type and scalar_name is the name of the scalar that the "
+                f"type would be renamed to: {sorted_renamed_to_builtin_scalar_conflicts}"
             )
         return "\n".join(
-            filter(None, [name_conflicts_message, renamed_to_builtin_scalar_conflicts_message])
+            filter(None, [type_name_conflicts_message, renamed_to_builtin_scalar_conflicts_message])
         )
 
 

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -80,8 +80,8 @@ class SchemaRenameNameConflictError(SchemaTransformError):
         if not type_name_conflicts and not renamed_to_builtin_scalar_conflicts:
             raise ValueError(
                 "Cannot raise SchemaRenameNameConflictError without at least one conflict, but "
-                "type_name_conflicts and renamed_to_builtin_scalar_conflicts arguments were both empty "
-                "dictionaries."
+                "type_name_conflicts and renamed_to_builtin_scalar_conflicts arguments were both "
+                "empty dictionaries."
             )
         super().__init__()
         self.type_name_conflicts = type_name_conflicts
@@ -91,7 +91,12 @@ class SchemaRenameNameConflictError(SchemaTransformError):
         """Explain renaming conflict and the fix."""
         type_name_conflicts_message = ""
         if self.type_name_conflicts:
-            sorted_type_name_conflicts = [(new_type_name, sorted(original_schema_type_names)) for new_type_name, original_schema_type_names in sorted(self.type_name_conflicts.items())]
+            sorted_type_name_conflicts = [
+                (new_type_name, sorted(original_schema_type_names))
+                for new_type_name, original_schema_type_names in sorted(
+                    self.type_name_conflicts.items()
+                )
+            ]
             type_name_conflicts_message = (
                 f"Applying the renaming would produce a schema in which multiple types have the "
                 f"same name, which is an illegal schema state. To fix this, modify the renamings "
@@ -104,7 +109,9 @@ class SchemaRenameNameConflictError(SchemaTransformError):
             )
         renamed_to_builtin_scalar_conflicts_message = ""
         if self.renamed_to_builtin_scalar_conflicts:
-            sorted_renamed_to_builtin_scalar_conflicts = sorted(self.renamed_to_builtin_scalar_conflicts.items())
+            sorted_renamed_to_builtin_scalar_conflicts = sorted(
+                self.renamed_to_builtin_scalar_conflicts.items()
+            )
             renamed_to_builtin_scalar_conflicts_message = (
                 f"Applying the renaming would rename type(s) to a name already used by a built-in "
                 f"GraphQL scalar type. To fix this, ensure that no type name is mapped to a "

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -27,93 +27,6 @@ from ..test_helpers import compare_schema_texts_order_independently
 from .input_schema_strings import InputSchemaStrings as ISS
 
 
-def check_rename_conflict_error_message(
-    expected_name_conflicts: Dict[str, Set[str]],
-    expected_renamed_to_builtin_scalar_conflicts: Dict[str, str],
-    error: SchemaRenameNameConflictError,
-) -> bool:
-    """Check SchemaRenameNameConflictError's error message contains the expected data structures.
-
-    Since there are no guarantees for the order in which GraphQL-core's visit function visits nodes
-    at the same depth in the schema AST, SchemaRenameNameConflictError's __str__ method is not
-    fully deterministic. This function checks that the __str__ method contains valid string
-    representations of SchemaRenameNameConflictError's name_conflicts and
-    renamed_to_builtin_scalar_conflicts fields.
-
-    Args:
-        expected_name_conflicts: expected name conflicts from renaming
-        expected_renamed_to_builtin_scalar_conflicts: expected conflicts from renaming to built-in
-                                                      scalar types
-        error: exception object raised during schema renaming due to name conflict
-
-    Returns:
-        True iff the error message correctly represents the data structures and matches the
-        expected SchemaRenameNameConflictError error message format.
-    """
-    name_conflicts_prefix = (
-        "Applying the renaming would produce a schema in which multiple types have the "
-        "same name, which is an illegal schema state. The name_conflicts dict describes "
-        "these problems. For each key k in name_conflicts, name_conflicts[k] is the set "
-        "of types in the original schema that get mapped to k in the new schema. To fix "
-        "this, modify the renamings argument of rename_schema to ensure that no two types "
-        "in the renamed schema have the same name. name_conflicts: "
-    )
-    renamed_to_builtin_scalar_conflicts_prefix = (
-        "Applying the renaming would rename type(s) to a name already used by a built-in "
-        "GraphQL scalar type. To fix this, ensure that no type name is mapped to a "
-        "scalar's name. The following dict maps each to-be-renamed type to the scalar "
-        "name it was mapped to: "
-    )
-    actual_error_message = str(error)
-    name_conflicts_part = None
-    renamed_to_builtin_scalar_conflicts_part = None
-    if expected_name_conflicts and expected_renamed_to_builtin_scalar_conflicts:
-        name_conflicts_part, renamed_to_builtin_scalar_conflicts_part = actual_error_message.split(
-            "\n"
-        )
-    elif expected_name_conflicts:
-        name_conflicts_part = actual_error_message
-    elif expected_renamed_to_builtin_scalar_conflicts:
-        renamed_to_builtin_scalar_conflicts_part = actual_error_message
-    else:
-        raise AssertionError(
-            "Illegal for SchemaRenameNameConflictError to have all arguments as empty dicts"
-        )
-
-    if name_conflicts_part:
-        if not name_conflicts_part.startswith(name_conflicts_prefix):
-            return False
-        # Then check the string representation of name_conflicts
-        try:
-            if (
-                literal_eval(name_conflicts_part[len(name_conflicts_prefix) :])
-                != expected_name_conflicts
-            ):
-                return False
-        except SyntaxError:
-            # In case it's syntactically invalid
-            return False
-    if renamed_to_builtin_scalar_conflicts_part:
-        if not renamed_to_builtin_scalar_conflicts_part.startswith(
-            renamed_to_builtin_scalar_conflicts_prefix
-        ):
-            return False
-        # Then check the string representation of renamed_to_builtin_scalar_conflicts
-        try:
-            if (
-                literal_eval(
-                    renamed_to_builtin_scalar_conflicts_part[
-                        len(renamed_to_builtin_scalar_conflicts_prefix) :
-                    ]
-                )
-                != expected_renamed_to_builtin_scalar_conflicts
-            ):
-                return False
-        except SyntaxError:
-            return False
-    return True
-
-
 class TestRenameSchema(unittest.TestCase):
     def test_rename_visitor_type_coverage(self) -> None:
         """Check that all types are covered without overlap."""
@@ -884,8 +797,16 @@ class TestRenameSchema(unittest.TestCase):
 
         with self.assertRaises(SchemaRenameNameConflictError) as e:
             rename_schema(parse(schema_string), {"Human1": "Human", "Human2": "Human"})
-        self.assertTrue(
-            check_rename_conflict_error_message({"Human": {"Human1", "Human2"}}, {}, e.exception)
+        self.assertEqual(
+            "Applying the renaming would produce a schema in which multiple types have the "
+            "same name, which is an illegal schema state. To fix this, modify the renamings "
+            "argument of rename_schema to ensure that no two types in the renamed schema have "
+            "the same name. The following is a list of tuples that describes what needs to be "
+            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
+            "where new_type_name is the type name that would appear in the new schema and "
+            "original_schema_type_names is a list of types in the original schema that get "
+            "mapped to new_type_name: [('Human', ['Human1', 'Human2'])]",
+            str(e.exception)
         )
 
     def test_clashing_type_single_rename(self) -> None:
@@ -912,8 +833,16 @@ class TestRenameSchema(unittest.TestCase):
 
         with self.assertRaises(SchemaRenameNameConflictError) as e:
             rename_schema(parse(schema_string), {"Human2": "Human"})
-        self.assertTrue(
-            check_rename_conflict_error_message({"Human": {"Human", "Human2"}}, {}, e.exception)
+        self.assertEqual(
+            "Applying the renaming would produce a schema in which multiple types have the "
+            "same name, which is an illegal schema state. To fix this, modify the renamings "
+            "argument of rename_schema to ensure that no two types in the renamed schema have "
+            "the same name. The following is a list of tuples that describes what needs to be "
+            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
+            "where new_type_name is the type name that would appear in the new schema and "
+            "original_schema_type_names is a list of types in the original schema that get "
+            "mapped to new_type_name: [('Human', ['Human', 'Human2'])]",
+            str(e.exception)
         )
 
     def test_clashing_type_one_unchanged_rename(self) -> None:
@@ -940,8 +869,16 @@ class TestRenameSchema(unittest.TestCase):
 
         with self.assertRaises(SchemaRenameNameConflictError) as e:
             rename_schema(parse(schema_string), {"Human": "Human3", "Human2": "Human3"})
-        self.assertTrue(
-            check_rename_conflict_error_message({"Human3": {"Human", "Human2"}}, {}, e.exception)
+        self.assertEqual(
+            "Applying the renaming would produce a schema in which multiple types have the "
+            "same name, which is an illegal schema state. To fix this, modify the renamings "
+            "argument of rename_schema to ensure that no two types in the renamed schema have "
+            "the same name. The following is a list of tuples that describes what needs to be "
+            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
+            "where new_type_name is the type name that would appear in the new schema and "
+            "original_schema_type_names is a list of types in the original schema that get "
+            "mapped to new_type_name: [('Human3', ['Human', 'Human2'])]",
+            str(e.exception)
         )
 
     def test_clashing_scalar_type_rename(self) -> None:
@@ -965,8 +902,16 @@ class TestRenameSchema(unittest.TestCase):
 
         with self.assertRaises(SchemaRenameNameConflictError) as e:
             rename_schema(parse(schema_string), {"Human": "SCALAR"})
-        self.assertTrue(
-            check_rename_conflict_error_message({"SCALAR": {"SCALAR", "Human"}}, {}, e.exception)
+        self.assertEqual(
+            "Applying the renaming would produce a schema in which multiple types have the "
+            "same name, which is an illegal schema state. To fix this, modify the renamings "
+            "argument of rename_schema to ensure that no two types in the renamed schema have "
+            "the same name. The following is a list of tuples that describes what needs to be "
+            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
+            "where new_type_name is the type name that would appear in the new schema and "
+            "original_schema_type_names is a list of types in the original schema that get "
+            "mapped to new_type_name: [('SCALAR', ['Human', 'SCALAR'])]",
+            str(e.exception)
         )
 
     def test_builtin_type_conflict_rename(self) -> None:
@@ -988,7 +933,15 @@ class TestRenameSchema(unittest.TestCase):
 
         with self.assertRaises(SchemaRenameNameConflictError) as e:
             rename_schema(parse(schema_string), {"Human": "String"})
-        self.assertTrue(check_rename_conflict_error_message({}, {"Human": "String"}, e.exception))
+        self.assertEqual(
+            f"Applying the renaming would rename type(s) to a name already used by a built-in "
+            f"GraphQL scalar type. To fix this, ensure that no type name is mapped to a "
+            f"scalar's name. The following is a list of tuples that describes what needs to be "
+            f"fixed. Each tuple is of the form (type_name, scalar_name) where type_name is the "
+            f"original name of the type and scalar_name is the name of the scalar that the "
+            f"type would be renamed to: [('Human', 'String')]",
+            str(e.exception)
+        )
 
     def test_multiple_naming_conflicts(self) -> None:
         schema_string = dedent(
@@ -1017,10 +970,22 @@ class TestRenameSchema(unittest.TestCase):
 
         with self.assertRaises(SchemaRenameNameConflictError) as e:
             rename_schema(parse(schema_string), {"Human": "String", "Dog": "Cat"})
-        self.assertTrue(
-            check_rename_conflict_error_message(
-                {"Cat": {"Dog", "Cat"}}, {"Human": "String"}, e.exception
-            )
+        self.assertEqual(
+            "Applying the renaming would produce a schema in which multiple types have the "
+            "same name, which is an illegal schema state. To fix this, modify the renamings "
+            "argument of rename_schema to ensure that no two types in the renamed schema have "
+            "the same name. The following is a list of tuples that describes what needs to be "
+            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
+            "where new_type_name is the type name that would appear in the new schema and "
+            "original_schema_type_names is a list of types in the original schema that get "
+            "mapped to new_type_name: [('Cat', ['Cat', 'Dog'])]\n"
+            "Applying the renaming would rename type(s) to a name already used by a built-in "
+            "GraphQL scalar type. To fix this, ensure that no type name is mapped to a "
+            "scalar's name. The following is a list of tuples that describes what needs to be "
+            "fixed. Each tuple is of the form (type_name, scalar_name) where type_name is the "
+            "original name of the type and scalar_name is the name of the scalar that the "
+            "type would be renamed to: [('Human', 'String')]",
+            str(e.exception)
         )
 
     def test_illegal_rename_start_with_number(self) -> None:

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -1,7 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
-from ast import literal_eval
 from textwrap import dedent
-from typing import Dict, Optional, Set
+from typing import Optional, Set
 import unittest
 
 from graphql import GraphQLSchema, build_ast_schema, parse
@@ -806,7 +805,7 @@ class TestRenameSchema(unittest.TestCase):
             "where new_type_name is the type name that would appear in the new schema and "
             "original_schema_type_names is a list of types in the original schema that get "
             "mapped to new_type_name: [('Human', ['Human1', 'Human2'])]",
-            str(e.exception)
+            str(e.exception),
         )
 
     def test_clashing_type_single_rename(self) -> None:
@@ -842,7 +841,7 @@ class TestRenameSchema(unittest.TestCase):
             "where new_type_name is the type name that would appear in the new schema and "
             "original_schema_type_names is a list of types in the original schema that get "
             "mapped to new_type_name: [('Human', ['Human', 'Human2'])]",
-            str(e.exception)
+            str(e.exception),
         )
 
     def test_clashing_type_one_unchanged_rename(self) -> None:
@@ -878,7 +877,7 @@ class TestRenameSchema(unittest.TestCase):
             "where new_type_name is the type name that would appear in the new schema and "
             "original_schema_type_names is a list of types in the original schema that get "
             "mapped to new_type_name: [('Human3', ['Human', 'Human2'])]",
-            str(e.exception)
+            str(e.exception),
         )
 
     def test_clashing_scalar_type_rename(self) -> None:
@@ -911,7 +910,7 @@ class TestRenameSchema(unittest.TestCase):
             "where new_type_name is the type name that would appear in the new schema and "
             "original_schema_type_names is a list of types in the original schema that get "
             "mapped to new_type_name: [('SCALAR', ['Human', 'SCALAR'])]",
-            str(e.exception)
+            str(e.exception),
         )
 
     def test_builtin_type_conflict_rename(self) -> None:
@@ -934,13 +933,13 @@ class TestRenameSchema(unittest.TestCase):
         with self.assertRaises(SchemaRenameNameConflictError) as e:
             rename_schema(parse(schema_string), {"Human": "String"})
         self.assertEqual(
-            f"Applying the renaming would rename type(s) to a name already used by a built-in "
-            f"GraphQL scalar type. To fix this, ensure that no type name is mapped to a "
-            f"scalar's name. The following is a list of tuples that describes what needs to be "
-            f"fixed. Each tuple is of the form (type_name, scalar_name) where type_name is the "
-            f"original name of the type and scalar_name is the name of the scalar that the "
-            f"type would be renamed to: [('Human', 'String')]",
-            str(e.exception)
+            "Applying the renaming would rename type(s) to a name already used by a built-in "
+            "GraphQL scalar type. To fix this, ensure that no type name is mapped to a "
+            "scalar's name. The following is a list of tuples that describes what needs to be "
+            "fixed. Each tuple is of the form (type_name, scalar_name) where type_name is the "
+            "original name of the type and scalar_name is the name of the scalar that the "
+            "type would be renamed to: [('Human', 'String')]",
+            str(e.exception),
         )
 
     def test_multiple_naming_conflicts(self) -> None:
@@ -985,7 +984,7 @@ class TestRenameSchema(unittest.TestCase):
             "fixed. Each tuple is of the form (type_name, scalar_name) where type_name is the "
             "original name of the type and scalar_name is the name of the scalar that the "
             "type would be renamed to: [('Human', 'String')]",
-            str(e.exception)
+            str(e.exception),
         )
 
     def test_illegal_rename_start_with_number(self) -> None:


### PR DESCRIPTION
In an effort to make field renaming easier to finish, I've come across all sorts of changes that would be nice to have. Here's one: cleaning up the code that handles name conflicts for types, since running into name conflicts can also happen when renaming fields, and it'd make it easier to clearly indicate that the existing code has to do with types in a GraphQL schema.