### PR TITLE
Add a few missing type hints.

### DIFF
--- a/graphql_compiler/query_formatting/common.py
+++ b/graphql_compiler/query_formatting/common.py
@@ -50,7 +50,7 @@ def _raise_invalid_type_error(
 ######
 
 
-def validate_argument_type(name: str, expected_type: QueryArgumentGraphQLType, value: Any):
+def validate_argument_type(name: str, expected_type: QueryArgumentGraphQLType, value: Any) -> None:
     """Ensure the value has the expected type and is usable in any of our backends, or raise errors.
 
     Backends are the database languages we have the ability to compile to, like OrientDB MATCH,
@@ -157,7 +157,10 @@ def validate_arguments(
         validate_argument_type(name, expected_types[name], arguments[name])
 
 
-def insert_arguments_into_query(compilation_result: CompilationResult, arguments: Dict[str, Any]):
+def insert_arguments_into_query(
+    compilation_result: CompilationResult,
+    arguments: Dict[str, Any],
+) -> Any:
     """Insert the arguments into the compiled GraphQL query to form a complete query.
 
     Args:
@@ -165,7 +168,8 @@ def insert_arguments_into_query(compilation_result: CompilationResult, arguments
         arguments: dict, mapping argument name to its value, for every parameter the query expects.
 
     Returns:
-        string, a query in the appropriate output language, with inserted argument data
+        string or SQLAlchemy query object, representing the query in the appropriate
+        output language, with inserted argument data
     """
     validate_arguments(compilation_result.input_metadata, arguments)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -131,23 +131,30 @@ check_untyped_defs = False
 disallow_untyped_calls = False
 disallow_untyped_defs = False
 
-[mypy-graphql_compiler.query_formatting.*]
-disallow_untyped_defs = False
-
 [mypy-graphql_compiler.query_formatting.common.*]
 disallow_untyped_calls = False
 
 [mypy-graphql_compiler.query_formatting.cypher_formatting.*]
 disallow_untyped_calls = False
+disallow_untyped_defs = False
 
 [mypy-graphql_compiler.query_formatting.graphql_formatting.*]
 disallow_untyped_calls = False
+disallow_untyped_defs = False
 
 [mypy-graphql_compiler.query_formatting.gremlin_formatting.*]
 disallow_untyped_calls = False
+disallow_untyped_defs = False
 
 [mypy-graphql_compiler.query_formatting.match_formatting.*]
 disallow_untyped_calls = False
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.query_formatting.representations.*]
+disallow_untyped_defs = False
+
+[mypy-graphql_compiler.query_formatting.sql_formatting.*]
+disallow_untyped_defs = False
 
 [mypy-graphql_compiler.query_pagination.pagination_planning.*]
 disallow_untyped_calls = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -135,7 +135,6 @@ disallow_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-graphql_compiler.query_formatting.common.*]
-disallow_incomplete_defs = False
 disallow_untyped_calls = False
 
 [mypy-graphql_compiler.query_formatting.cypher_formatting.*]


### PR DESCRIPTION
I found a missing `-> None` so I opened this PR to fix it.

Below the missing `-> None`, I ran into a bit of an issue. I wasn't sure what the type hint for SQL compilation should be, so I opened #977. Maybe @bojanserafimov or @chewselene can propose a better type hint than `Any` for that, and then we can make it explicitly written into the module.