### PR TITLE
Add ability to filter then traverse inside a fold for SQL backend

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -633,7 +633,10 @@ class FoldSubqueryBuilder(object):
         self._output_fields = output_fields
 
     def add_filter(
-        self, predicate: Expression, aliases: Dict[Tuple[QueryPath, Optional[FoldPath]], Alias]
+        self,
+        predicate: Expression,
+        aliases: Dict[Tuple[QueryPath, Optional[FoldPath]], Alias],
+        current_alias: Alias,
     ) -> None:
         """Add a new filter to the FoldSubqueryBuilder."""
         if self._ended:
@@ -641,8 +644,7 @@ class FoldSubqueryBuilder(object):
                 "Cannot add a filter after end_fold has been called. Invalid "
                 f"state encountered during fold {self}."
             )
-        # Filters are applied to output vertices, thus current_alias=self.output_vertex_alias.
-        sql_expression = predicate.to_sql(self._dialect, aliases, self._output_vertex_alias)
+        sql_expression = predicate.to_sql(self._dialect, aliases, current_alias)
         self._filters.append(sql_expression)
 
     def end_fold(self) -> Tuple[Select, FoldScopeLocation]:
@@ -1080,7 +1082,7 @@ class CompilationState(object):
                 raise NotImplementedError(
                     "Filtering with a tagged parameter in a fold scope is not implemented yet."
                 )
-            self._current_fold.add_filter(predicate, self._aliases)
+            self._current_fold.add_filter(predicate, self._aliases, self._current_alias)
 
         # Otherwise, add the filter to the compilation state. Note that this is for filters outside
         # a fold scope and _x_count filters within a fold scope.

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -2100,6 +2100,36 @@ def traverse_and_fold_and_traverse() -> CommonTestData:  # noqa: D103
     )
 
 
+def fold_and_filter_and_traverse_and_output() -> CommonTestData:  # noqa: D103
+    graphql_input = """{
+            Animal {
+                name @output(out_name: "animal_name")
+                in_Animal_ParentOf @fold {
+                    net_worth @filter(op_name: ">", value: ["$parent_min_worth"])
+                    in_Animal_ParentOf {
+                        name @output(out_name: "grand_parent_list")
+                    }
+                }
+            }
+        }"""
+    expected_output_metadata = {
+        "animal_name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+        "grand_parent_list": OutputMetadata(
+            type=GraphQLList(GraphQLString), optional=False, folded=True
+        ),
+    }
+    expected_input_metadata: Dict[str, GraphQLSchemaFieldType] = {
+        "parent_min_worth": GraphQLDecimal,
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None,
+    )
+
+
 def multiple_outputs_in_same_fold() -> CommonTestData:  # noqa: D103
     graphql_input = """{
         Animal {


### PR DESCRIPTION
We previously only allowed filtering at the output location when inside a fold in the SQL backend, but did not have an appropriate error message if a user tried to filter at a different location within a fold. This PR adds functionality and tests for queries that involve a fold, filter, traversal, and output (in that order). See example query in `test_input_data`.