### PR TITLE
Apply changes from PR #962

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -40,13 +40,6 @@ data.
         secondname: String
     }
 
-For both 1-1 or 1-many renaming, renamings only apply to types, fields, and enum values that exist
-in the original schema. For example, if a schema contains a type named "Foo" and a type named "Bar"
-but not a type named "Baz" and renamings maps "Foo" to "Bar" and "Bar" to "Baz", then the renamed
-schema will contain a type named "Bar" (corresponding to the original schema's type "Foo") and a
-type named "Baz" (corresponding to the original schema's type "Bar"), instead of containing two
-types both named "Baz".
-
 Suppressing part of the schema removes it altogether. For instance, given the following part of a
 schema:
     type Dog {
@@ -55,6 +48,13 @@ schema:
 suppressing "Dog" would produce an otherwise-identical schema but with that type (and therefore all
 its fields) removed. If "Dog" also appeared as a field in the schema's root type, it would be
 removed there as well.
+
+For both 1-1 or 1-many renaming, renamings only apply to types, fields, and enum values that exist
+in the original schema. For example, if a schema contains a type named "Foo" and a type named "Bar"
+but not a type named "Baz" and type_renamings maps "Foo" to "Bar" and "Bar" to "Baz", then the
+renamed schema will contain a type named "Bar" (corresponding to the original schema's type "Foo")
+and a type named "Baz" (corresponding to the original schema's type "Bar"), instead of containing
+two types both named "Baz".
 
 Operations that are already supported:
 - 1-1 renaming of object types, unions, enums, and interfaces.
@@ -76,14 +76,15 @@ Renaming constraints:
 - All names must be valid GraphQL names.
 - Names may not conflict with each other. For instance, you may not rename both "Foo" and "Bar" to
   "Baz". You also may not rename anything to "Baz" if a type "Baz" already exists and is not also
-  being renamed or suppressed.
-- Special rules apply to the renamings argument if it's iterable (e.g. if a dict). If iterable,
-  renamings may not contain no-op entries. In other words:
-    - A string type_name may be in renamings only if there exists a type in the schema named
-      type_name (since otherwise that entry would not affect any type in the schema).
-    - A string type_name is in renamings, then renamings[type_name] != type_name (since applying the
-      renaming would not change the type named type_name).
-  If not iterable, then these no-op rules don't apply.
+  being renamed or suppressed. The same rules apply for fields that belong to the same type, since
+  they share a namespace as well.
+- There exist special rules for iterable renamings (e.g. if renamings are represented as a
+  dictionary)-- specifically, no-op renamings are not allowed.
+  - If type_renamings argument is iterable:
+    - A string type_name may be in type_renamings only if there exists a type in the original schema
+      named type_name (since otherwise that entry would not affect any type in the schema).
+    - If string type_name is in type_renamings, then type_renamings[type_name] != type_name (since
+      if they were the same, then applying the renaming would not change the type named type_name).
 """
 from collections import namedtuple
 from collections.abc import Iterable
@@ -137,19 +138,21 @@ RenamedSchemaDescriptor = namedtuple(
 VisitorReturnType = Union[Node, VisitorAction]
 
 
-class RenamingMapping(Protocol):
+class TypeRenamingMapping(Protocol):
     def get(self, key: str, default: Optional[str]) -> Optional[str]:
-        """Define mapping for renaming object."""
+        """Define mapping for type_renamings object."""
         ...
 
 
-def rename_schema(schema_ast: DocumentNode, renamings: RenamingMapping) -> RenamedSchemaDescriptor:
-    """Create a RenamedSchemaDescriptor; rename/suppress types and root type fields using renamings.
+def rename_schema(
+    schema_ast: DocumentNode, type_renamings: TypeRenamingMapping
+) -> RenamedSchemaDescriptor:
+    """Create a RenamedSchemaDescriptor; rename/suppress types and root type fields.
 
-    Any type, interface, enum, or fields of the root type/query type whose name
-    appears in renamings will be renamed to the corresponding value if the value is not None. If the
-    value is None, it will be suppressed in the renamed schema and queries will not be able to
-    access it.
+    Any object type, interface type, enum type, or field of the root type/query type has a name. Let
+    the name be called type_name. If type_renamings.get(type_name, type_name) is not None, the type
+    or field of the root type/query type will be renamed to the returned value. If the value is
+    None, it will be suppressed in the renamed schema and queries will not be able to access it.
 
     Any such names that do not appear in renamings will be unchanged. Directives will never be
     renamed.
@@ -161,9 +164,9 @@ def rename_schema(schema_ast: DocumentNode, renamings: RenamingMapping) -> Renam
         schema_ast: represents a valid schema that does not contain extensions, input object
                     definitions, mutations, or subscriptions, whose fields of the query type share
                     the same name as the types they query. Not modified by this function
-        renamings: maps original type name to renamed name or None (for type suppression). A type
-                   named "Foo" will be unchanged iff renamings does not map "Foo" to anything, i.e.
-                   renamings.get("Foo", "Foo") returns "Foo".
+        type_renamings: maps original type name to renamed name or None (for type suppression). A
+                        type named "Foo" will be unchanged iff type_renamings does not map "Foo" to
+                        anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
 
     Returns:
         RenamedSchemaDescriptor containing the AST of the renamed schema, and the map of renamed
@@ -171,14 +174,14 @@ def rename_schema(schema_ast: DocumentNode, renamings: RenamingMapping) -> Renam
 
     Raises:
         - CascadingSuppressionError if a type suppression would require further suppressions
-        - SchemaTransformError if renamings suppressed every type. Note that this is a superclass of
-          CascadingSuppressionError, InvalidTypeNameError, SchemaStructureError, and
+        - SchemaTransformError if type_renamings suppressed every type. Note that this is a
+          superclass of CascadingSuppressionError, InvalidTypeNameError, SchemaStructureError, and
           SchemaRenameNameConflictError, so handling exceptions of type SchemaTransformError will
           also catch all of its subclasses. This will change after the error classes are modified so
           that errors can be fixed programmatically, at which point it will make sense for the user
           to attempt to treat different errors differently
-        - NotImplementedError if renamings attempts to suppress an enum, an interface, or a type
-          implementing an interface
+        - NotImplementedError if type_renamings attempts to suppress an enum, an interface, or a
+          type implementing an interface
         - InvalidTypeNameError if the schema contains an invalid type name, or if the user attempts
           to rename a type to an invalid name. A name is considered invalid if it does not consist
           of alphanumeric characters and underscores, if it starts with a numeric character, or
@@ -187,7 +190,9 @@ def rename_schema(schema_ast: DocumentNode, renamings: RenamingMapping) -> Renam
           the AST does not represent a valid schema, if any query type field does not have the
           same name as the type that it queries, if the schema contains type extensions or
           input object definitions, or if the schema contains mutations or subscriptions
-        - SchemaRenameNameConflictError if there are conflicts between the renamed types or fields
+        - SchemaRenameNameConflictError if there are name conflicts between the renamed types or
+          fields
+        - NoOpRenamingError if the renamings contain no-op renamings and are iterable
     """
     # Check input schema satisfies various structural requirements
     check_ast_schema_is_valid(schema_ast)
@@ -196,11 +201,11 @@ def rename_schema(schema_ast: DocumentNode, renamings: RenamingMapping) -> Renam
     query_type = get_query_type_name(schema)
     custom_scalar_names = get_custom_scalar_names(schema)
 
-    _validate_renamings(schema_ast, renamings, query_type, custom_scalar_names)
+    _validate_renamings(schema_ast, type_renamings, query_type, custom_scalar_names)
 
     # Rename types, interfaces, enums, unions and suppress types, unions
     schema_ast, reverse_name_map = _rename_and_suppress_types(
-        schema_ast, renamings, query_type, custom_scalar_names
+        schema_ast, type_renamings, query_type, custom_scalar_names
     )
     reverse_name_map_changed_names_only = {
         renamed_name: original_name
@@ -208,7 +213,7 @@ def rename_schema(schema_ast: DocumentNode, renamings: RenamingMapping) -> Renam
         if renamed_name != original_name
     }
 
-    schema_ast = _rename_and_suppress_query_type_fields(schema_ast, renamings, query_type)
+    schema_ast = _rename_and_suppress_query_type_fields(schema_ast, type_renamings, query_type)
     return RenamedSchemaDescriptor(
         schema_ast=schema_ast,
         schema=build_ast_schema(schema_ast),
@@ -218,14 +223,14 @@ def rename_schema(schema_ast: DocumentNode, renamings: RenamingMapping) -> Renam
 
 def _validate_renamings(
     schema_ast: DocumentNode,
-    renamings: RenamingMapping,
+    type_renamings: TypeRenamingMapping,
     query_type: str,
     custom_scalar_names: AbstractSet[str],
 ) -> None:
-    """Validate the renamings argument before attempting to rename the schema.
+    """Validate the type_renamings argument before attempting to rename the schema.
 
     Check for fields with suppressed types or unions whose members were all suppressed. Also,
-    confirm renamings contains no enums, interfaces, or interface implementation suppressions
+    confirm type_renamings contains no enums, interfaces, or interface implementation suppressions
     because that hasn't been implemented yet. Confirm that no scalars would be suppressed or
     renamed.
 
@@ -235,32 +240,32 @@ def _validate_renamings(
         schema_ast: represents a valid schema that does not contain extensions, input object
                     definitions, mutations, or subscriptions, whose fields of the query type share
                     the same name as the types they query. Not modified by this function
-        renamings: maps original type name to renamed name or None (for type suppression). A type
-                   named "Foo" will be unchanged iff renamings does not map "Foo" to anything, i.e.
-                   renamings.get("Foo", "Foo") returns "Foo".
+        type_renamings: maps original type name to renamed name or None (for type suppression). A
+                        type named "Foo" will be unchanged iff type_renamings does not map "Foo" to
+                        anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
         query_type: name of the query type, e.g. 'RootSchemaQuery'
         custom_scalar_names: set of all user defined scalars used in the schema (excluding
                              builtin scalars)
 
     Raises:
         - CascadingSuppressionError if a type suppression would require further suppressions
-        - NotImplementedError if renamings attempts to suppress an enum, an interface, or a type
-          implementing an interface
+        - NotImplementedError if type_renamings attempts to suppress an enum, an interface, or a
+          type implementing an interface
     """
-    _ensure_no_cascading_type_suppressions(schema_ast, renamings, query_type)
-    _ensure_no_unsupported_operations(schema_ast, renamings, custom_scalar_names)
+    _ensure_no_cascading_type_suppressions(schema_ast, type_renamings, query_type)
+    _ensure_no_unsupported_operations(schema_ast, type_renamings, custom_scalar_names)
 
 
 def _ensure_no_cascading_type_suppressions(
-    schema_ast: DocumentNode, renamings: RenamingMapping, query_type: str
+    schema_ast: DocumentNode, type_renamings: TypeRenamingMapping, query_type: str
 ) -> None:
     """Check for fields with suppressed types or unions whose members were all suppressed."""
-    visitor = CascadingSuppressionCheckVisitor(renamings, query_type)
+    visitor = CascadingSuppressionCheckVisitor(type_renamings, query_type)
     visit(schema_ast, visitor)
     if visitor.fields_to_suppress or visitor.union_types_to_suppress:
         error_message_components = [
-            f"Type renamings {renamings} would require further suppressions to produce a valid "
-            f"renamed schema."
+            f"Type renamings {type_renamings} would require further suppressions to produce a "
+            f"valid renamed schema."
         ]
         if visitor.fields_to_suppress:
             for object_type in visitor.fields_to_suppress:
@@ -287,58 +292,58 @@ def _ensure_no_cascading_type_suppressions(
                 )
             error_message_components.append(
                 "To fix this, you can suppress the union as well by adding union_type: None to the "
-                "renamings argument when renaming types, for each value of union_type described "
-                "here. Note that adding suppressions may lead to other types, fields, etc. "
-                "requiring suppression so you may need to iterate on this before getting a legal "
-                "schema."
+                "type_renamings argument when renaming types, for each value of union_type "
+                "described here. Note that adding suppressions may lead to other types, fields, "
+                "etc. requiring suppression so you may need to iterate on this before getting a "
+                "legal schema."
             )
         raise CascadingSuppressionError("\n".join(error_message_components))
 
 
 def _ensure_no_unsupported_operations(
     schema_ast: DocumentNode,
-    renamings: RenamingMapping,
+    type_renamings: TypeRenamingMapping,
     custom_scalar_names: AbstractSet[str],
 ) -> None:
     """Check for unsupported renaming or suppression operations."""
-    _ensure_no_unsupported_scalar_operations(renamings, custom_scalar_names)
-    _ensure_no_unsupported_suppressions(schema_ast, renamings)
+    _ensure_no_unsupported_scalar_operations(type_renamings, custom_scalar_names)
+    _ensure_no_unsupported_suppressions(schema_ast, type_renamings)
 
 
 def _ensure_no_unsupported_scalar_operations(
-    renamings: RenamingMapping,
+    type_renamings: TypeRenamingMapping,
     custom_scalar_names: AbstractSet[str],
 ) -> None:
     """Check for unsupported scalar operations."""
     unsupported_scalar_operations = {}  # Map scalars to value to be renamed.
     for scalar_name in custom_scalar_names:
-        possibly_renamed_scalar_name = renamings.get(scalar_name, scalar_name)
-        # renamings.get(scalar_name, scalar_name) returns something that is not scalar iff it
+        possibly_renamed_scalar_name = type_renamings.get(scalar_name, scalar_name)
+        # type_renamings.get(scalar_name, scalar_name) returns something that is not scalar iff it
         # attempts to do something with the scalar (i.e. renaming or suppressing it)
         if possibly_renamed_scalar_name != scalar_name:
             unsupported_scalar_operations[scalar_name] = possibly_renamed_scalar_name
     for builtin_scalar_name in builtin_scalar_type_names:
-        possibly_renamed_builtin_scalar_name = renamings.get(
+        possibly_renamed_builtin_scalar_name = type_renamings.get(
             builtin_scalar_name, builtin_scalar_name
         )
         if possibly_renamed_builtin_scalar_name != builtin_scalar_name:
-            # Check that built-in scalar types remain unchanged during renaming.
+            # Check that built-in scalar types remain unchanged during type renaming.
             unsupported_scalar_operations[
                 builtin_scalar_name
             ] = possibly_renamed_builtin_scalar_name
     if unsupported_scalar_operations:
         raise NotImplementedError(
-            f"Scalar renaming and suppression is not implemented yet, but renamings attempted to "
-            f"modify the following scalars: {unsupported_scalar_operations}. To fix this, remove "
-            f"them from renamings."
+            f"Scalar renaming and suppression is not implemented yet, but type_renamings attempted "
+            f"to modify the following scalars: {unsupported_scalar_operations}. To fix this, "
+            f"remove them from type_renamings."
         )
 
 
 def _ensure_no_unsupported_suppressions(
-    schema_ast: DocumentNode, renamings: RenamingMapping
+    schema_ast: DocumentNode, type_renamings: TypeRenamingMapping
 ) -> None:
-    """Confirm renamings contains no enums, interfaces, or interface implementation suppressions."""
-    visitor = SuppressionNotImplementedVisitor(renamings)
+    """Confirm type_renamings has no enums, interfaces, or interface implementation suppressions."""
+    visitor = SuppressionNotImplementedVisitor(type_renamings)
     visit(schema_ast, visitor)
     if (
         not visitor.unsupported_enum_suppressions
@@ -348,37 +353,37 @@ def _ensure_no_unsupported_suppressions(
         return
     # Otherwise, attempted to suppress something we shouldn't suppress.
     error_message_components = [
-        f"Type renamings {renamings} attempted to suppress parts of the schema for which "
+        f"Type renamings {type_renamings} attempted to suppress parts of the schema for which "
         f"suppression is not implemented yet."
     ]
     if visitor.unsupported_enum_suppressions:
         error_message_components.append(
             f"Type renamings mapped these schema enums to None: "
             f"{visitor.unsupported_enum_suppressions}, attempting to suppress them. However, "
-            f"schema renaming has not implemented enum suppression yet."
+            f"type renaming has not implemented enum suppression yet."
         )
     if visitor.unsupported_interface_suppressions:
         error_message_components.append(
             f"Type renamings mapped these schema interfaces to None: "
             f"{visitor.unsupported_interface_suppressions}, attempting to suppress them. However, "
-            f"schema renaming has not implemented interface suppression yet."
+            f"type renaming has not implemented interface suppression yet."
         )
     if visitor.unsupported_interface_implementation_suppressions:
         error_message_components.append(
             f"Type renamings mapped these object types to None: "
             f"{visitor.unsupported_interface_implementation_suppressions}, attempting to suppress "
             f"them. Normally, this would be fine. However, these types each implement at least one "
-            f"interface and schema renaming has not implemented this particular suppression yet."
+            f"interface and type renaming has not implemented this particular suppression yet."
         )
     error_message_components.append(
-        "To avoid these suppressions, remove the mappings from the renamings argument."
+        "To avoid these suppressions, remove the mappings from the type_renamings argument."
     )
     raise NotImplementedError("\n".join(error_message_components))
 
 
 def _rename_and_suppress_types(
     schema_ast: DocumentNode,
-    renamings: RenamingMapping,
+    type_renamings: TypeRenamingMapping,
     query_type: str,
     custom_scalar_names: AbstractSet[str],
 ) -> Tuple[DocumentNode, Dict[str, str]]:
@@ -390,9 +395,9 @@ def _rename_and_suppress_types(
 
     Args:
         schema_ast: schema that we're returning a modified version of
-        renamings: maps original type name to renamed name or None (for type suppression). A type
-                   named "Foo" will be unchanged iff renamings does not map "Foo" to anything, i.e.
-                   renamings.get("Foo", "Foo") returns "Foo".
+        type_renamings: maps original type name to renamed name or None (for type suppression). A
+                        type named "Foo" will be unchanged iff type_renamings does not map "Foo" to
+                        anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
         query_type: name of the query type, e.g. 'RootSchemaQuery'
         custom_scalar_names: set of all user defined scalars used in the schema (excluding
                              builtin scalars)
@@ -405,44 +410,49 @@ def _rename_and_suppress_types(
     Raises:
         - InvalidTypeNameError if the user attempts to rename a type to an invalid name
         - SchemaRenameNameConflictError if the rename causes name conflicts
+        - NoOpRenamingError if renamings contains no-op renamings and renamings are iterable
     """
-    visitor = RenameSchemaTypesVisitor(renamings, query_type, custom_scalar_names)
+    visitor = RenameSchemaTypesVisitor(type_renamings, query_type, custom_scalar_names)
     renamed_schema_ast = visit(schema_ast, visitor)
     if visitor.invalid_type_names:
+        sorted_invalid_type_names = sorted(visitor.invalid_type_names.items())
         raise InvalidTypeNameError(
             f"Applying the renaming would rename types with names that are not valid, unreserved "
             f"GraphQL names. Valid, unreserved GraphQL names must consist of only alphanumeric "
             f"characters and underscores, must not start with a numeric character, and must not "
             f"start with double underscores. The following dictionary maps each type's original "
-            f"name to what would be the new name: {visitor.invalid_type_names}"
+            f"name to what would be the new name: {sorted_invalid_type_names}"
         )
-    if visitor.type_name_conflicts or visitor.renamed_to_builtin_scalar_conflicts:
+    if visitor.type_name_conflicts or visitor.type_renamed_to_builtin_scalar_conflicts:
         raise SchemaRenameNameConflictError(
-            visitor.type_name_conflicts, visitor.renamed_to_builtin_scalar_conflicts
+            visitor.type_name_conflicts, visitor.type_renamed_to_builtin_scalar_conflicts
         )
-    if isinstance(renamings, Iterable):
-        # If renamings is iterable, then every renaming must be used and no renaming can map a
+    no_op_type_renames: Set[str] = set()
+    if isinstance(type_renamings, Iterable):
+        # If type_renamings is iterable, then every renaming must be used and no renaming can map a
         # name to itself
-        for type_name in visitor.suppressed_types:
-            if type_name not in renamings:
+        for type_name in visitor.suppressed_type_names:
+            if type_name not in type_renamings:
                 raise AssertionError(
-                    f"suppressed_types should be a subset of the set of keys in renamings, but "
-                    f"found {type_name} in suppressed_types that is not a key in renamings. This "
-                    f"is a bug."
+                    f"suppressed_type_names should be a subset of the set of keys in "
+                    f"type_renamings, but found {type_name} in suppressed_type_names that is not a "
+                    f"key in type_renamings. This is a bug."
                 )
         renamed_types = {
             visitor.reverse_name_map[type_name]
             for type_name in visitor.reverse_name_map
             if type_name != visitor.reverse_name_map[type_name]
         }
-        no_op_renames: Set[str] = set(renamings) - renamed_types - set(visitor.suppressed_types)
-        if no_op_renames:
-            raise NoOpRenamingError(no_op_renames)
+        no_op_type_renames = (
+            set(type_renamings) - renamed_types - set(visitor.suppressed_type_names)
+        )
+    if no_op_type_renames:
+        raise NoOpRenamingError(no_op_type_renames)
     return renamed_schema_ast, visitor.reverse_name_map
 
 
 def _rename_and_suppress_query_type_fields(
-    schema_ast: DocumentNode, renamings: RenamingMapping, query_type: str
+    schema_ast: DocumentNode, type_renamings: TypeRenamingMapping, query_type: str
 ) -> DocumentNode:
     """Rename or suppress all fields of the query type.
 
@@ -450,18 +460,18 @@ def _rename_and_suppress_query_type_fields(
 
     Args:
         schema_ast: schema that we're returning a modified version of
-        renamings: maps original type name to renamed name or None (for type suppression). A type
-                   named "Foo" will be unchanged iff renamings does not map "Foo" to anything, i.e.
-                   renamings.get("Foo", "Foo") returns "Foo".
+        type_renamings: maps original type name to renamed name or None (for type suppression). A
+                        type named "Foo" will be unchanged iff type_renamings does not map "Foo" to
+                        anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
         query_type: name of the query type, e.g. 'RootSchemaQuery'
 
     Returns:
         modified version of the input schema AST
 
     Raises:
-        - SchemaTransformError if renamings suppressed every type
+        - SchemaTransformError if type_renamings suppressed every type
     """
-    visitor = RenameQueryTypeFieldsVisitor(renamings, query_type)
+    visitor = RenameQueryTypeFieldsVisitor(type_renamings, query_type)
     renamed_schema_ast = visit(schema_ast, visitor)
     return renamed_schema_ast
 
@@ -510,6 +520,7 @@ class RenameSchemaTypesVisitor(Visitor):
             "ScalarTypeExtensionNode",
         }
     )
+
     # rename_types must be a set of strings corresponding to the names of the classes in
     # RenameTypes. The duplication exists because introspection for Unions via typing.get_args()
     # doesn't exist until Python 3.8. In Python 3.8, this would be a valid way to define
@@ -529,50 +540,56 @@ class RenameSchemaTypesVisitor(Visitor):
             "UnionTypeDefinitionNode",
         }
     )
+
     # Collects naming conflict errors involving types that are not built-in scalar types. If
-    # renaming would result in multiple types being named "Foo", type_name_conflicts will map "Foo"
-    # to a set containing the name of each such type
+    # type_renamings would result in multiple types being named "Foo", type_name_conflicts will map
+    # "Foo" to a set containing the name of each such type
     type_name_conflicts: Dict[str, Set[str]]
-    # Collects naming conflict errors involving built-in scalar types. If renaming would rename a
-    # type named "Foo" to "String", renamed_to_scalar_conflicts will map "Foo" to "String"
-    renamed_to_builtin_scalar_conflicts: Dict[str, str]
+
+    # Collects naming conflict errors involving built-in scalar types. If type_renamings would
+    # rename a type named "Foo" to "String", type_renamed_to_builtin_scalar_conflicts will map
+    # "Foo" to "String"
+    type_renamed_to_builtin_scalar_conflicts: Dict[str, str]
+
     # reverse_name_map maps renamed type name to original type name, containing all non-suppressed
     # non-scalar types, including those that were unchanged. Must contain unchanged names to prevent
-    # renaming conflicts and raise SchemaRenameNameConflictError when they arise
+    # type renaming conflicts and raise SchemaRenameNameConflictError when they arise
     reverse_name_map: Dict[str, str]
-    # Collects invalid type names in renamings. If renaming would rename a type named "Foo" to a
-    # string that is not a valid, unreserved GraphQL type name (see definition in the
-    # type_name_is_valid function in utils), invalid_type_names will map "Foo" to the invalid type
-    # name.
+
+    # Collects invalid type names in type_renamings. If type_renamings would rename a type named
+    # "Foo" to a string that is not a valid, unreserved GraphQL type name (valid, unreserved names
+    # consist only of alphanumeric characters and underscores, do not start with a number, and do
+    # not start with two underscores), invalid_type_names will map "Foo" to the invalid type name.
     invalid_type_names: Dict[str, str]
-    # Collects the type names for types that get suppressed. If renaming would suppress a type named
-    # "Foo", renamed_types will contain "Foo".
-    suppressed_types: Set[str]
+
+    # Collects the type names for types that get suppressed. If type_renamings would suppress a type
+    # named "Foo", suppressed_type_names will contain "Foo".
+    suppressed_type_names: Set[str]
 
     def __init__(
         self,
-        renamings: RenamingMapping,
+        type_renamings: TypeRenamingMapping,
         query_type: str,
         custom_scalar_names: AbstractSet[str],
     ) -> None:
         """Create a visitor for renaming types in a schema AST.
 
         Args:
-            renamings: maps original type name to renamed name or None (for type suppression). A
-                       type named "Foo" will be unchanged iff renamings does not map "Foo" to
-                       anything, i.e. renamings.get("Foo", "Foo") returns "Foo".
+            type_renamings: maps original type name to renamed name or None (for type suppression).
+                            A type named "Foo" will be unchanged iff type_renamings does not map
+                            "Foo" to anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
             query_type: name of the query type (e.g. RootSchemaQuery), which will not be renamed
             custom_scalar_names: set of all user defined scalars used in the schema (excluding
                                  builtin scalars)
         """
-        self.renamings = renamings
+        self.type_renamings = type_renamings
         self.reverse_name_map = {}
         self.type_name_conflicts = {}
-        self.renamed_to_builtin_scalar_conflicts = {}
+        self.type_renamed_to_builtin_scalar_conflicts = {}
         self.invalid_type_names = {}
         self.query_type = query_type
         self.custom_scalar_names = frozenset(custom_scalar_names)
-        self.suppressed_types = set()
+        self.suppressed_type_names = set()
 
     def _rename_or_suppress_or_ignore_name_and_add_to_record(
         self, node: RenameTypesT
@@ -603,10 +620,10 @@ class RenameSchemaTypesVisitor(Visitor):
         ):
             return IDLE
 
-        desired_type_name = self.renamings.get(type_name, type_name)  # Default use original
+        desired_type_name = self.type_renamings.get(type_name, type_name)  # Default use original
         if desired_type_name is None:
             # Suppress the type
-            self.suppressed_types.add(type_name)
+            self.suppressed_type_names.add(type_name)
             return REMOVE
         if not type_name_is_valid(desired_type_name):
             self.invalid_type_names[type_name] = desired_type_name
@@ -653,7 +670,7 @@ class RenameSchemaTypesVisitor(Visitor):
             self.type_name_conflicts[desired_type_name].add(type_name)
 
         if desired_type_name in builtin_scalar_type_names:
-            self.renamed_to_builtin_scalar_conflicts[type_name] = desired_type_name
+            self.type_renamed_to_builtin_scalar_conflicts[type_name] = desired_type_name
 
         self.reverse_name_map[desired_type_name] = type_name
         if desired_type_name == type_name:
@@ -677,7 +694,7 @@ class RenameSchemaTypesVisitor(Visitor):
             return IDLE
         elif node_type in self.rename_types:
             # Process the node by either renaming, suppressing, or not doing anything with it
-            # (depending on what renamings specifies)
+            # (depending on what type_renamings specifies)
             return self._rename_or_suppress_or_ignore_name_and_add_to_record(
                 cast(RenameTypes, node)
             )
@@ -687,13 +704,13 @@ class RenameSchemaTypesVisitor(Visitor):
 
 
 class RenameQueryTypeFieldsVisitor(Visitor):
-    def __init__(self, renamings: RenamingMapping, query_type: str) -> None:
+    def __init__(self, type_renamings: TypeRenamingMapping, query_type: str) -> None:
         """Create a visitor for renaming or suppressing fields of the query type in a schema AST.
 
         Args:
-            renamings: maps original type name to renamed name or None (for type suppression). A
-                       type named "Foo" will be unchanged iff renamings does not map "Foo" to
-                       anything, i.e. renamings.get("Foo", "Foo") returns "Foo".
+            type_renamings: maps original type name to renamed name or None (for type suppression).
+                            A type named "Foo" will be unchanged iff type_renamings does not map
+                            "Foo" to anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
             query_type: name of the query type (e.g. RootSchemaQuery)
 
         Raises:
@@ -702,7 +719,7 @@ class RenameQueryTypeFieldsVisitor(Visitor):
         # Note that as field names and type names have been confirmed to match up, any renamed
         # query type field already has a corresponding renamed type.
         self.in_query_type = False
-        self.renamings = renamings
+        self.type_renamings = type_renamings
         self.query_type = query_type
 
     def enter_object_type_definition(
@@ -728,9 +745,9 @@ class RenameQueryTypeFieldsVisitor(Visitor):
         """If the node's name matches the query type, record that we left the query type."""
         if not node.fields:
             raise SchemaTransformError(
-                f"Type renamings {self.renamings} suppressed every type in the schema so it will "
-                f"be impossible to query for anything. To fix this, check why the `renamings` "
-                f"argument of `rename_schema` mapped every type to None."
+                f"Type renamings {self.type_renamings} suppressed every type in the schema so it "
+                f"will be impossible to query for anything. To fix this, check why the "
+                f"type_renamings argument of rename_schema mapped every type to None."
             )
         if node.name.value == self.query_type:
             self.in_query_type = False
@@ -743,10 +760,10 @@ class RenameQueryTypeFieldsVisitor(Visitor):
         path: List[Any],
         ancestors: List[Any],
     ) -> VisitorReturnType:
-        """If inside query type, rename or remove field as specified by renamings."""
+        """If inside query type, rename or remove field as specified by type_renamings."""
         if self.in_query_type:
             field_name = node.name.value
-            new_field_name = self.renamings.get(field_name, field_name)  # Default use original
+            new_field_name = self.type_renamings.get(field_name, field_name)  # Default use original
             if new_field_name == field_name:
                 return IDLE
             if new_field_name is None:
@@ -776,16 +793,16 @@ class CascadingSuppressionCheckVisitor(Visitor):
     fields_to_suppress: Dict[str, Dict[str, str]]
     union_types_to_suppress: List[UnionTypeDefinitionNode]
 
-    def __init__(self, renamings: RenamingMapping, query_type: str) -> None:
+    def __init__(self, type_renamings: TypeRenamingMapping, query_type: str) -> None:
         """Create a visitor to check that suppression does not cause an illegal state.
 
         Args:
-            renamings: maps original type name to renamed name or None (for type suppression). A
-                       type named "Foo" will be unchanged iff renamings does not map "Foo" to
-                       anything, i.e. renamings.get("Foo", "Foo") returns "Foo".
+            type_renamings: maps original type name to renamed name or None (for type suppression).
+                            A type named "Foo" will be unchanged iff type_renamings does not map
+                            "Foo" to anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
             query_type: name of the query type (e.g. RootSchemaQuery)
         """
-        self.renamings = renamings
+        self.type_renamings = type_renamings
         self.query_type = query_type
         self.current_type: Optional[str] = None
         self.fields_to_suppress = {}
@@ -827,7 +844,7 @@ class CascadingSuppressionCheckVisitor(Visitor):
         # At a field of a type that is not the query type
         field_name = node.name.value
         field_type = get_ast_with_non_null_and_list_stripped(node.type).name.value
-        if self.renamings.get(field_type, field_type):
+        if self.type_renamings.get(field_type, field_type):
             return IDLE
         # Reaching this point means this field is of a type to be suppressed.
         if self.current_type is None:
@@ -858,11 +875,11 @@ class CascadingSuppressionCheckVisitor(Visitor):
         # Check if all the union members are suppressed.
         for union_member in node.types:
             union_member_type = get_ast_with_non_null_and_list_stripped(union_member).name.value
-            if self.renamings.get(union_member_type, union_member_type):
+            if self.type_renamings.get(union_member_type, union_member_type):
                 # Then at least one member of the union is not suppressed, so there is no cascading
                 # suppression error concern.
                 return IDLE
-        if self.renamings.get(union_name, union_name) is None:
+        if self.type_renamings.get(union_name, union_name) is None:
             # If the union is also suppressed, then nothing needs to happen here
             return IDLE
         self.union_types_to_suppress.append(node)
@@ -873,12 +890,12 @@ class CascadingSuppressionCheckVisitor(Visitor):
 class SuppressionNotImplementedVisitor(Visitor):
     """Traverse the schema to check for suppressions that are not yet implemented.
 
-    Each attribute that mentions an unsupported suppression records the types that renamings
+    Each attribute that mentions an unsupported suppression records the types that type_renamings
     attempts to suppress.
 
     After calling visit() on the schema using this visitor, if any of these attributes are non-empty
-    then some suppressions specified by renamings are unsupported, so the code should then raise a
-    NotImplementedError.
+    then some suppressions specified by type_renamings are unsupported, so the code should then
+    raise a NotImplementedError.
 
     """
 
@@ -886,15 +903,15 @@ class SuppressionNotImplementedVisitor(Visitor):
     unsupported_interface_suppressions: Set[str]
     unsupported_interface_implementation_suppressions: Set[str]
 
-    def __init__(self, renamings: RenamingMapping) -> None:
-        """Confirm renamings does not attempt to suppress enum/interface/interface implementation.
+    def __init__(self, type_renamings: TypeRenamingMapping) -> None:
+        """Confirm type_renamings doesn't try to suppress enum/interface/interface implementation.
 
         Args:
-            renamings: from original field name to renamed field name or None (for type
-                       suppression). A type named "Foo" will be unchanged iff renamings does not map
-                       "Foo" to anything, i.e. renamings.get("Foo", "Foo") returns "Foo".
+            type_renamings: maps original type name to renamed name or None (for type suppression).
+                            A type named "Foo" will be unchanged iff type_renamings does not map
+                            "Foo" to anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
         """
-        self.renamings = renamings
+        self.type_renamings = type_renamings
         self.unsupported_enum_suppressions = set()
         self.unsupported_interface_suppressions = set()
         self.unsupported_interface_implementation_suppressions = set()
@@ -907,9 +924,9 @@ class SuppressionNotImplementedVisitor(Visitor):
         path: List[Any],
         ancestors: List[Any],
     ) -> None:
-        """If renamings has enum suppression, record it for error message."""
+        """If type_renamings suppresses enums, record it for error message."""
         enum_name = node.name.value
-        if self.renamings.get(enum_name, enum_name) is None:
+        if self.type_renamings.get(enum_name, enum_name) is None:
             self.unsupported_enum_suppressions.add(enum_name)
 
     def enter_interface_type_definition(
@@ -920,9 +937,9 @@ class SuppressionNotImplementedVisitor(Visitor):
         path: List[Any],
         ancestors: List[Any],
     ) -> None:
-        """If renamings has interface suppression, record it for error message."""
+        """If type_renamings suppresses interfaces, record it for error message."""
         interface_name = node.name.value
-        if self.renamings.get(interface_name, interface_name) is None:
+        if self.type_renamings.get(interface_name, interface_name) is None:
             self.unsupported_interface_suppressions.add(interface_name)
 
     def enter_object_type_definition(
@@ -933,10 +950,10 @@ class SuppressionNotImplementedVisitor(Visitor):
         path: List[Any],
         ancestors: List[Any],
     ) -> None:
-        """If renamings has interface implementation suppression, record it for error message."""
+        """If type_renamings suppresses interface implementations, record it for error message."""
         if not node.interfaces:
             return
         object_name = node.name.value
-        if self.renamings.get(object_name, object_name) is None:
+        if self.type_renamings.get(object_name, object_name) is None:
             # Suppressing interface implementations isn't supported yet.
             self.unsupported_interface_implementation_suppressions.add(object_name)

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -50,9 +50,9 @@ class InvalidTypeNameError(SchemaTransformError):
 
     This may be raised if the input schema contains invalid names, or if the user attempts to
     rename a type/field to an invalid name. A name is considered valid if it consists of
-    alphanumeric characters and underscores and doesn't start with a numeric character (as
-    required by GraphQL), and doesn't start with double underscores as such type names are
-    reserved for GraphQL internal use.
+    alphanumeric characters and underscores and doesn't start with a numeric character (as required
+    by GraphQL), and doesn't start with double underscores as such type names are reserved for
+    GraphQL internal use.
     """
 
 
@@ -99,13 +99,14 @@ class SchemaRenameNameConflictError(SchemaTransformError):
             ]
             type_name_conflicts_message = (
                 f"Applying the renaming would produce a schema in which multiple types have the "
-                f"same name, which is an illegal schema state. To fix this, modify the renamings "
-                f"argument of rename_schema to ensure that no two types in the renamed schema have "
-                f"the same name. The following is a list of tuples that describes what needs to be "
-                f"fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
-                f"where new_type_name is the type name that would appear in the new schema and "
-                f"original_schema_type_names is a list of types in the original schema that get "
-                f"mapped to new_type_name: {sorted_type_name_conflicts}"
+                f"same name, which is an illegal schema state. To fix this, modify the "
+                f"type_renamings argument of rename_schema to ensure that no two types in the "
+                f"renamed schema have the same name. The following is a list of tuples that "
+                f"describes what needs to be fixed. Each tuple is of the form "
+                f"(new_type_name, original_schema_type_names) where new_type_name is the type name "
+                f"that would appear in the new schema and original_schema_type_names is a list of "
+                f"types in the original schema that get mapped to new_type_name: "
+                f"{sorted_type_name_conflicts}"
             )
         renamed_to_builtin_scalar_conflicts_message = ""
         if self.renamed_to_builtin_scalar_conflicts:
@@ -149,28 +150,34 @@ class CascadingSuppressionError(SchemaTransformError):
 
 
 class NoOpRenamingError(SchemaTransformError):
-    """Raised if renamings argument is iterable and contains no-op renames.
+    """Raised if renamings are iterable and contains no-op renames.
 
     No-op renames can occur in these ways:
-    * renamings contains a string type_name but there doesn't exist a type in the schema named
-      type_name
-    * renamings maps a string type_name to itself, i.e. renamings[type_name] == type_name
+    * type_renamings is iterable and contains a string type_name but there doesn't exist a type in
+      the schema named type_name
+    * type_renamings is iterable and maps a string type_name to itself, i.e.
+      type_renamings[type_name] == type_name
     """
 
-    no_op_renames: Set[str]
+    no_op_type_renames: Set[str]
 
-    def __init__(self, no_op_renames: Set[str]) -> None:
-        """Record all renaming conflicts."""
+    def __init__(self, no_op_type_renames: Set[str]) -> None:
+        """Record all no-op renamings."""
+        if not no_op_type_renames:
+            raise ValueError(
+                "Cannot raise NoOpRenamingError without at least one invalid name, but "
+                "all arguments were empty."
+            )
         super().__init__()
-        self.no_op_renames = no_op_renames
+        self.no_op_type_renames = no_op_type_renames
 
     def __str__(self) -> str:
         """Explain renaming conflict and the fix."""
         return (
-            f"Renamings is iterable, so it cannot have no-op renamings. However, the following "
-            f"entries exist in the renamings argument, which either rename a type to itself or "
-            f"would rename a type that doesn't exist in the schema, both of which are invalid: "
-            f"{sorted(self.no_op_renames)}"
+            f"type_renamings is iterable, so it cannot have no-op renamings. However, the "
+            f"following entries exist in the type_renamings argument, which either rename a "
+            f"type to itself or would rename a type that doesn't exist in the schema, both of "
+            f"which are invalid: {sorted(self.no_op_type_renames)}"
         )
 
 

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -8,8 +8,11 @@ from graphql.language.printer import print_ast
 from graphql.language.visitor import QUERY_DOCUMENT_KEYS
 from graphql.pyutils import snake_to_camel
 
-from ...schema_transformation.rename_schema import RenameSchemaTypesVisitor, rename_schema, \
-    TypeRenamingMapping
+from ...schema_transformation.rename_schema import (
+    RenameSchemaTypesVisitor,
+    TypeRenamingMapping,
+    rename_schema,
+)
 from ...schema_transformation.utils import (
     CascadingSuppressionError,
     InvalidTypeNameError,

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -8,7 +8,8 @@ from graphql.language.printer import print_ast
 from graphql.language.visitor import QUERY_DOCUMENT_KEYS
 from graphql.pyutils import snake_to_camel
 
-from ...schema_transformation.rename_schema import RenameSchemaTypesVisitor, rename_schema
+from ...schema_transformation.rename_schema import RenameSchemaTypesVisitor, rename_schema, \
+    TypeRenamingMapping
 from ...schema_transformation.utils import (
     CascadingSuppressionError,
     InvalidTypeNameError,
@@ -980,7 +981,7 @@ class TestRenameSchema(unittest.TestCase):
             rename_schema(parse(ISS.list_schema), {"Height": None})
 
     def test_rename_using_dict_like_prefixer_class(self) -> None:
-        class PrefixNewDict:
+        class PrefixNewDict(TypeRenamingMapping):
             def __init__(self, schema: GraphQLSchema):
                 self.schema = schema
                 super().__init__()

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -8,11 +8,7 @@ from graphql.language.printer import print_ast
 from graphql.language.visitor import QUERY_DOCUMENT_KEYS
 from graphql.pyutils import snake_to_camel
 
-from ...schema_transformation.rename_schema import (
-    RenameSchemaTypesVisitor,
-    RenamingMapping,
-    rename_schema,
-)
+from ...schema_transformation.rename_schema import RenameSchemaTypesVisitor, rename_schema
 from ...schema_transformation.utils import (
     CascadingSuppressionError,
     InvalidTypeNameError,
@@ -111,18 +107,11 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual(original_ast, parse(ISS.multiple_objects_schema))
 
     def test_rename_illegal_noop_unused_renaming(self) -> None:
-        with self.assertRaises(NoOpRenamingError) as e:
+        with self.assertRaises(NoOpRenamingError):
             rename_schema(parse(ISS.basic_schema), {"Dinosaur": "NewDinosaur"})
-        self.assertEqual(
-            "Renamings is iterable, so it cannot have no-op renamings. However, the following "
-            "entries exist in the renamings argument, which either rename a type to itself or "
-            "would rename a type that doesn't exist in the schema, both of which are invalid: "
-            "['Dinosaur']",
-            str(e.exception),
-        )
 
     def test_rename_legal_noop_unused_renaming(self) -> None:
-        # Unlike with test_rename_illegal_noop_unused_renaming, here renamings is not
+        # Unlike with test_rename_illegal_noop_unused_renaming, here type_renamings is not
         # iterable. As a result, this renaming is technically legal but it is inadvisable to
         # write a renaming like this since the intended "Dinosaur" -> "NewDinosaur" mapping is
         # unused and will silently do nothing when applied to the given schema.
@@ -140,15 +129,8 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual({}, renamed_schema.reverse_name_map)
 
     def test_rename_illegal_noop_renamed_to_self(self) -> None:
-        with self.assertRaises(NoOpRenamingError) as e:
+        with self.assertRaises(NoOpRenamingError):
             rename_schema(parse(ISS.basic_schema), {"Human": "Human"})
-        self.assertEqual(
-            "Renamings is iterable, so it cannot have no-op renamings. However, the following "
-            "entries exist in the renamings argument, which either rename a type to itself or "
-            "would rename a type that doesn't exist in the schema, both of which are invalid: "
-            "['Human']",
-            str(e.exception),
-        )
 
     def test_basic_suppress(self) -> None:
         renamed_schema = rename_schema(parse(ISS.multiple_objects_schema), {"Human": None})
@@ -202,18 +184,11 @@ class TestRenameSchema(unittest.TestCase):
         self.assertEqual({}, renamed_schema.reverse_name_map)
 
     def test_suppress_illegal_noop_unused_suppression(self) -> None:
-        with self.assertRaises(NoOpRenamingError) as e:
+        with self.assertRaises(NoOpRenamingError):
             rename_schema(parse(ISS.multiple_objects_schema), {"Dinosaur": None})
-        self.assertEqual(
-            "Renamings is iterable, so it cannot have no-op renamings. However, the following "
-            "entries exist in the renamings argument, which either rename a type to itself or "
-            "would rename a type that doesn't exist in the schema, both of which are invalid: "
-            "['Dinosaur']",
-            str(e.exception),
-        )
 
     def test_suppress_legal_noop_unused_suppression(self) -> None:
-        # Unlike with test_suppress_illegal_noop_unused_suppression, here renamings is not
+        # Unlike with test_suppress_illegal_noop_unused_suppression, here type_renamings is not
         # iterable. As a result, this renaming is technically legal but it is inadvisable to
         # write a renaming like this since the intended "Dinosaur" -> None mapping is unused and
         # will silently do nothing when applied to the given schema.
@@ -230,14 +205,14 @@ class TestRenameSchema(unittest.TestCase):
         )
         self.assertEqual({}, renamed_schema.reverse_name_map)
 
-    def test_various_illegal_noop_renamings(self) -> None:
+    def test_various_illegal_noop_type_renamings_error_message(self) -> None:
         with self.assertRaises(NoOpRenamingError) as e:
             rename_schema(
                 parse(ISS.basic_schema), {"Dinosaur": None, "Human": "Human", "Bird": "Birdie"}
             )
         self.assertEqual(
-            "Renamings is iterable, so it cannot have no-op renamings. However, the following "
-            "entries exist in the renamings argument, which either rename a type to itself or "
+            "type_renamings is iterable, so it cannot have no-op renamings. However, the following "
+            "entries exist in the type_renamings argument, which either rename a type to itself or "
             "would rename a type that doesn't exist in the schema, both of which are invalid: "
             "['Bird', 'Dinosaur', 'Human']",
             str(e.exception),
@@ -675,24 +650,18 @@ class TestRenameSchema(unittest.TestCase):
 
     def test_directive_renaming_illegal_noop(self) -> None:
         # This renaming is illegal because directives can't be renamed, so the
-        # "stitch" -> "NewStitch" mapping is a no-op which is not allowed for iterable renamings.
-        with self.assertRaises(NoOpRenamingError) as e:
+        # "stitch" -> "NewStitch" mapping is a no-op which is not allowed for iterable
+        # type_renamings.
+        with self.assertRaises(NoOpRenamingError):
             rename_schema(
                 parse(ISS.directive_schema),
                 {
                     "stitch": "NewStitch",
                 },
             )
-        self.assertEqual(
-            "Renamings is iterable, so it cannot have no-op renamings. However, the following "
-            "entries exist in the renamings argument, which either rename a type to itself or "
-            "would rename a type that doesn't exist in the schema, both of which are invalid: "
-            "['stitch']",
-            str(e.exception),
-        )
 
     def test_directive_renaming_legal_noop(self) -> None:
-        # Unlike with test_directive_renaming_illegal_noop, here renamings is not iterable.
+        # Unlike with test_directive_renaming_illegal_noop, here type_renamings is not iterable.
         # As a result, this renaming is technically legal but it is inadvisable to write a
         # renaming like this since directives cannot be renamed so the intended
         # "stitch" -> "NewStitch" mapping is unused and will silently do nothing when applied to
@@ -712,7 +681,7 @@ class TestRenameSchema(unittest.TestCase):
 
     def test_query_type_field_argument_illegal_noop(self) -> None:
         # This renaming is illegal because query type field arguments can't be renamed, so the
-        # "id" -> "Id" mapping is a no-op which is not allowed for iterable renamings.
+        # "id" -> "Id" mapping is a no-op which is not allowed for iterable type_renamings.
         schema_string = dedent(
             """\
             schema {
@@ -728,18 +697,11 @@ class TestRenameSchema(unittest.TestCase):
             }
         """
         )
-        with self.assertRaises(NoOpRenamingError) as e:
+        with self.assertRaises(NoOpRenamingError):
             rename_schema(parse(schema_string), {"id": "Id"})
-        self.assertEqual(
-            "Renamings is iterable, so it cannot have no-op renamings. However, the following "
-            "entries exist in the renamings argument, which either rename a type to itself or "
-            "would rename a type that doesn't exist in the schema, both of which are invalid: "
-            "['id']",
-            str(e.exception),
-        )
 
     def test_query_type_field_argument_legal_noop(self) -> None:
-        # Unlike with test_query_type_field_argument_illegal_noop, here renamings is not
+        # Unlike with test_query_type_field_argument_illegal_noop, here type_renamings is not
         # iterable. As a result, this renaming is technically legal but it is inadvisable to
         # write a renaming like this since the intended "id" -> "Id" mapping is unused and will
         # silently do nothing when applied to the given schema.
@@ -794,19 +756,8 @@ class TestRenameSchema(unittest.TestCase):
         """
         )
 
