### PR TITLE
Remove extra IR generation step during pagination

### DIFF
--- a/graphql_compiler/interpreter/debugging.py
+++ b/graphql_compiler/interpreter/debugging.py
@@ -1,3 +1,4 @@
+# Copyright 2020-present Kensho Technologies, LLC.
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, Generic, Iterable, List, Sequence, Tuple, TypeVar

--- a/graphql_compiler/query_pagination/__init__.py
+++ b/graphql_compiler/query_pagination/__init__.py
@@ -98,8 +98,7 @@ def paginate_query_ast(
         elif len(pagination_plan.vertex_partitions) == 1:
             plan_vertex_partition = pagination_plan.vertex_partitions[0]
             parameter_generator = generate_parameters_for_vertex_partition(
-                query_analysis.schema_info,
-                query_analysis.ast_with_parameters,
+                query_analysis,
                 plan_vertex_partition,
             )
 

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -208,8 +208,7 @@ def generate_parameters_for_vertex_partition(
     the same results.
 
     Args:
-        schema_info: contains statistics and relevant schema information
-        query: the query for which we are generating parameters
+        analysis: the query augmented with various analysis steps
         vertex_partition: the pagination plan we are working on
 
     Returns:

--- a/graphql_compiler/query_pagination/parameter_generator.py
+++ b/graphql_compiler/query_pagination/parameter_generator.py
@@ -3,8 +3,6 @@ import bisect
 import itertools
 from typing import Any, Iterator, List, cast
 
-from ..compiler.compiler_frontend import ast_to_ir
-from ..compiler.helpers import Location
 from ..cost_estimation.analysis import QueryPlanningAnalysis
 from ..cost_estimation.filter_selectivity_utils import get_integer_interval_for_filters_on_field
 from ..cost_estimation.helpers import is_uuid4_type
@@ -14,7 +12,6 @@ from ..cost_estimation.int_value_conversion import (
     convert_int_to_field_value,
 )
 from ..cost_estimation.interval import Interval, intersect_int_intervals, measure_int_interval
-from ..global_utils import ASTWithParameters
 from ..schema.schema_info import QueryPlanningSchemaInfo
 from .pagination_planning import VertexPartitionPlan
 
@@ -229,8 +226,11 @@ def generate_parameters_for_vertex_partition(
 
     # Get the value interval currently imposed by existing filters
     integer_interval = get_integer_interval_for_filters_on_field(
-        analysis.schema_info, filters_on_field, vertex_type,
-        pagination_field, analysis.ast_with_parameters.parameters
+        analysis.schema_info,
+        filters_on_field,
+        vertex_type,
+        pagination_field,
+        analysis.ast_with_parameters.parameters,
     )
     field_value_interval = _convert_int_interval_to_field_value_interval(
         analysis.schema_info, vertex_type, pagination_field, integer_interval
@@ -243,6 +243,9 @@ def generate_parameters_for_vertex_partition(
         )
     else:
         return _compute_parameters_for_non_uuid_field(
-            analysis.schema_info, field_value_interval,
-            vertex_partition, vertex_type, pagination_field
+            analysis.schema_info,
+            field_value_interval,
+            vertex_partition,
+            vertex_type,
+            pagination_field,
         )

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -842,17 +842,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Species {
                 name @output(out_name: "species_name")
             }
-        }"""
-        args = {}
-        query_ast = safe_parse_graphql(query)
+        }""", {})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [25, 50, 75]
         self.assertEqual(expected_parameters, list(generated_parameters))
@@ -888,17 +885,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Species {
                 name @output(out_name: "species_name")
             }
-        }"""
-        args = {}
-        query_ast = safe_parse_graphql(query)
+        }""", {})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [10, 20]
         self.assertEqual(expected_parameters, list(generated_parameters))
@@ -941,18 +935,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Species {
                 name @output(out_name: "species_name")
                 limbs @filter(op_name: ">=", value: ["$limbs_lower"])
             }
-        }"""
-        args = {"limbs_lower": 25}
-        query_ast = safe_parse_graphql(query)
+        }""", {"limbs_lower": 25})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [50, 75]
         self.assertEqual(expected_parameters, list(generated_parameters))
