### PR TITLE
Refactor names

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -107,7 +107,7 @@ from ..ast_manipulation import get_ast_with_non_null_and_list_stripped
 from ..typedefs import Protocol
 from .utils import (
     CascadingSuppressionError,
-    InvalidTypeNameError,
+    InvalidNameError,
     NoOpRenamingError,
     RenameTypes,
     RenameTypesT,
@@ -175,14 +175,14 @@ def rename_schema(
     Raises:
         - CascadingSuppressionError if a type suppression would require further suppressions
         - SchemaTransformError if type_renamings suppressed every type. Note that this is a
-          superclass of CascadingSuppressionError, InvalidTypeNameError, SchemaStructureError, and
+          superclass of CascadingSuppressionError, InvalidNameError, SchemaStructureError, and
           SchemaRenameNameConflictError, so handling exceptions of type SchemaTransformError will
           also catch all of its subclasses. This will change after the error classes are modified so
           that errors can be fixed programmatically, at which point it will make sense for the user
           to attempt to treat different errors differently
         - NotImplementedError if type_renamings attempts to suppress an enum, an interface, or a
           type implementing an interface
-        - InvalidTypeNameError if the schema contains an invalid type name, or if the user attempts
+        - InvalidNameError if the schema contains an invalid type name, or if the user attempts
           to rename a type to an invalid name. A name is considered invalid if it does not consist
           of alphanumeric characters and underscores, if it starts with a numeric character, or
           if it starts with double underscores
@@ -408,7 +408,7 @@ def _rename_and_suppress_types(
         renamed.
 
     Raises:
-        - InvalidTypeNameError if the user attempts to rename a type to an invalid name
+        - InvalidNameError if the user attempts to rename a type to an invalid name
         - SchemaRenameNameConflictError if the rename causes name conflicts
         - NoOpRenamingError if renamings contains no-op renamings and renamings are iterable
     """
@@ -416,7 +416,7 @@ def _rename_and_suppress_types(
     renamed_schema_ast = visit(schema_ast, visitor)
     if visitor.invalid_type_names:
         sorted_invalid_type_names = sorted(visitor.invalid_type_names.items())
-        raise InvalidTypeNameError(
+        raise InvalidNameError(
             f"Applying the renaming would rename types with names that are not valid, unreserved "
             f"GraphQL names. Valid, unreserved GraphQL names must consist of only alphanumeric "
             f"characters and underscores, must not start with a numeric character, and must not "

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -417,8 +417,8 @@ def _rename_and_suppress_types(
     if visitor.invalid_type_names:
         sorted_invalid_type_names = sorted(visitor.invalid_type_names.items())
         raise InvalidNameError(
-            f"Applying the renaming would rename types with names that are not valid, nonreserved "
-            f"GraphQL names. Valid, nonreserved GraphQL names must consist of only alphanumeric "
+            f"Applying the renaming would rename types with names that are not valid, non-reserved "
+            f"GraphQL names. Valid, non-reserved GraphQL names must consist of only alphanumeric "
             f"characters and underscores, must not start with a numeric character, and must not "
             f"start with double underscores. The following dictionary maps each type's original "
             f"name to what would be the new name: {sorted_invalid_type_names}"
@@ -557,9 +557,10 @@ class RenameSchemaTypesVisitor(Visitor):
     reverse_name_map: Dict[str, str]
 
     # Collects invalid type names in type_renamings. If type_renamings would rename a type named
-    # "Foo" to a string that is not a valid, nonreserved GraphQL type name (valid, nonreserved names
-    # consist only of alphanumeric characters and underscores, do not start with a number, and do
-    # not start with two underscores), invalid_type_names will map "Foo" to the invalid type name.
+    # "Foo" to a string that is not a valid, non-reserved GraphQL type name (valid, non-reserved
+    # names consist only of alphanumeric characters and underscores, do not start with a number, and
+    # do not start with two underscores), invalid_type_names will map "Foo" to the invalid type
+    # name.
     invalid_type_names: Dict[str, str]
 
     # Collects the type names for types that get suppressed. If type_renamings would suppress a type

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -118,7 +118,7 @@ from .utils import (
     get_copy_of_node_with_new_name,
     get_custom_scalar_names,
     get_query_type_name,
-    is_valid_unreserved_name,
+    is_valid_nonreserved_name,
 )
 
 
@@ -417,8 +417,8 @@ def _rename_and_suppress_types(
     if visitor.invalid_type_names:
         sorted_invalid_type_names = sorted(visitor.invalid_type_names.items())
         raise InvalidNameError(
-            f"Applying the renaming would rename types with names that are not valid, unreserved "
-            f"GraphQL names. Valid, unreserved GraphQL names must consist of only alphanumeric "
+            f"Applying the renaming would rename types with names that are not valid, nonreserved "
+            f"GraphQL names. Valid, nonreserved GraphQL names must consist of only alphanumeric "
             f"characters and underscores, must not start with a numeric character, and must not "
             f"start with double underscores. The following dictionary maps each type's original "
             f"name to what would be the new name: {sorted_invalid_type_names}"
@@ -557,7 +557,7 @@ class RenameSchemaTypesVisitor(Visitor):
     reverse_name_map: Dict[str, str]
 
     # Collects invalid type names in type_renamings. If type_renamings would rename a type named
-    # "Foo" to a string that is not a valid, unreserved GraphQL type name (valid, unreserved names
+    # "Foo" to a string that is not a valid, nonreserved GraphQL type name (valid, nonreserved names
     # consist only of alphanumeric characters and underscores, do not start with a number, and do
     # not start with two underscores), invalid_type_names will map "Foo" to the invalid type name.
     invalid_type_names: Dict[str, str]
@@ -625,7 +625,7 @@ class RenameSchemaTypesVisitor(Visitor):
             # Suppress the type
             self.suppressed_type_names.add(type_name)
             return REMOVE
-        if not is_valid_unreserved_name(desired_type_name):
+        if not is_valid_nonreserved_name(desired_type_name):
             self.invalid_type_names[type_name] = desired_type_name
 
         # Renaming conflict arises when two types with different names in the original schema have

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -118,7 +118,7 @@ from .utils import (
     get_copy_of_node_with_new_name,
     get_custom_scalar_names,
     get_query_type_name,
-    type_name_is_valid,
+    is_valid_unreserved_name,
 )
 
 
@@ -625,7 +625,7 @@ class RenameSchemaTypesVisitor(Visitor):
             # Suppress the type
             self.suppressed_type_names.add(type_name)
             return REMOVE
-        if not type_name_is_valid(desired_type_name):
+        if not is_valid_unreserved_name(desired_type_name):
             self.invalid_type_names[type_name] = desired_type_name
 
         # Renaming conflict arises when two types with different names in the original schema have

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -254,18 +254,18 @@ def check_schema_identifier_is_valid(identifier: str) -> None:
         )
 
 
-def is_valid_unreserved_name(name: str) -> bool:
-    """Check if input is a valid, unreserved GraphQL name.
+def is_valid_nonreserved_name(name: str) -> bool:
+    """Check if input is a valid, nonreserved GraphQL name.
 
     A GraphQL name is valid iff it consists of only alphanumeric characters and underscores and
-    does not start with a numeric character. It is unreserved (i.e. not reserved for GraphQL
+    does not start with a numeric character. It is nonreserved (i.e. not reserved for GraphQL
     internal use) if it does not start with double underscores.
 
     Args:
         name: to be checked
 
     Returns:
-        True iff name is a valid, unreserved GraphQL type name.
+        True iff name is a valid, nonreserved GraphQL type name.
     """
     return bool(re_name.match(name)) and not name.startswith("__")
 
@@ -454,10 +454,10 @@ class CheckValidTypesAndNamesVisitor(Visitor):
         elif node_type in self.unexpected_types:
             raise SchemaStructureError('Node type "{}" unexpected in schema AST'.format(node_type))
         elif isinstance(node, self.check_name_validity_types):
-            if not is_valid_unreserved_name(node.name.value):
+            if not is_valid_nonreserved_name(node.name.value):
                 raise InvalidNameError(
-                    f"Node name {node.name.value} is not a valid, unreserved GraphQL name. Valid, "
-                    f"unreserved GraphQL names must consist of only alphanumeric characters and "
+                    f"Node name {node.name.value} is not a valid, nonreserved GraphQL name. Valid, "
+                    f"nonreserved GraphQL names must consist of only alphanumeric characters and "
                     f"underscores, must not start with a numeric character, and must not start "
                     f"with double underscores."
                 )

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -255,17 +255,17 @@ def check_schema_identifier_is_valid(identifier: str) -> None:
 
 
 def is_valid_nonreserved_name(name: str) -> bool:
-    """Check if input is a valid, nonreserved GraphQL name.
+    """Check if input is a valid, non-reserved GraphQL name.
 
     A GraphQL name is valid iff it consists of only alphanumeric characters and underscores and
-    does not start with a numeric character. It is nonreserved (i.e. not reserved for GraphQL
+    does not start with a numeric character. It is non-reserved (i.e. not reserved for GraphQL
     internal use) if it does not start with double underscores.
 
     Args:
         name: to be checked
 
     Returns:
-        True iff name is a valid, nonreserved GraphQL type name.
+        True iff name is a valid, non-reserved GraphQL type name.
     """
     return bool(re_name.match(name)) and not name.startswith("__")
 
@@ -456,10 +456,10 @@ class CheckValidTypesAndNamesVisitor(Visitor):
         elif isinstance(node, self.check_name_validity_types):
             if not is_valid_nonreserved_name(node.name.value):
                 raise InvalidNameError(
-                    f"Node name {node.name.value} is not a valid, nonreserved GraphQL name. Valid, "
-                    f"nonreserved GraphQL names must consist of only alphanumeric characters and "
-                    f"underscores, must not start with a numeric character, and must not start "
-                    f"with double underscores."
+                    f"Node name {node.name.value} is not a valid, non-reserved GraphQL name. "
+                    f"Valid, non-reserved GraphQL names must consist of only alphanumeric "
+                    f"characters and underscores, must not start with a numeric character, and "
+                    f"must not start with double underscores."
                 )
 
 

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -45,7 +45,7 @@ class SchemaStructureError(SchemaTransformError):
     """
 
 
-class InvalidTypeNameError(SchemaTransformError):
+class InvalidNameError(SchemaTransformError):
     """Raised if a type/field name is not valid.
 
     This may be raised if the input schema contains invalid names, or if the user attempts to
@@ -407,7 +407,7 @@ class CheckValidTypesAndNamesVisitor(Visitor):
     """Check that the AST does not contain invalid types or types with invalid names.
 
     If AST contains invalid types, raise SchemaStructureError; if AST contains types with
-    invalid names, raise InvalidTypeNameError.
+    invalid names, raise InvalidNameError.
     """
 
     disallowed_types = frozenset(
@@ -446,7 +446,7 @@ class CheckValidTypesAndNamesVisitor(Visitor):
         Raises:
             - SchemaStructureError if the node is an InputObjectTypeDefinition,
               TypeExtensionDefinition, or a type that shouldn't exist in a schema definition
-            - InvalidTypeNameError if a node has an invalid name
+            - InvalidNameError if a node has an invalid name
         """
         node_type = type(node).__name__
         if node_type in self.disallowed_types:
@@ -455,7 +455,7 @@ class CheckValidTypesAndNamesVisitor(Visitor):
             raise SchemaStructureError('Node type "{}" unexpected in schema AST'.format(node_type))
         elif isinstance(node, self.check_name_validity_types):
             if not type_name_is_valid(node.name.value):
-                raise InvalidTypeNameError(
+                raise InvalidNameError(
                     f"Node name {node.name.value} is not a valid, unreserved GraphQL name. Valid, "
                     f"unreserved GraphQL names must consist of only alphanumeric characters and "
                     f"underscores, must not start with a numeric character, and must not start "
@@ -542,7 +542,7 @@ def check_ast_schema_is_valid(ast: DocumentNode) -> None:
         - SchemaStructureError if the AST cannot be built into a valid schema, if the schema
           contains mutations, subscriptions, InputObjectTypeDefinitions, TypeExtensionsDefinitions,
           or if any query type field does not match the queried type.
-        - InvalidTypeNameError if a type has a type name that is invalid or reserved
+        - InvalidNameError if a type has a type name that is invalid or reserved
     """
     schema = build_ast_schema(ast)
 

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -254,18 +254,18 @@ def check_schema_identifier_is_valid(identifier: str) -> None:
         )
 
 
-def type_name_is_valid(name: str) -> bool:
-    """Check if input is a valid, nonreserved GraphQL type name.
+def is_valid_unreserved_name(name: str) -> bool:
+    """Check if input is a valid, unreserved GraphQL name.
 
-    A GraphQL type name is valid iff it consists of only alphanumeric characters and underscores and
-    does not start with a numeric character. It is nonreserved (i.e. not reserved for GraphQL
+    A GraphQL name is valid iff it consists of only alphanumeric characters and underscores and
+    does not start with a numeric character. It is unreserved (i.e. not reserved for GraphQL
     internal use) if it does not start with double underscores.
 
     Args:
         name: to be checked
 
     Returns:
-        True iff name is a valid, nonreserved GraphQL type name.
+        True iff name is a valid, unreserved GraphQL type name.
     """
     return bool(re_name.match(name)) and not name.startswith("__")
 
@@ -454,7 +454,7 @@ class CheckValidTypesAndNamesVisitor(Visitor):
         elif node_type in self.unexpected_types:
             raise SchemaStructureError('Node type "{}" unexpected in schema AST'.format(node_type))
         elif isinstance(node, self.check_name_validity_types):
-            if not type_name_is_valid(node.name.value):
+            if not is_valid_unreserved_name(node.name.value):
                 raise InvalidNameError(
                     f"Node name {node.name.value} is not a valid, unreserved GraphQL name. Valid, "
                     f"unreserved GraphQL names must consist of only alphanumeric characters and "

--- a/graphql_compiler/tests/schema_transformation_tests/test_check_schema_valid.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_check_schema_valid.py
@@ -5,7 +5,7 @@ import unittest
 from graphql import parse
 
 from ...schema_transformation.utils import (
-    InvalidTypeNameError,
+    InvalidNameError,
     SchemaStructureError,
     check_ast_schema_is_valid,
 )
@@ -150,7 +150,7 @@ class TestCheckSchemaValid(unittest.TestCase):
             }
         """
         )
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             check_ast_schema_is_valid(parse(schema_string))
 
     def test_illegal_reserved_name_type(self):
@@ -173,7 +173,7 @@ class TestCheckSchemaValid(unittest.TestCase):
             }
         """
         )
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             check_ast_schema_is_valid(parse(schema_string))
 
     def test_illegal_reserved_name_enum(self):
@@ -197,7 +197,7 @@ class TestCheckSchemaValid(unittest.TestCase):
             }
         """
         )
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             check_ast_schema_is_valid(parse(schema_string))
 
     def test_illegal_reserved_name_scalar(self):
@@ -220,5 +220,5 @@ class TestCheckSchemaValid(unittest.TestCase):
             scalar __Type
         """
         )
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             check_ast_schema_is_valid(parse(schema_string))

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -15,7 +15,7 @@ from ...schema_transformation.rename_schema import (
 )
 from ...schema_transformation.utils import (
     CascadingSuppressionError,
-    InvalidTypeNameError,
+    InvalidNameError,
     NoOpRenamingError,
     SchemaRenameNameConflictError,
     SchemaTransformError,
@@ -901,7 +901,7 @@ class TestRenameSchema(unittest.TestCase):
         )
 
     def test_invalid_name_error_message(self) -> None:
-        with self.assertRaises(InvalidTypeNameError) as e:
+        with self.assertRaises(InvalidNameError) as e:
             rename_schema(
                 parse(ISS.multiple_objects_schema),
                 {"Human": "0Human", "Dog": "__Dog", "Droid": "NewDroid"},
@@ -916,23 +916,23 @@ class TestRenameSchema(unittest.TestCase):
         )
 
     def test_illegal_rename_type_start_with_number(self) -> None:
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "0Human"})
 
     def test_illegal_rename_type_contains_illegal_char(self) -> None:
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "Human!"})
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "H-uman"})
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "H.uman"})
 
     def test_illegal_rename_type_to_double_underscore(self) -> None:
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "__Human"})
 
     def test_illegal_rename_type_to_reserved_name_type(self) -> None:
