### PR TITLE
Fix pagination capacity bug

### DIFF
--- a/graphql_compiler/cost_estimation/analysis.py
+++ b/graphql_compiler/cost_estimation/analysis.py
@@ -295,13 +295,13 @@ def get_distinct_result_set_estimates(
             if EdgeConstraint.AtMostOneSource in edge_constraints:
                 single_destination_traversals.add((to_path, from_path))
 
-    # Make sure there's no path of many-to-one traversals leading to a node with lower
+    # Make sure there's no path of many-to-one traversals leading to a node with higher
     # distinct_result_set_estimate.
     max_path_length = len(single_destination_traversals)
     for _ in range(max_path_length):
         for from_path, to_path in single_destination_traversals:
-            distinct_result_set_estimates[from_path] = min(
-                distinct_result_set_estimates[from_path], distinct_result_set_estimates[to_path]
+            distinct_result_set_estimates[to_path] = min(
+                distinct_result_set_estimates[to_path], distinct_result_set_estimates[from_path]
             )
 
     return distinct_result_set_estimates

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -8,7 +8,7 @@ from ...cost_estimation.filter_selectivity_utils import Selectivity
 from ...cost_estimation.interval import Interval
 from ...cost_estimation.statistics import LocalStatistics
 from ...global_utils import QueryStringWithParameters
-from ...schema.schema_info import QueryPlanningSchemaInfo, UUIDOrdering, EdgeConstraint
+from ...schema.schema_info import EdgeConstraint, QueryPlanningSchemaInfo, UUIDOrdering
 from ...schema_generation.graphql_schema import get_graphql_schema_from_schema_graph
 from ..test_helpers import generate_schema_graph
 


### PR DESCRIPTION
Tests were interpretting the `Animal_ParentOf` edge in the wrong direction, which caused a bug in pagination capacity calculation not to be detected.