-        with self.assertRaises(SchemaRenameNameConflictError) as e:
+        with self.assertRaises(SchemaRenameNameConflictError):
             rename_schema(parse(schema_string), {"Human1": "Human", "Human2": "Human"})
-        self.assertEqual(
-            "Applying the renaming would produce a schema in which multiple types have the "
-            "same name, which is an illegal schema state. To fix this, modify the renamings "
-            "argument of rename_schema to ensure that no two types in the renamed schema have "
-            "the same name. The following is a list of tuples that describes what needs to be "
-            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
-            "where new_type_name is the type name that would appear in the new schema and "
-            "original_schema_type_names is a list of types in the original schema that get "
-            "mapped to new_type_name: [('Human', ['Human1', 'Human2'])]",
-            str(e.exception),
-        )
 
     def test_clashing_type_single_rename(self) -> None:
         schema_string = dedent(
@@ -830,19 +781,8 @@ class TestRenameSchema(unittest.TestCase):
         """
         )
 
-        with self.assertRaises(SchemaRenameNameConflictError) as e:
+        with self.assertRaises(SchemaRenameNameConflictError):
             rename_schema(parse(schema_string), {"Human2": "Human"})
-        self.assertEqual(
-            "Applying the renaming would produce a schema in which multiple types have the "
-            "same name, which is an illegal schema state. To fix this, modify the renamings "
-            "argument of rename_schema to ensure that no two types in the renamed schema have "
-            "the same name. The following is a list of tuples that describes what needs to be "
-            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
-            "where new_type_name is the type name that would appear in the new schema and "
-            "original_schema_type_names is a list of types in the original schema that get "
-            "mapped to new_type_name: [('Human', ['Human', 'Human2'])]",
-            str(e.exception),
-        )
 
     def test_clashing_type_one_unchanged_rename(self) -> None:
         schema_string = dedent(
@@ -866,19 +806,8 @@ class TestRenameSchema(unittest.TestCase):
         """
         )
 