@@ -981,18 +972,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Species {
                 name @output(out_name: "species_name")
                 limbs @filter(op_name: ">=", value: ["$limbs_lower"])
             }
-        }"""
-        args = {"limbs_lower": 10}
-        query_ast = safe_parse_graphql(query)
+        }""", {"limbs_lower": 10})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 10)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         first_parameter = next(generated_parameters)
         self.assertTrue(first_parameter > 10)
@@ -1023,18 +1011,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Species {
                 name @output(out_name: "species_name")
                 limbs @filter(op_name: "<", value: ["$limbs_upper"])
             }
-        }"""
-        args = {"limbs_upper": 76}
-        query_ast = safe_parse_graphql(query)
+        }""", {"limbs_upper": 76})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [25, 50]
         self.assertEqual(expected_parameters, list(generated_parameters))
@@ -1065,7 +1050,7 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Species {
                 out_Entity_Related {
                     ... on Species {
@@ -1073,13 +1058,10 @@ class QueryPaginationTests(unittest.TestCase):
                     }
                 }
             }
-        }"""
-        args = {}
-        query_ast = safe_parse_graphql(query)
+        }""", {})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species", "out_Entity_Related"), "limbs", 4)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [25, 50, 75]
         self.assertEqual(expected_parameters, list(generated_parameters))
@@ -1107,18 +1089,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Species {
                 limbs @filter(op_name: "<", value: ["$num_limbs"])
                 name @output(out_name: "species_name")
             }
-        }"""
-        args = {"num_limbs": 505}
-        query_ast = safe_parse_graphql(query)
+        }""", {"num_limbs": 505})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         # XXX document why this is expected, see if bisect_left logic is correct
         expected_parameters = [130, 260, 390]
@@ -1150,17 +1129,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Event {
                 name @output(out_name: "event_name")
             }
-        }"""
-        args = {}
-        query_ast = safe_parse_graphql(query)
+        }""", {})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Event",), "event_date", 4)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [
             datetime.datetime(2025, 1, 1, 0, 0),
@@ -1189,17 +1165,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Animal {
                 name @output(out_name: "animal_name")
             }
-        }"""
-        args = {}
-        query_ast = safe_parse_graphql(query)
+        }""", {})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Animal",), "uuid", 4)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [
             "40000000-0000-0000-0000-000000000000",
@@ -1228,17 +1201,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Animal {
                 name @output(out_name: "animal_name")
             }
-        }"""
-        args = {}
-        query_ast = safe_parse_graphql(query)
+        }""", {})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Animal",), "uuid", 4)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [
             "00000000-0000-0000-0000-400000000000",
@@ -1267,20 +1237,17 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Animal {
                 uuid @filter(op_name: ">=", value: ["$uuid_lower"])
                 name @output(out_name: "animal_name")
             }
-        }"""
-        args = {
+        }""", {
             "uuid_lower": "00000000-0000-0000-0000-800000000000",
-        }
-        query_ast = safe_parse_graphql(query)
+        })
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Animal",), "uuid", 4)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         expected_parameters = [
             "00000000-0000-0000-0000-a00000000000",
@@ -1313,17 +1280,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = """{
+        query = QueryStringWithParameters("""{
             Species {
                 name @output(out_name: "species_name")
             }
-        }"""
-        args = {}
-        query_ast = safe_parse_graphql(query)
+        }""", {})
+        analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, ASTWithParameters(query_ast, args), vertex_partition
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         # Check that there are no duplicates
         list_parameters = list(generated_parameters)
@@ -1874,9 +1838,7 @@ class QueryPaginationTests(unittest.TestCase):
 
         vertex_partition_plan = VertexPartitionPlan(("Species", "out_Entity_Related"), "limbs", 2)
 
-        generated_parameters = generate_parameters_for_vertex_partition(
-            schema_info, analysis.ast_with_parameters, vertex_partition_plan
-        )
+        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
 
         sentinel = object()
         first_param = next(generated_parameters, sentinel)

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -7,11 +7,10 @@ from graphql import print_ast
 import pytest
 
 from .. import test_input_data
-from ...ast_manipulation import safe_parse_graphql
 from ...cost_estimation.analysis import analyze_query_string
 from ...cost_estimation.statistics import LocalStatistics
 from ...exceptions import GraphQLInvalidArgumentError
