### PR TITLE
Fix recurse bug

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1158,6 +1158,20 @@ class CompilationState(object):
                 f"Attempted to unfold while the _current_alias was None during fold {self}."
             )
         outer_vertex_primary_key_name = self._get_current_primary_key_name("@fold")
+
+        # Postgres uses a LEFT OUTER JOIN and coalesces nulls to an empty array in the top SELECT.
+        if isinstance(self._sql_schema_info.dialect, PGDialect):
+            is_left_outer_join = True
+        # MSSQL folded subquery returns exactly 1 folded result for each row in the outer table
+        # so should use an INNER JOIN.
+        elif isinstance(self._sql_schema_info.dialect, MSDialect):
+            is_left_outer_join = False
+        else:
+            raise NotImplementedError(
+                "Fold only supported for MSSQL and PostgreSQL, "
+                f"dialect set to {self._sql_schema_info.dialect.name}."
+            )
+
         self._from_clause = sqlalchemy.join(
             self._from_clause,
             fold_subquery_alias,
@@ -1165,7 +1179,7 @@ class CompilationState(object):
                 self._current_alias.c[outer_vertex_primary_key_name]
                 == fold_subquery_alias.c[outer_vertex_primary_key_name]
             ),
-            isouter=False,
+            isouter=is_left_outer_join,
         )
 
         # 5. Clear the fold from the compilation state.

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -47,7 +47,7 @@ FOLD_SUBQUERY_FORMAT_STRING = "folded_subquery_{}"
 
 
 def _get_primary_key_name(alias: Alias, vertex_type_name: str, directive_name: str) -> str:
-    """Return the name of the single-column primary key for the alias
+    """Return the name of the single-column primary key for the alias.
 
     If there is no single-column primary key for this alias, an error is raised.
 

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -110,7 +110,7 @@ def _find_used_columns(
         primary_keys = (
             sql_schema_info.vertex_name_to_table[location_info.type.name].alias().primary_key
         )
-        if len(primary_keys) > 1:
+        if len(primary_keys) == 1:
             primary_key = str(primary_keys[0].name)
 
         for child_location in ir.query_metadata_table.get_child_locations(location):

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -55,7 +55,7 @@ def _get_primary_key_name(alias: Alias, vertex_type_name: str, directive_name: s
         alias: the sqlalchemy object with primary key information
         vertex_type_name: The vertex name that represents the alias. Used for error messages
                           only.
-        directive_name: name of the directive that requires for the single-column
+        directive_name: name of the directive that requires the single-column
                         primary key to exist. Used in error messages only.
 
     Returns:

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2427,9 +2427,7 @@ class CompilerTests(unittest.TestCase):
         expected_mssql = """
             WITH anon_2 AS (
                 SELECT
-                    [Animal_1].color AS [Animal__color],
                     [Animal_1].name AS [Animal__name],
-                    [Animal_1].parent AS [Animal__parent],
                     [Animal_1].uuid AS [Animal__uuid]
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_1]
@@ -2491,7 +2489,6 @@ class CompilerTests(unittest.TestCase):
             WITH anon_2 AS (
                 SELECT
                     [Animal_1].name AS [Animal__name],
-                    [Animal_1].parent AS [Animal__parent],
                     [Animal_1].uuid AS [Animal__uuid]
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_1]
@@ -9793,7 +9790,6 @@ class CompilerTests(unittest.TestCase):
                     [Animal_1].name AS [Animal__name],
                     [Animal_1].parent AS [Animal__parent],
                     [Animal_2].name AS [Animal_in_Animal_ParentOf__name],
-                    [Animal_2].parent AS [Animal_in_Animal_ParentOf__parent],
                     [Animal_2].uuid AS [Animal_in_Animal_ParentOf__uuid]
                 FROM
                     db_1.schema_1.[Animal] AS [Animal_1]
@@ -9844,7 +9840,6 @@ class CompilerTests(unittest.TestCase):
                     "Animal_1".name AS "Animal__name",
                     "Animal_1".parent AS "Animal__parent",
                     "Animal_2".name AS "Animal_in_Animal_ParentOf__name",
-                    "Animal_2".parent AS "Animal_in_Animal_ParentOf__parent",
                     "Animal_2".uuid AS "Animal_in_Animal_ParentOf__uuid"
                 FROM
                     schema_1."Animal" AS "Animal_1"

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -1226,7 +1226,7 @@ class CompilerTests(unittest.TestCase):
             FROM schema_1."Species" AS "Species_1"
             LEFT OUTER JOIN schema_1."Animal" AS "Animal_1"
             ON "Species_1".uuid = "Animal_1".species
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Species_2".uuid AS uuid,
                     coalesce(count(*), 0) AS fold_output__x_count
@@ -5346,7 +5346,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list
             FROM
                 schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
@@ -5373,7 +5373,7 @@ class CompilerTests(unittest.TestCase):
               folded_subquery_1.fold_output_name AS child_names_list
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN(
+            JOIN (
                 SELECT
                     [Animal_2].uuid AS uuid,
                     coalesce((
@@ -5418,7 +5418,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS homes_list
             FROM
                 schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Location_1".name) AS fold_output_name
@@ -5435,7 +5435,7 @@ class CompilerTests(unittest.TestCase):
                 folded_subquery_1.fold_output_name AS homes_list
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN(
+            JOIN (
                 SELECT
                     [Animal_2].uuid AS uuid,
                     coalesce((
@@ -5561,7 +5561,7 @@ class CompilerTests(unittest.TestCase):
               ) AS child_names_list
             FROM
                 schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
@@ -5599,7 +5599,7 @@ class CompilerTests(unittest.TestCase):
                 AS sibling_and_self_names_list
             FROM
               schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
@@ -5610,7 +5610,7 @@ class CompilerTests(unittest.TestCase):
                   "Animal_2".uuid
             ) AS folded_subquery_1 ON "Animal_1".uuid = folded_subquery_1.uuid
             JOIN schema_1."Animal" AS "Animal_4" ON "Animal_1".parent = "Animal_4".uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_5".uuid AS uuid,
                     array_agg("Animal_6".name) AS fold_output_name
@@ -5628,7 +5628,7 @@ class CompilerTests(unittest.TestCase):
                 folded_subquery_2.fold_output_name AS sibling_and_self_names_list
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN(
+            JOIN (
                 SELECT
                     [Animal_2].uuid AS uuid,
                     coalesce((
@@ -5651,7 +5651,7 @@ class CompilerTests(unittest.TestCase):
                     db_1.schema_1.[Animal] AS [Animal_2]
             ) AS folded_subquery_1 ON [Animal_1].uuid = folded_subquery_1.uuid
             JOIN db_1.schema_1.[Animal] AS [Animal_4] ON [Animal_1].parent = [Animal_4].uuid
-            JOIN(
+            JOIN (
                 SELECT
                     [Animal_5].uuid AS uuid,
                     coalesce((
@@ -5735,7 +5735,7 @@ class CompilerTests(unittest.TestCase):
               schema_1."Animal" AS "Animal_1"
             JOIN schema_1."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
-            JOIN(
+            LEFT OUTER JOIN(
                 SELECT
                     "Animal_3".uuid AS uuid,
                     array_agg("Animal_4".name) AS fold_output_name
@@ -5812,7 +5812,7 @@ class CompilerTests(unittest.TestCase):
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
             JOIN db_1.schema_1.[Location] AS [Location_1] ON [Animal_1].lives_in = [Location_1].uuid
-            JOIN(
+            JOIN (
                 SELECT
                     [Location_2].uuid AS uuid,
                     coalesce((
@@ -5843,7 +5843,7 @@ class CompilerTests(unittest.TestCase):
             FROM schema_1."Animal" AS "Animal_1"
             JOIN schema_1."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                   "Location_2".uuid AS uuid,
                   array_agg("Animal_2".name) AS fold_output_name
@@ -5879,7 +5879,7 @@ class CompilerTests(unittest.TestCase):
             FROM schema_1."Animal" AS "Animal_1"
             JOIN schema_1."Location" AS "Location_1"
             ON "Animal_1".lives_in = "Location_1".uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Location_2".uuid AS uuid,
                     array_agg("Animal_2".name) AS fold_output_name
@@ -5897,7 +5897,7 @@ class CompilerTests(unittest.TestCase):
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
             JOIN db_1.schema_1.[Location] AS [Location_1] ON [Animal_1].lives_in = [Location_1].uuid
-            JOIN(
+            JOIN (
                 SELECT
                     [Location_2].uuid AS uuid,
                     coalesce((
@@ -6022,7 +6022,7 @@ class CompilerTests(unittest.TestCase):
                     AS sibling_and_self_names_list
             FROM
                 schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
@@ -6146,7 +6146,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
                     AS sibling_and_self_species_list
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Species_1".name) AS fold_output_name
@@ -6277,7 +6277,7 @@ class CompilerTests(unittest.TestCase):
             FROM schema_1."Animal" AS "Animal_1"
             JOIN schema_1."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_3".uuid AS uuid,
                     array_agg("Species_1".name) AS fold_output_name
@@ -6389,7 +6389,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[])
                     AS grand_parent_list
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
@@ -6468,7 +6468,7 @@ class CompilerTests(unittest.TestCase):
                     AS child_names_list,
                 coalesce(folded_subquery_1.fold_output_uuid, ARRAY[]::VARCHAR[]) AS child_uuids_list
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".uuid) AS fold_output_uuid,
@@ -6567,7 +6567,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_uuid, ARRAY[]::VARCHAR[])
                     AS sibling_and_self_uuids_list
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".uuid) AS fold_output_uuid,
@@ -6670,7 +6670,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_2.fold_output_uuid, ARRAY[]::VARCHAR[])
                     AS parent_uuids_list
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".uuid) AS fold_output_uuid,
@@ -6681,7 +6681,7 @@ class CompilerTests(unittest.TestCase):
                 GROUP BY "Animal_2".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_4".uuid AS uuid,
                     array_agg("Animal_5".uuid) AS fold_output_uuid,
@@ -6823,7 +6823,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_uuid, ARRAY[]::VARCHAR[])
                     AS spouse_and_self_uuids_list
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".uuid) AS fold_output_uuid,
@@ -6836,7 +6836,7 @@ class CompilerTests(unittest.TestCase):
                 GROUP BY "Animal_2".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_5".uuid AS uuid,
                     array_agg("Animal_6".uuid) AS fold_output_uuid,
@@ -6962,7 +6962,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_2.fold_output_event_date, ARRAY[]::TIMESTAMP[])
                     AS fed_at_datetimes_list
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".birthday) AS fold_output_birthday
@@ -6972,7 +6972,7 @@ class CompilerTests(unittest.TestCase):
                 GROUP BY "Animal_2".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_4".uuid AS uuid,
                     array_agg("FeedingEvent_1".event_date) AS fold_output_event_date
@@ -7095,29 +7095,29 @@ class CompilerTests(unittest.TestCase):
                 folded_subquery_1.fold_output_name AS related_entities
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
-                JOIN (
-                    SELECT
-                        [Animal_2].uuid AS uuid,
-                        coalesce(
-                            (
-                                SELECT '|' + coalesce(
+            JOIN (
+                SELECT
+                    [Animal_2].uuid AS uuid,
+                    coalesce(
+                        (
+                            SELECT '|' + coalesce(
+                                REPLACE(
                                     REPLACE(
                                         REPLACE(
-                                            REPLACE(
-                                                [Entity_1].name, '^', '^e'),
-                                            '~', '^n'),
-                                        '|', '^d'),
-                                    '~')
-                                FROM
-                                    db_1.schema_1.[Entity] AS [Entity_1]
-                                WHERE [Animal_2].related_entity = [Entity_1].uuid
-                            FOR XML PATH ('')
-                            ),
-                        '') AS fold_output_name
-                    FROM
-                        db_1.schema_1.[Animal] AS [Animal_2]
-                ) AS folded_subquery_1
-                    ON [Animal_1].uuid = folded_subquery_1.uuid
+                                            [Entity_1].name, '^', '^e'),
+                                        '~', '^n'),
+                                    '|', '^d'),
+                                '~')
+                            FROM
+                                db_1.schema_1.[Entity] AS [Entity_1]
+                            WHERE [Animal_2].related_entity = [Entity_1].uuid
+                        FOR XML PATH ('')
+                        ),
+                    '') AS fold_output_name
+                FROM
+                    db_1.schema_1.[Animal] AS [Animal_2]
+            ) AS folded_subquery_1
+            ON [Animal_1].uuid = folded_subquery_1.uuid
         """
         expected_cypher = SKIP_TEST  # Type coercion not implemented for Cypher
         expected_postgresql = """
@@ -7126,16 +7126,16 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS related_entities
             FROM
                 schema_1."Animal" AS "Animal_1"
-                JOIN (
-                    SELECT
-                        "Animal_2".uuid AS uuid,
-                        array_agg("Entity_1".name) AS fold_output_name
-                    FROM
-                        schema_1."Animal" AS "Animal_2"
-                        JOIN schema_1."Entity" AS "Entity_1"
-                            ON "Animal_2".related_entity = "Entity_1".uuid
-                        GROUP BY "Animal_2".uuid
-                ) AS folded_subquery_1
+            LEFT OUTER JOIN (
+                SELECT
+                    "Animal_2".uuid AS uuid,
+                    array_agg("Entity_1".name) AS fold_output_name
+                FROM
+                    schema_1."Animal" AS "Animal_2"
+                    JOIN schema_1."Entity" AS "Entity_1"
+                        ON "Animal_2".related_entity = "Entity_1".uuid
+                    GROUP BY "Animal_2".uuid
+            ) AS folded_subquery_1
                     ON "Animal_1".uuid = folded_subquery_1.uuid
         """
 
@@ -7292,7 +7292,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_list,
                 "Animal_1".name AS name
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name
@@ -7378,7 +7378,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_list,
                 "Animal_1".name AS name
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
@@ -7786,7 +7786,7 @@ class CompilerTests(unittest.TestCase):
                 "Animal_1".name AS name,
                 folded_subquery_1.fold_output__x_count AS number_of_children
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
@@ -7796,7 +7796,7 @@ class CompilerTests(unittest.TestCase):
                 ON "Animal_2".uuid = "Animal_3".parent
                 GROUP BY "Animal_2".uuid
               ) AS folded_subquery_1
-              ON "Animal_1".uuid = folded_subquery_1.uuid
+            ON "Animal_1".uuid = folded_subquery_1.uuid
               """
 
         expected_cypher = NotImplementedError
@@ -7839,7 +7839,7 @@ class CompilerTests(unittest.TestCase):
                 coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names,
                 "Animal_1".name AS name
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
@@ -7989,7 +7989,7 @@ class CompilerTests(unittest.TestCase):
             FROM schema_1."Animal" AS "Animal_1"
             LEFT OUTER JOIN schema_1."Species" AS "Species_1"
             ON "Animal_1".species = "Species_1".uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
@@ -8048,7 +8048,7 @@ class CompilerTests(unittest.TestCase):
             FROM schema_1."Animal" AS "Animal_1"
             JOIN schema_1."Species" AS "Species_1"
             ON "Animal_1".species = "Species_1".uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     array_agg("Animal_3".name) AS fold_output_name,
@@ -8137,7 +8137,7 @@ class CompilerTests(unittest.TestCase):
             SELECT
                 "Animal_1".name AS name
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_2".uuid AS uuid,
                     coalesce(count(*), 0) AS fold_output__x_count
@@ -8147,7 +8147,7 @@ class CompilerTests(unittest.TestCase):
                 GROUP BY "Animal_2".uuid
             ) AS folded_subquery_1
             ON "Animal_1".uuid = folded_subquery_1.uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_4".uuid AS uuid,
                     coalesce(count(*), 0) AS fold_output__x_count
@@ -8199,7 +8199,7 @@ class CompilerTests(unittest.TestCase):
             SELECT
                 "Species_1".name AS name
             FROM schema_1."Species" AS "Species_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Species_2".uuid AS uuid,
                     coalesce(count(*), 0) AS fold_output__x_count
@@ -10094,7 +10094,7 @@ class CompilerTests(unittest.TestCase):
             LEFT OUTER JOIN
                 schema_1."Animal" AS "Animal_2"
             ON "Animal_1".parent = "Animal_2".uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name
@@ -10224,7 +10224,7 @@ class CompilerTests(unittest.TestCase):
               coalesce(folded_subquery_1.fold_output_name, ARRAY[]::VARCHAR[]) AS child_names_list,
               "Animal_2".name AS parent_name
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                   "Animal_3".uuid AS uuid,
                   array_agg("Animal_4".name) AS fold_output_name
@@ -10262,7 +10262,7 @@ class CompilerTests(unittest.TestCase):
                 [Animal_2].nameASparent_name
             FROM
                 db_1.schema_1.[Animal] AS [Animal_1]
-            JOIN(
+            JOIN (
                 SELECT
                     [Animal_3].uuid AS uuid,
                     coalesce((
@@ -10447,7 +10447,7 @@ class CompilerTests(unittest.TestCase):
             ON "Animal_1".parent = "Animal_3".uuid
             LEFT OUTER JOIN schema_1."Animal" AS "Animal_2"
             ON "Animal_3".parent = "Animal_2".uuid
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_4".uuid AS uuid,
                     array_agg("Animal_5".name) AS fold_output_name
@@ -10612,7 +10612,7 @@ class CompilerTests(unittest.TestCase):
                     AS grandchild_names_list,
                 "Animal_2".name AS grandparent_name
             FROM schema_1."Animal" AS "Animal_1"
-            JOIN (
+            LEFT OUTER JOIN (
                 SELECT
                     "Animal_3".uuid AS uuid,
                     array_agg("Animal_4".name) AS fold_output_name

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -2419,6 +2419,72 @@ class CompilerTests(unittest.TestCase):
             expected_postgresql,
         )
 
+    def test_inwards_recurse_after_traverse(self) -> None:
+        test_data = test_input_data.inwards_recurse_after_traverse()
+
+        expected_match = SKIP_TEST
+        expected_gremlin = SKIP_TEST
+        expected_mssql = """
+            WITH anon_2 AS (
+                SELECT
+                    [Species_1].name AS [Species__name],
+                    [Species_1].uuid AS [Species__uuid],
+                    [Animal_1].name AS [Species_in_Animal_OfSpecies__name],
+                    [Animal_1].parent AS [Species_in_Animal_OfSpecies__parent],
+                    [Animal_1].species AS [Species_in_Animal_OfSpecies__species],
+                    [Animal_1].uuid AS [Species_in_Animal_OfSpecies__uuid]
+                FROM
+                    db_1.schema_1.[Species] AS [Species_1]
+                    JOIN db_1.schema_1.[Animal] AS [Animal_1]
+                        ON [Species_1].uuid = [Animal_1].species
+            ),
+            anon_1(name, parent, uuid, __cte_key, __cte_depth) AS (
+                SELECT
+                    [Animal_2].name AS name,
+                    [Animal_2].parent AS parent,
+                    [Animal_2].uuid AS uuid,
+                    [Animal_2].uuid AS __cte_key,
+                    0 AS __cte_depth
+                FROM
+                    db_1.schema_1.[Animal] AS [Animal_2]
+                WHERE
+                    [Animal_2].uuid IN (
+                        SELECT anon_2.[Species_in_Animal_OfSpecies__uuid] FROM anon_2
+                    )
+                UNION ALL
+                    SELECT
+                        [Animal_3].name AS name,
+                        [Animal_3].parent AS parent,
+                        [Animal_3].uuid AS uuid,
+                        anon_1.__cte_key AS __cte_key,
+                        anon_1.__cte_depth + 1 AS __cte_depth
+                    FROM
+                        anon_1
+                        JOIN db_1.schema_1.[Animal] AS [Animal_3]
+                            ON anon_1.parent = [Animal_3].uuid
+                    WHERE anon_1.__cte_depth < 1
+            )
+            SELECT
+                anon_1.name AS ancestor_name,
+                anon_2.[Species_in_Animal_OfSpecies__name] AS animal_name,
+                anon_2.[Species__name] AS species_name
+            FROM
+                anon_2
+                JOIN anon_1
+                    ON anon_2.[Species_in_Animal_OfSpecies__uuid] = anon_1.__cte_key
+        """
+        expected_cypher = SKIP_TEST
+        expected_postgresql = SKIP_TEST
+        check_test_data(
+            self,
+            test_data,
+            expected_match,
+            expected_gremlin,
+            expected_mssql,
+            expected_cypher,
+            expected_postgresql,
+        )
+
     def test_recurse_with_new_output_inside_recursion_and_filter_at_root(self) -> None:
         test_data = test_input_data.recurse_with_new_output_inside_recursion_and_filter_at_root()
 

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -908,6 +908,33 @@ def simple_recurse() -> CommonTestData:  # noqa: D103
     )
 
 
+def inwards_recurse_after_traverse() -> CommonTestData:  # noqa: D103
+    graphql_input = """{
+        Species {
+            name @output(out_name: "species_name")
+            in_Animal_OfSpecies {
+                name @output(out_name: "animal_name")
+                in_Animal_ParentOf @recurse(depth: 1) {
+                    name @output(out_name: "ancestor_name")
+                }
+            }
+        }
+    }"""
+    expected_output_metadata = {
+        "species_name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+        "animal_name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+        "ancestor_name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+    }
+    expected_input_metadata: Dict[str, GraphQLSchemaFieldType] = {}
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=None,
+    )
+
+
 def recurse_with_new_output_inside_recursion_and_filter_at_root() -> CommonTestData:  # noqa: D103
     # The filter on the root location will make SQL emit a cte at the base. Since
     # the color field is used in the base case of the recursive cte, the root cte


### PR DESCRIPTION
There was a bug in the code that chooses which columns to select from the base CTE of a recursion that caused the compiler to raise `KeyError`.

Line 43 (see red code) uses the `edge` variable, which is is garbage from another scope. The solution is to remove the line, and the entire block surrounding it (see TODO in the red code).

I don't add any regression tests since this is a very silly thing to regression test. Finding a query that fails is hard, but if I find one I might add it since it doesn't hurt. I've manually verified that the query that caused this problem now works.

To prevent more bugs in this code, the best thing to do is explained in the TODO at the top of the function. In fact, the implementation of that TODO would have prevented this bug.