-        with self.assertRaises(SchemaRenameNameConflictError) as e:
+        with self.assertRaises(SchemaRenameNameConflictError):
             rename_schema(parse(schema_string), {"Human": "Human3", "Human2": "Human3"})
-        self.assertEqual(
-            "Applying the renaming would produce a schema in which multiple types have the "
-            "same name, which is an illegal schema state. To fix this, modify the renamings "
-            "argument of rename_schema to ensure that no two types in the renamed schema have "
-            "the same name. The following is a list of tuples that describes what needs to be "
-            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
-            "where new_type_name is the type name that would appear in the new schema and "
-            "original_schema_type_names is a list of types in the original schema that get "
-            "mapped to new_type_name: [('Human3', ['Human', 'Human2'])]",
-            str(e.exception),
-        )
 
     def test_clashing_scalar_type_rename(self) -> None:
         schema_string = dedent(
@@ -899,19 +828,8 @@ class TestRenameSchema(unittest.TestCase):
         """
         )
 
-        with self.assertRaises(SchemaRenameNameConflictError) as e:
+        with self.assertRaises(SchemaRenameNameConflictError):
             rename_schema(parse(schema_string), {"Human": "SCALAR"})
-        self.assertEqual(
-            "Applying the renaming would produce a schema in which multiple types have the "
-            "same name, which is an illegal schema state. To fix this, modify the renamings "
-            "argument of rename_schema to ensure that no two types in the renamed schema have "
-            "the same name. The following is a list of tuples that describes what needs to be "
-            "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
-            "where new_type_name is the type name that would appear in the new schema and "
-            "original_schema_type_names is a list of types in the original schema that get "
-            "mapped to new_type_name: [('SCALAR', ['Human', 'SCALAR'])]",
-            str(e.exception),
-        )
 
     def test_builtin_type_conflict_rename(self) -> None:
         schema_string = dedent(
@@ -930,17 +848,8 @@ class TestRenameSchema(unittest.TestCase):
         """
         )
 