-from ...global_utils import ASTWithParameters, QueryStringWithParameters
+from ...global_utils import QueryStringWithParameters
 from ...query_pagination import paginate_query
 from ...query_pagination.pagination_planning import (
     InsufficientQuantiles,
@@ -842,11 +841,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Species {
                 name @output(out_name: "species_name")
             }
-        }""", {})
+        }""",
+            {},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -885,11 +887,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Species {
                 name @output(out_name: "species_name")
             }
-        }""", {})
+        }""",
+            {},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -935,12 +940,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Species {
                 name @output(out_name: "species_name")
                 limbs @filter(op_name: ">=", value: ["$limbs_lower"])
             }
-        }""", {"limbs_lower": 25})
+        }""",
+            {"limbs_lower": 25},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -972,12 +980,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Species {
                 name @output(out_name: "species_name")
                 limbs @filter(op_name: ">=", value: ["$limbs_lower"])
             }
-        }""", {"limbs_lower": 10})
+        }""",
+            {"limbs_lower": 10},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 10)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1011,12 +1022,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Species {
                 name @output(out_name: "species_name")
                 limbs @filter(op_name: "<", value: ["$limbs_upper"])
             }
-        }""", {"limbs_upper": 76})
+        }""",
+            {"limbs_upper": 76},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 3)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1050,7 +1064,8 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Species {
                 out_Entity_Related {
                     ... on Species {
@@ -1058,7 +1073,9 @@ class QueryPaginationTests(unittest.TestCase):
                     }
                 }
             }
-        }""", {})
+        }""",
+            {},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species", "out_Entity_Related"), "limbs", 4)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1089,12 +1106,15 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Species {
                 limbs @filter(op_name: "<", value: ["$num_limbs"])
                 name @output(out_name: "species_name")
             }
-        }""", {"num_limbs": 505})
+        }""",
+            {"num_limbs": 505},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1129,11 +1149,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Event {
                 name @output(out_name: "event_name")
             }
-        }""", {})
+        }""",
+            {},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Event",), "event_date", 4)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1165,11 +1188,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Animal {
                 name @output(out_name: "animal_name")
             }
-        }""", {})
+        }""",
+            {},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Animal",), "uuid", 4)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1201,11 +1227,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Animal {
                 name @output(out_name: "animal_name")
             }
-        }""", {})
+        }""",
+            {},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Animal",), "uuid", 4)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1237,14 +1266,17 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Animal {
                 uuid @filter(op_name: ">=", value: ["$uuid_lower"])
                 name @output(out_name: "animal_name")
             }
-        }""", {
-            "uuid_lower": "00000000-0000-0000-0000-800000000000",
-        })
+        }""",
+            {
+                "uuid_lower": "00000000-0000-0000-0000-800000000000",
+            },
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Animal",), "uuid", 4)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1280,11 +1312,14 @@ class QueryPaginationTests(unittest.TestCase):
             uuid4_field_info=uuid4_field_info,
         )
 
-        query = QueryStringWithParameters("""{
+        query = QueryStringWithParameters(
+            """{
             Species {
                 name @output(out_name: "species_name")
             }
-        }""", {})
+        }""",
+            {},
+        )
         analysis = analyze_query_string(schema_info, query)
         vertex_partition = VertexPartitionPlan(("Species",), "limbs", 4)
         generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
@@ -1838,7 +1873,9 @@ class QueryPaginationTests(unittest.TestCase):
 
         vertex_partition_plan = VertexPartitionPlan(("Species", "out_Entity_Related"), "limbs", 2)
 
-        generated_parameters = generate_parameters_for_vertex_partition(analysis, vertex_partition)
+        generated_parameters = generate_parameters_for_vertex_partition(
+            analysis, vertex_partition_plan
+        )
 
         sentinel = object()
         first_param = next(generated_parameters, sentinel)


### PR DESCRIPTION
This is just tech debt resolution with no functional changes.

Instead of recomputing the IR to get filter infos during parameter generation, I look up that information from the cached analysis passes. The type signature of the function changes, so most of the changes in this PR are to update the tests to use the new function signature.