### PR TITLE
Switch some NamedTuples to equivalent dataclasses.

### DIFF
--- a/graphql_compiler/compiler/compiler_frontend.py
+++ b/graphql_compiler/compiler/compiler_frontend.py
@@ -59,7 +59,8 @@ To get from GraphQL AST to IR, we follow the following pattern:
     step F-2. Emit a type coercion block if appropriate, then recurse into the fragment's selection.
     ***************
 """
-from typing import Dict, List, NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Dict, List, Optional
 
 from graphql import (
     DocumentNode,
@@ -132,7 +133,8 @@ from .metadata import LocationInfo, OutputInfo, QueryMetadataTable, RecurseInfo,
 from .validation import validate_schema_and_query_ast
 
 
-class OutputMetadata(NamedTuple):
+@dataclass(frozen=True)
+class OutputMetadata:
     """Metadata about a query's outputs."""
 
     # The type of the output value.
@@ -161,7 +163,8 @@ class OutputMetadata(NamedTuple):
         return not self.__eq__(other)
 
 
-class IrAndMetadata(NamedTuple):
+@dataclass(frozen=True)
+class IrAndMetadata:
     """Internal representation (IR) and metadata for a particular schema and query combination."""
 
     # List of basic block objects describing the query.

--- a/graphql_compiler/macros/macro_edge/validation.py
+++ b/graphql_compiler/macros/macro_edge/validation.py
@@ -363,11 +363,11 @@ def get_and_validate_macro_edge_info(
     )
 
     # Ensure that the macro successfully compiles to IR.
-    _, input_metadata, _, _ = ast_to_ir(
+    input_metadata = ast_to_ir(
         schema,
         _get_minimal_query_ast_from_macro_ast(ast),
         type_equivalence_hints=type_equivalence_hints,
-    )
+    ).input_metadata
     validate_arguments(input_metadata, macro_edge_args)
 
     _validate_that_macro_edge_definition_is_only_top_level_field_directive(


### PR DESCRIPTION
I used one of the built-in [codemods](https://libcst.readthedocs.io/en/latest/codemods_tutorial.html) from the `libCST` library to automatically change a few `NamedTuple` uses into equivalent `dataclass` types. What you're seeing in this PR is the (blackened) output of the following command:
```bash
$ python -m libcst.tool codemod convert_namedtuple_to_dataclass.ConvertNamedTupleToDataclassCommand graphql_compiler/compiler/compiler_frontend.py 
Calculating full-repo metadata...
Executing codemod...
All done! ✨ 🍰 ✨
1 file left unchanged.
Finished codemodding 1 files!
 - Transformed 1 files successfully.
 - Skipped 0 files.
 - Failed to codemod 0 files.
 - 0 warnings were generated.
```

Automatic codemods are super cool!