-        with self.assertRaises(InvalidTypeNameError):
+        with self.assertRaises(InvalidNameError):
             rename_schema(parse(ISS.basic_schema), {"Human": "__Type"})
 
     def test_suppress_every_type(self) -> None:

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -907,8 +907,8 @@ class TestRenameSchema(unittest.TestCase):
                 {"Human": "0Human", "Dog": "__Dog", "Droid": "NewDroid"},
             )
         self.assertEqual(
-            "Applying the renaming would rename types with names that are not valid, nonreserved "
-            "GraphQL names. Valid, nonreserved GraphQL names must consist of only alphanumeric "
+            "Applying the renaming would rename types with names that are not valid, non-reserved "
+            "GraphQL names. Valid, non-reserved GraphQL names must consist of only alphanumeric "
             "characters and underscores, must not start with a numeric character, and must not "
             "start with double underscores. The following dictionary maps each type's original "
             "name to what would be the new name: [('Dog', '__Dog'), ('Human', '0Human')]",

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -907,8 +907,8 @@ class TestRenameSchema(unittest.TestCase):
                 {"Human": "0Human", "Dog": "__Dog", "Droid": "NewDroid"},
             )
         self.assertEqual(
-            "Applying the renaming would rename types with names that are not valid, unreserved "
-            "GraphQL names. Valid, unreserved GraphQL names must consist of only alphanumeric "
+            "Applying the renaming would rename types with names that are not valid, nonreserved "
+            "GraphQL names. Valid, nonreserved GraphQL names must consist of only alphanumeric "
             "characters and underscores, must not start with a numeric character, and must not "
             "start with double underscores. The following dictionary maps each type's original "
             "name to what would be the new name: [('Dog', '__Dog'), ('Human', '0Human')]",


### PR DESCRIPTION
Small refactoring for code that was specific to types, not fields, but wasn't part of the `renamings`-> `type_renamings` transition in #966. After this PR, #959 (which contains the field_renaming code) will be very close to being ready for review-- I have some remaining nits to iron out there, but it's getting close!