### PR TITLE
Enable per-function dynamic contexts during test run coverage collection

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+dynamic_context = test_function
 omit =
     # No coverage for tests
     graphql_compiler/tests/*


### PR DESCRIPTION
TL;DR: For each line, this will capture which test cases ran it. This means we get to see how many test cases cover each line, from which test suites, etc., which in turn hopefully lets us write better test cases. The biggest downside is that our coverage report files get somewhat bigger with the new data.

Docs for this functionality:
https://coverage.readthedocs.io/en/coverage-5.3/contexts.html#dynamic-contexts