-        with self.assertRaises(SchemaRenameNameConflictError) as e:
+        with self.assertRaises(SchemaRenameNameConflictError):
             rename_schema(parse(schema_string), {"Human": "String"})
-        self.assertEqual(
-            "Applying the renaming would rename type(s) to a name already used by a built-in "
-            "GraphQL scalar type. To fix this, ensure that no type name is mapped to a "
-            "scalar's name. The following is a list of tuples that describes what needs to be "
-            "fixed. Each tuple is of the form (type_name, scalar_name) where type_name is the "
-            "original name of the type and scalar_name is the name of the scalar that the "
-            "type would be renamed to: [('Human', 'String')]",
-            str(e.exception),
-        )
 
     def test_multiple_naming_conflicts(self) -> None:
         schema_string = dedent(
@@ -971,7 +880,7 @@ class TestRenameSchema(unittest.TestCase):
             rename_schema(parse(schema_string), {"Human": "String", "Dog": "Cat"})
         self.assertEqual(
             "Applying the renaming would produce a schema in which multiple types have the "
-            "same name, which is an illegal schema state. To fix this, modify the renamings "
+            "same name, which is an illegal schema state. To fix this, modify the type_renamings "
             "argument of rename_schema to ensure that no two types in the renamed schema have "
             "the same name. The following is a list of tuples that describes what needs to be "
             "fixed. Each tuple is of the form (new_type_name, original_schema_type_names) "
@@ -987,11 +896,26 @@ class TestRenameSchema(unittest.TestCase):
             str(e.exception),
         )
 
-    def test_illegal_rename_start_with_number(self) -> None:
+    def test_invalid_name_error_message(self) -> None:
+        with self.assertRaises(InvalidTypeNameError) as e:
+            rename_schema(
+                parse(ISS.multiple_objects_schema),
+                {"Human": "0Human", "Dog": "__Dog", "Droid": "NewDroid"},
+            )
+        self.assertEqual(
+            "Applying the renaming would rename types with names that are not valid, unreserved "
+            "GraphQL names. Valid, unreserved GraphQL names must consist of only alphanumeric "
+            "characters and underscores, must not start with a numeric character, and must not "
+            "start with double underscores. The following dictionary maps each type's original "
+            "name to what would be the new name: [('Dog', '__Dog'), ('Human', '0Human')]",
+            str(e.exception),
+        )
+
+    def test_illegal_rename_type_start_with_number(self) -> None:
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "0Human"})
 
