### PR TITLE
Refactor type_renamings to be of type Mapping

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -899,7 +899,7 @@ class SuppressionNotImplementedVisitor(Visitor):
     ) -> None:
         """If type_renamings suppresses enums, record it for error message."""
         enum_name = node.name.value
-        if self.type_renamings.get(enum_name) is None:
+        if self.type_renamings.get(enum_name, enum_name) is None:
             self.unsupported_enum_suppressions.add(enum_name)
 
     def enter_interface_type_definition(
@@ -912,7 +912,7 @@ class SuppressionNotImplementedVisitor(Visitor):
     ) -> None:
         """If type_renamings suppresses interfaces, record it for error message."""
         interface_name = node.name.value
-        if self.type_renamings.get(interface_name) is None:
+        if self.type_renamings.get(interface_name, interface_name) is None:
             self.unsupported_interface_suppressions.add(interface_name)
 
     def enter_object_type_definition(
@@ -927,6 +927,6 @@ class SuppressionNotImplementedVisitor(Visitor):
         if not node.interfaces:
             return
         object_name = node.name.value
-        if self.type_renamings.get(object_name) is None:
+        if self.type_renamings.get(object_name, object_name) is None:
             # Suppressing interface implementations isn't supported yet.
             self.unsupported_interface_implementation_suppressions.add(object_name)

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -78,7 +78,7 @@ Renaming constraints:
   "Baz". You also may not rename anything to "Baz" if a type "Baz" already exists and is not also
   being renamed or suppressed. The same rules apply for fields that belong to the same type, since
   they share a namespace as well.
-- No-op renamings are not allowed.
+- No-op renamings are not allowed meaning that:
   - A string type_name may be in type_renamings only if there exists a type in the original schema
     named type_name (since otherwise that entry would not affect any type in the schema).
   - If string type_name is in type_renamings, then type_renamings[type_name] != type_name (since

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -78,17 +78,14 @@ Renaming constraints:
   "Baz". You also may not rename anything to "Baz" if a type "Baz" already exists and is not also
   being renamed or suppressed. The same rules apply for fields that belong to the same type, since
   they share a namespace as well.
-- There exist special rules for iterable renamings (e.g. if renamings are represented as a
-  dictionary)-- specifically, no-op renamings are not allowed.
-  - If type_renamings argument is iterable:
-    - A string type_name may be in type_renamings only if there exists a type in the original schema
-      named type_name (since otherwise that entry would not affect any type in the schema).
-    - If string type_name is in type_renamings, then type_renamings[type_name] != type_name (since
-      if they were the same, then applying the renaming would not change the type named type_name).
+- No-op renamings are not allowed.
+  - A string type_name may be in type_renamings only if there exists a type in the original schema
+    named type_name (since otherwise that entry would not affect any type in the schema).
+  - If string type_name is in type_renamings, then type_renamings[type_name] != type_name (since
+    if they were the same, then applying the renaming would not change the type named type_name).
 """
 from collections import namedtuple
-from collections.abc import Iterable
-from typing import AbstractSet, Any, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Set, Tuple, Union, cast
 
 from graphql import (
     DocumentNode,
@@ -104,7 +101,6 @@ from graphql.language.visitor import IDLE, REMOVE, Visitor, VisitorAction, visit
 import six
 
 from ..ast_manipulation import get_ast_with_non_null_and_list_stripped
-from ..typedefs import Protocol
 from .utils import (
     CascadingSuppressionError,
     InvalidNameError,
@@ -138,14 +134,8 @@ RenamedSchemaDescriptor = namedtuple(
 VisitorReturnType = Union[Node, VisitorAction]
 
 
-class TypeRenamingMapping(Protocol):
-    def get(self, key: str, default: Optional[str]) -> Optional[str]:
-        """Define mapping for type_renamings object."""
-        ...
-
-
 def rename_schema(
-    schema_ast: DocumentNode, type_renamings: TypeRenamingMapping
+    schema_ast: DocumentNode, type_renamings: Mapping[str, Optional[str]]
 ) -> RenamedSchemaDescriptor:
     """Create a RenamedSchemaDescriptor; rename/suppress types and root type fields.
 
@@ -166,7 +156,7 @@ def rename_schema(
                     the same name as the types they query. Not modified by this function
         type_renamings: maps original type name to renamed name or None (for type suppression). A
                         type named "Foo" will be unchanged iff type_renamings does not map "Foo" to
-                        anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
+                        anything, i.e. "Foo" not in type_renamings
 
     Returns:
         RenamedSchemaDescriptor containing the AST of the renamed schema, and the map of renamed
@@ -192,7 +182,7 @@ def rename_schema(
           input object definitions, or if the schema contains mutations or subscriptions
         - SchemaRenameNameConflictError if there are name conflicts between the renamed types or
           fields
-        - NoOpRenamingError if the renamings contain no-op renamings and are iterable
+        - NoOpRenamingError if the renamings contain no-op renamings
     """
     # Check input schema satisfies various structural requirements
     check_ast_schema_is_valid(schema_ast)
@@ -223,7 +213,7 @@ def rename_schema(
 
 def _validate_renamings(
     schema_ast: DocumentNode,
-    type_renamings: TypeRenamingMapping,
+    type_renamings: Mapping[str, Optional[str]],
     query_type: str,
     custom_scalar_names: AbstractSet[str],
 ) -> None:
@@ -242,7 +232,7 @@ def _validate_renamings(
                     the same name as the types they query. Not modified by this function
         type_renamings: maps original type name to renamed name or None (for type suppression). A
                         type named "Foo" will be unchanged iff type_renamings does not map "Foo" to
-                        anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
+                        anything, i.e. "Foo" not in type_renamings
         query_type: name of the query type, e.g. 'RootSchemaQuery'
         custom_scalar_names: set of all user defined scalars used in the schema (excluding
                              builtin scalars)
@@ -257,7 +247,7 @@ def _validate_renamings(
 
 
 def _ensure_no_cascading_type_suppressions(
-    schema_ast: DocumentNode, type_renamings: TypeRenamingMapping, query_type: str
+    schema_ast: DocumentNode, type_renamings: Mapping[str, Optional[str]], query_type: str
 ) -> None:
     """Check for fields with suppressed types or unions whose members were all suppressed."""
     visitor = CascadingSuppressionCheckVisitor(type_renamings, query_type)
@@ -302,7 +292,7 @@ def _ensure_no_cascading_type_suppressions(
 
 def _ensure_no_unsupported_operations(
     schema_ast: DocumentNode,
-    type_renamings: TypeRenamingMapping,
+    type_renamings: Mapping[str, Optional[str]],
     custom_scalar_names: AbstractSet[str],
 ) -> None:
     """Check for unsupported renaming or suppression operations."""
@@ -311,15 +301,15 @@ def _ensure_no_unsupported_operations(
 
 
 def _ensure_no_unsupported_scalar_operations(
-    type_renamings: TypeRenamingMapping,
+    type_renamings: Mapping[str, Optional[str]],
     custom_scalar_names: AbstractSet[str],
 ) -> None:
     """Check for unsupported scalar operations."""
     unsupported_scalar_operations = {}  # Map scalars to value to be renamed.
     for scalar_name in custom_scalar_names:
         possibly_renamed_scalar_name = type_renamings.get(scalar_name, scalar_name)
-        # type_renamings.get(scalar_name, scalar_name) returns something that is not scalar iff it
-        # attempts to do something with the scalar (i.e. renaming or suppressing it)
+        # type_renamings.get(scalar_name, scalar_name) returns something that is not scalar_name iff
+        # it attempts to do something with the scalar (i.e. renaming or suppressing it)
         if possibly_renamed_scalar_name != scalar_name:
             unsupported_scalar_operations[scalar_name] = possibly_renamed_scalar_name
     for builtin_scalar_name in builtin_scalar_type_names:
@@ -340,7 +330,7 @@ def _ensure_no_unsupported_scalar_operations(
 
 
 def _ensure_no_unsupported_suppressions(
-    schema_ast: DocumentNode, type_renamings: TypeRenamingMapping
+    schema_ast: DocumentNode, type_renamings: Mapping[str, Optional[str]]
 ) -> None:
     """Confirm type_renamings has no enums, interfaces, or interface implementation suppressions."""
     visitor = SuppressionNotImplementedVisitor(type_renamings)
@@ -383,7 +373,7 @@ def _ensure_no_unsupported_suppressions(
 
 def _rename_and_suppress_types(
     schema_ast: DocumentNode,
-    type_renamings: TypeRenamingMapping,
+    type_renamings: Mapping[str, Optional[str]],
     query_type: str,
     custom_scalar_names: AbstractSet[str],
 ) -> Tuple[DocumentNode, Dict[str, str]]:
@@ -397,7 +387,7 @@ def _rename_and_suppress_types(
         schema_ast: schema that we're returning a modified version of
         type_renamings: maps original type name to renamed name or None (for type suppression). A
                         type named "Foo" will be unchanged iff type_renamings does not map "Foo" to
-                        anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
+                        anything, i.e. "Foo" not in type_renamings
         query_type: name of the query type, e.g. 'RootSchemaQuery'
         custom_scalar_names: set of all user defined scalars used in the schema (excluding
                              builtin scalars)
@@ -410,7 +400,7 @@ def _rename_and_suppress_types(
     Raises:
         - InvalidNameError if the user attempts to rename a type to an invalid name
         - SchemaRenameNameConflictError if the rename causes name conflicts
-        - NoOpRenamingError if renamings contains no-op renamings and renamings are iterable
+        - NoOpRenamingError if renamings contains no-op renamings
     """
     visitor = RenameSchemaTypesVisitor(type_renamings, query_type, custom_scalar_names)
     renamed_schema_ast = visit(schema_ast, visitor)
@@ -427,32 +417,26 @@ def _rename_and_suppress_types(
         raise SchemaRenameNameConflictError(
             visitor.type_name_conflicts, visitor.type_renamed_to_builtin_scalar_conflicts
         )
-    no_op_type_renames: Set[str] = set()
-    if isinstance(type_renamings, Iterable):
-        # If type_renamings is iterable, then every renaming must be used and no renaming can map a
-        # name to itself
-        for type_name in visitor.suppressed_type_names:
-            if type_name not in type_renamings:
-                raise AssertionError(
-                    f"suppressed_type_names should be a subset of the set of keys in "
-                    f"type_renamings, but found {type_name} in suppressed_type_names that is not a "
-                    f"key in type_renamings. This is a bug."
-                )
-        renamed_types = {
-            visitor.reverse_name_map[type_name]
-            for type_name in visitor.reverse_name_map
-            if type_name != visitor.reverse_name_map[type_name]
-        }
-        no_op_type_renames = (
-            set(type_renamings) - renamed_types - set(visitor.suppressed_type_names)
-        )
+    for type_name in visitor.suppressed_type_names:
+        if type_name not in type_renamings:
+            raise AssertionError(
+                f"suppressed_type_names should be a subset of the set of keys in "
+                f"type_renamings, but found {type_name} in suppressed_type_names that is not a "
+                f"key in type_renamings. This is a bug."
+            )
+    renamed_types = {
+        visitor.reverse_name_map[type_name]
+        for type_name in visitor.reverse_name_map
+        if type_name != visitor.reverse_name_map[type_name]
+    }
+    no_op_type_renames = set(type_renamings) - renamed_types - set(visitor.suppressed_type_names)
     if no_op_type_renames:
         raise NoOpRenamingError(no_op_type_renames)
     return renamed_schema_ast, visitor.reverse_name_map
 
 
 def _rename_and_suppress_query_type_fields(
-    schema_ast: DocumentNode, type_renamings: TypeRenamingMapping, query_type: str
+    schema_ast: DocumentNode, type_renamings: Mapping[str, Optional[str]], query_type: str
 ) -> DocumentNode:
     """Rename or suppress all fields of the query type.
 
@@ -462,7 +446,7 @@ def _rename_and_suppress_query_type_fields(
         schema_ast: schema that we're returning a modified version of
         type_renamings: maps original type name to renamed name or None (for type suppression). A
                         type named "Foo" will be unchanged iff type_renamings does not map "Foo" to
-                        anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
+                        anything, i.e. "Foo" not in type_renamings
         query_type: name of the query type, e.g. 'RootSchemaQuery'
 
     Returns:
@@ -546,8 +530,8 @@ class RenameSchemaTypesVisitor(Visitor):
     # "Foo" to a set containing the name of each such type
     type_name_conflicts: Dict[str, Set[str]]
 
-    # Collects naming conflict errors involving built-in scalar types. If type_renamings would
-    # rename a type named "Foo" to "String", type_renamed_to_builtin_scalar_conflicts will map
+    # Collects naming conflict errors involving built-in scalar types. If
+    # type_renamings["Foo"] == "String", type_renamed_to_builtin_scalar_conflicts will map
     # "Foo" to "String"
     type_renamed_to_builtin_scalar_conflicts: Dict[str, str]
 
@@ -556,20 +540,19 @@ class RenameSchemaTypesVisitor(Visitor):
     # type renaming conflicts and raise SchemaRenameNameConflictError when they arise
     reverse_name_map: Dict[str, str]
 
-    # Collects invalid type names in type_renamings. If type_renamings would rename a type named
-    # "Foo" to a string that is not a valid, non-reserved GraphQL type name (valid, non-reserved
-    # names consist only of alphanumeric characters and underscores, do not start with a number, and
-    # do not start with two underscores), invalid_type_names will map "Foo" to the invalid type
-    # name.
+    # Collects invalid type names in type_renamings. If type_renamings["Foo"] is a string that is
+    # not a valid, non-reserved GraphQL type name (valid, non-reserved names consist only of
+    # alphanumeric characters and underscores, do not start with a number, and do not start with two
+    # underscores), invalid_type_names will map "Foo" to the invalid type name.
     invalid_type_names: Dict[str, str]
 
-    # Collects the type names for types that get suppressed. If type_renamings would suppress a type
-    # named "Foo", suppressed_type_names will contain "Foo".
+    # Collects the type names for types that get suppressed. If type_renamings["Foo"] == None,
+    # suppressed_type_names will contain "Foo".
     suppressed_type_names: Set[str]
 
     def __init__(
         self,
-        type_renamings: TypeRenamingMapping,
+        type_renamings: Mapping[str, Optional[str]],
         query_type: str,
         custom_scalar_names: AbstractSet[str],
     ) -> None:
@@ -578,7 +561,7 @@ class RenameSchemaTypesVisitor(Visitor):
         Args:
             type_renamings: maps original type name to renamed name or None (for type suppression).
                             A type named "Foo" will be unchanged iff type_renamings does not map
-                            "Foo" to anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
+                            "Foo" to anything, i.e. "Foo" not in type_renamings
             query_type: name of the query type (e.g. RootSchemaQuery), which will not be renamed
             custom_scalar_names: set of all user defined scalars used in the schema (excluding
                                  builtin scalars)
@@ -705,13 +688,13 @@ class RenameSchemaTypesVisitor(Visitor):
 
 
 class RenameQueryTypeFieldsVisitor(Visitor):
-    def __init__(self, type_renamings: TypeRenamingMapping, query_type: str) -> None:
+    def __init__(self, type_renamings: Mapping[str, Optional[str]], query_type: str) -> None:
         """Create a visitor for renaming or suppressing fields of the query type in a schema AST.
 
         Args:
             type_renamings: maps original type name to renamed name or None (for type suppression).
                             A type named "Foo" will be unchanged iff type_renamings does not map
-                            "Foo" to anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
+                            "Foo" to anything, i.e. "Foo" not in type_renamings
             query_type: name of the query type (e.g. RootSchemaQuery)
 
         Raises:
@@ -794,13 +777,13 @@ class CascadingSuppressionCheckVisitor(Visitor):
     fields_to_suppress: Dict[str, Dict[str, str]]
     union_types_to_suppress: List[UnionTypeDefinitionNode]
 
-    def __init__(self, type_renamings: TypeRenamingMapping, query_type: str) -> None:
+    def __init__(self, type_renamings: Mapping[str, Optional[str]], query_type: str) -> None:
         """Create a visitor to check that suppression does not cause an illegal state.
 
         Args:
             type_renamings: maps original type name to renamed name or None (for type suppression).
                             A type named "Foo" will be unchanged iff type_renamings does not map
-                            "Foo" to anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
+                            "Foo" to anything, i.e. "Foo" not in type_renamings
             query_type: name of the query type (e.g. RootSchemaQuery)
         """
         self.type_renamings = type_renamings
@@ -904,13 +887,13 @@ class SuppressionNotImplementedVisitor(Visitor):
     unsupported_interface_suppressions: Set[str]
     unsupported_interface_implementation_suppressions: Set[str]
 
-    def __init__(self, type_renamings: TypeRenamingMapping) -> None:
+    def __init__(self, type_renamings: Mapping[str, Optional[str]]) -> None:
         """Confirm type_renamings doesn't try to suppress enum/interface/interface implementation.
 
         Args:
             type_renamings: maps original type name to renamed name or None (for type suppression).
                             A type named "Foo" will be unchanged iff type_renamings does not map
-                            "Foo" to anything, i.e. type_renamings.get("Foo", "Foo") returns "Foo"
+                            "Foo" to anything, i.e. "Foo" not in type_renamings
         """
         self.type_renamings = type_renamings
         self.unsupported_enum_suppressions = set()
@@ -927,7 +910,7 @@ class SuppressionNotImplementedVisitor(Visitor):
     ) -> None:
         """If type_renamings suppresses enums, record it for error message."""
         enum_name = node.name.value
-        if self.type_renamings.get(enum_name, enum_name) is None:
+        if self.type_renamings.get(enum_name) is None:
             self.unsupported_enum_suppressions.add(enum_name)
 
     def enter_interface_type_definition(
@@ -940,7 +923,7 @@ class SuppressionNotImplementedVisitor(Visitor):
     ) -> None:
         """If type_renamings suppresses interfaces, record it for error message."""
         interface_name = node.name.value
-        if self.type_renamings.get(interface_name, interface_name) is None:
+        if self.type_renamings.get(interface_name) is None:
             self.unsupported_interface_suppressions.add(interface_name)
 
     def enter_object_type_definition(
@@ -955,6 +938,6 @@ class SuppressionNotImplementedVisitor(Visitor):
         if not node.interfaces:
             return
         object_name = node.name.value
-        if self.type_renamings.get(object_name, object_name) is None:
+        if self.type_renamings.get(object_name) is None:
             # Suppressing interface implementations isn't supported yet.
             self.unsupported_interface_implementation_suppressions.add(object_name)

--- a/graphql_compiler/schema_transformation/utils.py
+++ b/graphql_compiler/schema_transformation/utils.py
@@ -150,13 +150,12 @@ class CascadingSuppressionError(SchemaTransformError):
 
 
 class NoOpRenamingError(SchemaTransformError):
-    """Raised if renamings are iterable and contains no-op renames.
+    """Raised if renamings contain no-op renames.
 
     No-op renames can occur in these ways:
-    * type_renamings is iterable and contains a string type_name but there doesn't exist a type in
-      the schema named type_name
-    * type_renamings is iterable and maps a string type_name to itself, i.e.
-      type_renamings[type_name] == type_name
+    * type_renamings contains a string type_name but there doesn't exist a type in the schema named
+      type_name
+    * type_renamings maps a string type_name to itself, i.e. type_renamings[type_name] == type_name
     """
 
     no_op_type_renames: Set[str]
@@ -174,10 +173,10 @@ class NoOpRenamingError(SchemaTransformError):
     def __str__(self) -> str:
         """Explain renaming conflict and the fix."""
         return (
-            f"type_renamings is iterable, so it cannot have no-op renamings. However, the "
-            f"following entries exist in the type_renamings argument, which either rename a "
-            f"type to itself or would rename a type that doesn't exist in the schema, both of "
-            f"which are invalid: {sorted(self.no_op_type_renames)}"
+            f"type_renamings cannot have no-op renamings. However, the following entries exist in "
+            f"the type_renamings argument, which either rename a type to itself or would rename a "
+            f"type that doesn't exist in the schema, both of which are invalid: "
+            f"{sorted(self.no_op_type_renames)}"
         )
 
 

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -1,9 +1,9 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 from textwrap import dedent
-from typing import Optional, Set
+from typing import Set
 import unittest
 
-from graphql import GraphQLSchema, build_ast_schema, parse
+from graphql import parse
 from graphql.language.printer import print_ast
 from graphql.language.visitor import QUERY_DOCUMENT_KEYS
 from graphql.pyutils import snake_to_camel
@@ -15,8 +15,6 @@ from ...schema_transformation.utils import (
     NoOpRenamingError,
     SchemaRenameNameConflictError,
     SchemaTransformError,
-    builtin_scalar_type_names,
-    get_custom_scalar_names,
 )
 from ..test_helpers import compare_schema_texts_order_independently
 from .input_schema_strings import InputSchemaStrings as ISS

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -8,11 +8,7 @@ from graphql.language.printer import print_ast
 from graphql.language.visitor import QUERY_DOCUMENT_KEYS
 from graphql.pyutils import snake_to_camel
 
-from ...schema_transformation.rename_schema import (
-    RenameSchemaTypesVisitor,
-    TypeRenamingMapping,
-    rename_schema,
-)
+from ...schema_transformation.rename_schema import RenameSchemaTypesVisitor, rename_schema
 from ...schema_transformation.utils import (
     CascadingSuppressionError,
     InvalidNameError,
@@ -114,24 +110,6 @@ class TestRenameSchema(unittest.TestCase):
         with self.assertRaises(NoOpRenamingError):
             rename_schema(parse(ISS.basic_schema), {"Dinosaur": "NewDinosaur"})
 
-    def test_rename_legal_noop_unused_renaming(self) -> None:
-        # Unlike with test_rename_illegal_noop_unused_renaming, here type_renamings is not
-        # iterable. As a result, this renaming is technically legal but it is inadvisable to
-        # write a renaming like this since the intended "Dinosaur" -> "NewDinosaur" mapping is
-        # unused and will silently do nothing when applied to the given schema.
-        class RenameMapping:
-            def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
-                """Define mapping for renaming object."""
-                if key == "Dinosaur":
-                    return "NewDinosaur"
-                return key
-
-        renamed_schema = rename_schema(parse(ISS.basic_schema), RenameMapping())
-        compare_schema_texts_order_independently(
-            self, ISS.basic_schema, print_ast(renamed_schema.schema_ast)
-        )
-        self.assertEqual({}, renamed_schema.reverse_name_map)
-
     def test_rename_illegal_noop_renamed_to_self(self) -> None:
         with self.assertRaises(NoOpRenamingError):
             rename_schema(parse(ISS.basic_schema), {"Human": "Human"})
@@ -191,31 +169,13 @@ class TestRenameSchema(unittest.TestCase):
         with self.assertRaises(NoOpRenamingError):
             rename_schema(parse(ISS.multiple_objects_schema), {"Dinosaur": None})
 
-    def test_suppress_legal_noop_unused_suppression(self) -> None:
-        # Unlike with test_suppress_illegal_noop_unused_suppression, here type_renamings is not
-        # iterable. As a result, this renaming is technically legal but it is inadvisable to
-        # write a renaming like this since the intended "Dinosaur" -> None mapping is unused and
-        # will silently do nothing when applied to the given schema.
-        class SuppressMapping:
-            def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
-                """Define mapping for renaming object."""
-                if key == "Dinosaur":
-                    return None
-                return key
-
-        renamed_schema = rename_schema(parse(ISS.multiple_objects_schema), SuppressMapping())
-        compare_schema_texts_order_independently(
-            self, ISS.multiple_objects_schema, print_ast(renamed_schema.schema_ast)
-        )
-        self.assertEqual({}, renamed_schema.reverse_name_map)
-
     def test_various_illegal_noop_type_renamings_error_message(self) -> None:
         with self.assertRaises(NoOpRenamingError) as e:
             rename_schema(
                 parse(ISS.basic_schema), {"Dinosaur": None, "Human": "Human", "Bird": "Birdie"}
             )
         self.assertEqual(
-            "type_renamings is iterable, so it cannot have no-op renamings. However, the following "
+            "type_renamings cannot have no-op renamings. However, the following "
             "entries exist in the type_renamings argument, which either rename a type to itself or "
             "would rename a type that doesn't exist in the schema, both of which are invalid: "
             "['Bird', 'Dinosaur', 'Human']",
@@ -654,8 +614,7 @@ class TestRenameSchema(unittest.TestCase):
 
     def test_directive_renaming_illegal_noop(self) -> None:
         # This renaming is illegal because directives can't be renamed, so the
-        # "stitch" -> "NewStitch" mapping is a no-op which is not allowed for iterable
-        # type_renamings.
+        # "stitch" -> "NewStitch" mapping is a no-op
         with self.assertRaises(NoOpRenamingError):
             rename_schema(
                 parse(ISS.directive_schema),
@@ -664,28 +623,9 @@ class TestRenameSchema(unittest.TestCase):
                 },
             )
 
-    def test_directive_renaming_legal_noop(self) -> None:
-        # Unlike with test_directive_renaming_illegal_noop, here type_renamings is not iterable.
-        # As a result, this renaming is technically legal but it is inadvisable to write a
-        # renaming like this since directives cannot be renamed so the intended
-        # "stitch" -> "NewStitch" mapping is unused and will silently do nothing when applied to
-        #  ISS.directive_schema.
-        class DirectiveRenamingMapping:
-            def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
-                """Define mapping for renaming object."""
-                if key == "stitch":
-                    return "NewStitch"
-                return key
-
-        renamed_schema = rename_schema(parse(ISS.directive_schema), DirectiveRenamingMapping())
-        compare_schema_texts_order_independently(
-            self, ISS.directive_schema, print_ast(renamed_schema.schema_ast)
-        )
-        self.assertEqual({}, renamed_schema.reverse_name_map)
-
     def test_query_type_field_argument_illegal_noop(self) -> None:
         # This renaming is illegal because query type field arguments can't be renamed, so the
-        # "id" -> "Id" mapping is a no-op which is not allowed for iterable type_renamings.
+        # "id" -> "Id" mapping is a no-op
         schema_string = dedent(
             """\
             schema {
@@ -703,40 +643,6 @@ class TestRenameSchema(unittest.TestCase):
         )
         with self.assertRaises(NoOpRenamingError):
             rename_schema(parse(schema_string), {"id": "Id"})
-
-    def test_query_type_field_argument_legal_noop(self) -> None:
-        # Unlike with test_query_type_field_argument_illegal_noop, here type_renamings is not
-        # iterable. As a result, this renaming is technically legal but it is inadvisable to
-        # write a renaming like this since the intended "id" -> "Id" mapping is unused and will
-        # silently do nothing when applied to the given schema.
-        schema_string = dedent(
-            """\
-            schema {
-              query: SchemaQuery
-            }
-
-            type SchemaQuery {
-              Human(id: String!): Human
-            }
-
-            type Human {
-              name: String
-            }
-        """
-        )
-
-        class QueryTypeFieldArgumentMapping:
-            def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
-                """Define mapping for renaming object."""
-                if key == "id":
-                    return "Id"
-                return key
-
-        renamed_schema = rename_schema(parse(schema_string), QueryTypeFieldArgumentMapping())
-        compare_schema_texts_order_independently(
-            self, schema_string, print_ast(renamed_schema.schema_ast)
-        )
-        self.assertEqual({}, renamed_schema.reverse_name_map)
 
     def test_clashing_type_rename(self) -> None:
         schema_string = dedent(
@@ -982,74 +888,3 @@ class TestRenameSchema(unittest.TestCase):
     def test_field_in_list_still_depends_on_suppressed_type(self) -> None:
         with self.assertRaises(CascadingSuppressionError):
             rename_schema(parse(ISS.list_schema), {"Height": None})
-
-    def test_rename_using_dict_like_prefixer_class(self) -> None:
-        class PrefixNewDict(TypeRenamingMapping):
-            def __init__(self, schema: GraphQLSchema):
-                self.schema = schema
-                super().__init__()
-
-            def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
-                """Define mapping for renaming object."""
-                if key in get_custom_scalar_names(self.schema) or key in builtin_scalar_type_names:
-                    # Making an exception for scalar types because renaming and suppressing them
-                    # hasn't been implemented yet
-                    return key
-                return "New" + key
-
-        schema = parse(ISS.various_types_schema)
-        renamed_schema = rename_schema(schema, PrefixNewDict(build_ast_schema(schema)))
-        renamed_schema_string = dedent(
-            """\
-            schema {
-              query: SchemaQuery
-            }
-
-            scalar Date
-
-            enum NewHeight {
-              TALL
-              SHORT
-            }
-
-            interface NewCharacter {
-              id: String
-            }
-
-            type NewHuman implements NewCharacter {
-              id: String
-              name: String
-              birthday: Date
-            }
-
-            type NewGiraffe implements NewCharacter {
-              id: String
-              height: NewHeight
-            }
-
-            type NewDog {
-              nickname: String
-            }
-
-            directive @stitch(source_field: String!, sink_field: String!) on FIELD_DEFINITION
-
-            type SchemaQuery {
-              NewHuman: NewHuman
-              NewGiraffe: NewGiraffe
-              NewDog: NewDog
-            }
-        """
-        )
-        compare_schema_texts_order_independently(
-            self, renamed_schema_string, print_ast(renamed_schema.schema_ast)
-        )
-        self.assertEqual(
-            {
-                "NewCharacter": "Character",
-                "NewGiraffe": "Giraffe",
-                "NewHeight": "Height",
-                "NewHuman": "Human",
-                "NewDog": "Dog",
-            },
-            renamed_schema.reverse_name_map,
-        )


### PR DESCRIPTION
Based on discussion in #970, we've decided to choose `Mapping`s for our renaming objects (note we chose `Mappings` instead of `Dict`s because `Mapping`s cannot be mutated)