-    def test_illegal_rename_contains_illegal_char(self) -> None:
+    def test_illegal_rename_type_contains_illegal_char(self) -> None:
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "Human!"})
         with self.assertRaises(InvalidTypeNameError):
@@ -999,11 +923,11 @@ class TestRenameSchema(unittest.TestCase):
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "H.uman"})
 
-    def test_illegal_rename_to_double_underscore(self) -> None:
+    def test_illegal_rename_type_to_double_underscore(self) -> None:
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "__Human"})
 
-    def test_illegal_rename_to_reserved_name_type(self) -> None:
+    def test_illegal_rename_type_to_reserved_name_type(self) -> None:
         with self.assertRaises(InvalidTypeNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "__Type"})
 
@@ -1056,7 +980,7 @@ class TestRenameSchema(unittest.TestCase):
             rename_schema(parse(ISS.list_schema), {"Height": None})
 
     def test_rename_using_dict_like_prefixer_class(self) -> None:
-        class PrefixNewDict(RenamingMapping):
+        class PrefixNewDict:
             def __init__(self, schema: GraphQLSchema):
                 self.schema = schema
                 super().__init__()


### PR DESCRIPTION
See comment here:
https://github.com/kensho-technologies/graphql-compiler/pull/962#issuecomment-729261585

---

Brief summary of the changes:

*  Refactor `renamings` argument to `type_renamings` since we'll want to rename fields soon and we'll want to keep the fields separate.

* Remove the redundant error message testing if these checks are very similar to each other.

A design decision (written here for reference): Although I planned to create a new error class for invalid names that arise during schema renaming in #962, I've decided to keep all invalid name errors as a single class rather than splitting it off as originally intended because my original extra-class reasoning wasn't quite right. When I originally made a separate class, I envisioned that the `SchemaRenameInvalidNameError` object would contain data structures describing what parts of the renaming were invalid. I'd planned to keep these data structures to eventually allow for some sort of (semi)automated error correction by being able to inspect the problematic renamings programmatically instead of just outputting them directly in an error message string (see `CascadingSuppressionError` for an example of this in action).

Unfortunately, unlike something like cascading suppressions, there isn't really a natural automatic thing to do for invalid names.  Whereas for cascading suppressions, the natural thing to do is to simply continue suppressing unreachable things until the schema is valid again, there isn't a really good way to guess at what an invalid GraphQL name _should_ be. As a result, the extra data structures wouldn't help, so keeping everything in one class is fine.