### PR TITLE
Prefer fields with inequality filters for pagination

### DIFF
--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -129,9 +129,6 @@ def get_pagination_plan(
     # fields, it's best to paginate on it to prevent empty pages. After applying this rule,
     # we use the order given by schema_info.pagination_keys to resolve ties.
     pagination_keys = query_analysis.schema_info.pagination_keys.get(pagination_node, tuple())
-    if not isinstance(pagination_keys, tuple):
-        raise AssertionError(f"Invalid pagination keys specified for {root_node}: "
-                             f"{pagination_keys} of type {type(pagination_keys)}. Expected tuple.")
     range_filtered_pagination_keys = [
         key
         for key in pagination_keys

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -125,13 +125,6 @@ def get_pagination_plan(
     root_node = get_only_selection_from_ast(definition_ast, GraphQLError).name.value
     pagination_node = root_node
 
-
-    # If we have more quantiles than desired pages, we can create the desired number of pages.
-    # However, if we don't have 5 times as much, those pages might differ in size by a factor
-    # of 2.
-    acceptable_quantile_resolution = number_of_pages + 1
-    ideal_quantile_resolution = 5 * number_of_pages + 1
-
     # If there is a range filter on a field on this vertex that might be correlated with other
     # fields, it's best to paginate on it to prevent empty pages. After applying this rule,
     # we use the order given by schema_info.pagination_keys to resolve ties.
@@ -157,6 +150,9 @@ def get_pagination_plan(
     capacity = query_analysis.pagination_capacities.get(property_path)
     # If the pagination capacity is None, then there must be no quantiles for this property.
     if capacity is None:
+        # If we have more quantiles than desired pages, we can create the desired number of pages.
+        # However, if we don't have 5 times as much, those pages might differ in size by a factor
+        # of 2.
         ideal_min_num_quantiles_per_page = 5
         ideal_quantile_resolution = ideal_min_num_quantiles_per_page * number_of_pages + 1
         return (

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -135,7 +135,10 @@ def get_pagination_plan(
     # If there is a range filter on a field on this vertex that might be correlated with other
     # fields, it's best to paginate on it to prevent empty pages. After applying this rule,
     # we use the order given by schema_info.pagination_keys to resolve ties.
-    pagination_keys = query_analysis.schema_info.pagination_keys.get(pagination_node)
+    pagination_keys = query_analysis.schema_info.pagination_keys.get(pagination_node, tuple())
+    if not isinstance(pagination_keys, tuple):
+        raise AssertionError(f"Invalid pagination keys specified for {root_node}: "
+                             f"{pagination_keys} of type {type(pagination_keys)}. Expected tuple.")
     range_filtered_pagination_keys = [
         key
         for key in pagination_keys

--- a/graphql_compiler/query_pagination/pagination_planning.py
+++ b/graphql_compiler/query_pagination/pagination_planning.py
@@ -125,11 +125,16 @@ def get_pagination_plan(
     root_node = get_only_selection_from_ast(definition_ast, GraphQLError).name.value
     pagination_node = root_node
 
+    # XXX Just specify multiple pagination keys (make it a list). Then to choose a field:
+    # 1. Find the set of fields with sufficient capacity on the root
+    # 2. First preference for fields with field value intervals on them
+    # 3. Second preference for fields that appear earlier in the list of pagination keys.
+    #
     # TODO(bojanserafimov): Remove pagination fields. The pagination planner is now smart enough
     #                       to pick the best field for pagination based on the query. This is not
     #                       trivial since the pagination_fields are used in tests to force int
     #                       pagination when uuid pagination is also available.
-    pagination_field = query_analysis.schema_info.pagination_keys.get(pagination_node)
+    pagination_field = query_analysis.schema_info.pagination_keys.get(pagination_node)[0]
     if pagination_field is None:
         return PaginationPlan(tuple()), (PaginationFieldNotSpecified(pagination_node),)
 

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -392,7 +392,7 @@ class QueryPlanningSchemaInfo:
     # that are eligible pagination on that vertex in a general context. Some of the provided
     # properties might be ineligible for pagination in certain queries, for instance if the
     # query has a "=" filter on the field and it's uniquely indexed. The order of properties
-    # within this list is used as a final (least significant) step in choosing which one
+    # within this sequence is used as a final (least significant) step in choosing which one
     # to use when multiple options are available. The pagination key list for a vertex can
     # be omitted, making the entire vertex ineligible for pagination.
     pagination_keys: Mapping[str, Sequence[str]]

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, Flag, auto, unique
 from functools import partial
-from typing import Dict, Optional, List
+from typing import Dict, Optional, Tuple
 
 from graphql.type import GraphQLSchema
 from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType
@@ -388,14 +388,14 @@ class QueryPlanningSchemaInfo:
     # A Statistics object giving statistical information about all objects in the schema.
     statistics: Statistics
 
-    # Dict mapping vertex names in the graphql schema to the non-empty list of property names
+    # Dict mapping vertex names in the graphql schema to the non-empty tuple of property names
     # that are eligible pagination on that vertex in a general context. Some of the provided
     # properties might be ineligible for pagination in certain queries, for instance if the
     # query has a "=" filter on the field and it's uniquely indexed. The order of properties
     # within this list is used as a final (least significant) step in choosing which one
     # to use when multiple options are available. The pagination key list for a vertex can
     # be omitted, making the entire vertex ineligible for pagination.
-    pagination_keys: Dict[str, List[str]]
+    pagination_keys: Dict[str, Tuple[str, ...]]
 
     # Dict mapping vertex names in the graphql schema to a dict mapping property names that
     # are known to contain uniformly distributed uuid values to the ordering method used for

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -388,7 +388,7 @@ class QueryPlanningSchemaInfo:
     # A Statistics object giving statistical information about all objects in the schema.
     statistics: Statistics
 
-    # Dict mapping vertex names in the graphql schema to the non-empty sequence of property names
+    # Mapping vertex names in the graphql schema to the non-empty sequence of property names
     # that are eligible pagination on that vertex in a general context. Some of the provided
     # properties might be ineligible for pagination in certain queries, for instance if the
     # query has a "=" filter on the field and it's uniquely indexed. The order of properties

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, Flag, auto, unique
 from functools import partial
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from graphql.type import GraphQLSchema
 from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType
@@ -395,7 +395,7 @@ class QueryPlanningSchemaInfo:
     # within this list is used as a final (least significant) step in choosing which one
     # to use when multiple options are available. The pagination key list for a vertex can
     # be omitted, making the entire vertex ineligible for pagination.
-    pagination_keys: Dict[str, str]
+    pagination_keys: Dict[str, List[str]]
 
     # Dict mapping vertex names in the graphql schema to a dict mapping property names that
     # are known to contain uniformly distributed uuid values to the ordering method used for

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -393,8 +393,9 @@ class QueryPlanningSchemaInfo:
     # properties might be ineligible for pagination in certain queries, for instance if the
     # query has a "=" filter on the field and it's uniquely indexed. The order of properties
     # within this sequence is used as a final (least significant) step in choosing which one
-    # to use when multiple options are available. The pagination key sequence for a vertex can
-    # be omitted, making the entire vertex ineligible for pagination.
+    # to use when multiple options are available.
+    #
+    # If a vertex name is omitted from this dict, the entire vertex is ineligible for pagination.
     pagination_keys: Mapping[str, Sequence[str]]
 
     # Dict mapping vertex names in the graphql schema to a dict mapping property names that

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, Flag, auto, unique
 from functools import partial
-from typing import Dict, Optional, Tuple
+from typing import Dict, Mapping, Optional, Sequence
 
 from graphql.type import GraphQLSchema
 from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType
@@ -388,14 +388,14 @@ class QueryPlanningSchemaInfo:
     # A Statistics object giving statistical information about all objects in the schema.
     statistics: Statistics
 
-    # Dict mapping vertex names in the graphql schema to the non-empty tuple of property names
+    # Dict mapping vertex names in the graphql schema to the non-empty sequence of property names
     # that are eligible pagination on that vertex in a general context. Some of the provided
     # properties might be ineligible for pagination in certain queries, for instance if the
     # query has a "=" filter on the field and it's uniquely indexed. The order of properties
     # within this list is used as a final (least significant) step in choosing which one
     # to use when multiple options are available. The pagination key list for a vertex can
     # be omitted, making the entire vertex ineligible for pagination.
-    pagination_keys: Dict[str, Tuple[str, ...]]
+    pagination_keys: Mapping[str, Sequence[str]]
 
     # Dict mapping vertex names in the graphql schema to a dict mapping property names that
     # are known to contain uniformly distributed uuid values to the ordering method used for

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -388,15 +388,13 @@ class QueryPlanningSchemaInfo:
     # A Statistics object giving statistical information about all objects in the schema.
     statistics: Statistics
 
-    # Dict mapping vertex names in the graphql schema to the Int or ID type property name
-    # to be used for pagination on that vertex. This property should be non-null and
-    # unique for all rows.  An easy choice for pagination key in most situations is the
-    # primary key. The pagination key for a vertex can be omitted making the vertex
-    # ineligible for pagination.
-    #
-    # NOTE(bojanserafimov): The type of this property might be different in the
-    #                       schema graph, due to the process of type overrides that happens
-    #                       during schema generation.
+    # Dict mapping vertex names in the graphql schema to the non-empty list of property names
+    # that are eligible pagination on that vertex in a general context. Some of the provided
+    # properties might be ineligible for pagination in certain queries, for instance if the
+    # query has a "=" filter on the field and it's uniquely indexed. The order of properties
+    # within this list is used as a final (least significant) step in choosing which one
+    # to use when multiple options are available. The pagination key list for a vertex can
+    # be omitted, making the entire vertex ineligible for pagination.
     pagination_keys: Dict[str, str]
 
     # Dict mapping vertex names in the graphql schema to a dict mapping property names that

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -393,7 +393,7 @@ class QueryPlanningSchemaInfo:
     # properties might be ineligible for pagination in certain queries, for instance if the
     # query has a "=" filter on the field and it's uniquely indexed. The order of properties
     # within this sequence is used as a final (least significant) step in choosing which one
-    # to use when multiple options are available. The pagination key list for a vertex can
+    # to use when multiple options are available. The pagination key sequence for a vertex can
     # be omitted, making the entire vertex ineligible for pagination.
     pagination_keys: Mapping[str, Sequence[str]]
 

--- a/graphql_compiler/schema_generation/schema_graph.py
+++ b/graphql_compiler/schema_generation/schema_graph.py
@@ -2,6 +2,7 @@
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict, namedtuple
 from itertools import chain
+from typing import Set
 
 import six
 
@@ -208,7 +209,7 @@ class SchemaGraph(object):
         return set(six.iterkeys(self._elements))
 
     @property
-    def vertex_class_names(self):
+    def vertex_class_names(self) -> Set[str]:
         """Return the set of vertex class names in the SchemaGraph."""
         return self._vertex_class_names
 

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -24,7 +24,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_field_value_intervals(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -63,7 +63,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_distinct_result_set_estimates(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -105,7 +105,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_pagination_capacities(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -141,7 +141,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_pagination_capacities_unique_filter(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -177,7 +177,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_selectivities(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -221,7 +221,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_pagination_capacities_int_field(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -260,7 +260,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_pagination_capacities_int_field_existing_filter(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -302,7 +302,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_analysis_with_fold(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -354,7 +354,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_eligible_fields(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -398,7 +398,7 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_distinct_result_set_estimates_edge_constraint_propagation(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names

--- a/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
+++ b/graphql_compiler/tests/snapshot_tests/test_cost_estimation_analysis.py
@@ -24,7 +24,9 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_field_value_intervals(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -63,7 +65,9 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_distinct_result_set_estimates(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -105,7 +109,9 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_pagination_capacities(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -141,7 +147,9 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_pagination_capacities_unique_filter(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -177,7 +185,9 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_selectivities(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -221,12 +231,14 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_pagination_capacities_int_field(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
         }
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): list(range(101))}
@@ -260,12 +272,14 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_get_pagination_capacities_int_field_existing_filter(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
         }
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): list(range(101))}
@@ -302,7 +316,9 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_analysis_with_fold(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -354,7 +370,9 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_eligible_fields(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -398,7 +416,9 @@ class CostEstimationAnalysisTests(unittest.TestCase):
     def test_distinct_result_set_estimates_edge_constraint_propagation(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -670,7 +670,9 @@ class QueryPaginationTests(unittest.TestCase):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
         pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
+        # We allow pagination on uuid as well and leave it to the pagination planner to decide to
+        # paginate on event_date to prevent empty pages in case the two fields are correlated.
+        pagination_keys["Event"] = ["uuid", "event_date"]
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -42,7 +42,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_basic(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -79,7 +79,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_invalid_extra_args(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -113,7 +113,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_invalid_missing_args(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -148,7 +148,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_unique_filter(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -191,7 +191,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_unique_filter_on_many_to_one(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -245,12 +245,12 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_on_int(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
         }
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(
             class_counts, field_quantiles={("Species", "limbs"): list(range(100))}
@@ -287,12 +287,12 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_on_int_error(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
         }
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         class_counts = {"Species": 1000}
         statistics = LocalStatistics(class_counts)
         schema_info = QueryPlanningSchemaInfo(
@@ -327,7 +327,7 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -444,7 +444,7 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst}
             for vertex_name in schema_graph.vertex_class_names
@@ -560,8 +560,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_datetime(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Event"] = ("event_date",)  # Force pagination on datetime field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -669,10 +669,10 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_datetime_existing_filter(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         # We allow pagination on uuid as well and leave it to the pagination planner to decide to
-        # paginate on event_date to prevent empty pages in case the two fields are correlated.
-        pagination_keys["Event"] = ["uuid", "event_date"]
+        # paginate on event_date to prevent empty pages if the two fields are correlated.
+        pagination_keys["Event"] = ("uuid", "event_date")
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -746,8 +746,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_existing_datetime_filter(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Event"] = ("event_date",)  # Force pagination on datetime field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -821,8 +821,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -862,8 +862,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int_few_quantiles(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -920,8 +920,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int_existing_filters(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -962,8 +962,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int_existing_filter_tiny_page(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1002,8 +1002,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int_existing_filters_2(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1044,8 +1044,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_inline_fragment(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1089,8 +1089,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_with_existing_filters(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1129,8 +1129,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_datetime(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Event"] = "event_date"  # Force pagination on datetime field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Event"] = ("event_date",)  # Force pagination on datetime field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1174,7 +1174,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_uuid(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1213,7 +1213,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_mssql_uuid(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst}
             for vertex_name in schema_graph.vertex_class_names
@@ -1252,7 +1252,7 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_mssql_uuid_with_existing_filter(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst}
             for vertex_name in schema_graph.vertex_class_names
@@ -1294,8 +1294,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_consecutive(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1334,8 +1334,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_query_parameterizer(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1386,8 +1386,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_query_parameterizer_name_conflict(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1441,8 +1441,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_query_parameterizer_filter_deduplication(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1498,7 +1498,7 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure pagination is not done when not needed."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1581,8 +1581,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_impossible_pagination_strong_filters_few_repeated_quantiles(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1629,8 +1629,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_impossible_pagination_strong_filters_few_quantiles(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1678,7 +1678,7 @@ class QueryPaginationTests(unittest.TestCase):
         """Test that pagination doesn't crash on any of the queries from the compiler tests."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1723,7 +1723,7 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1757,7 +1757,7 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1798,7 +1798,7 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1839,8 +1839,8 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_with_inline_fragment(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: "uuid" for vertex_name in schema_graph.vertex_class_names}
-        pagination_keys["Species"] = "limbs"  # Force pagination on int field
+        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names

--- a/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
+++ b/graphql_compiler/tests/snapshot_tests/test_query_pagination.py
@@ -42,7 +42,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_basic(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -79,7 +81,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_invalid_extra_args(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -113,7 +117,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_invalid_missing_args(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -148,7 +154,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_unique_filter(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -191,7 +199,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_unique_filter_on_many_to_one(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -245,7 +255,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_on_int(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -287,7 +299,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_planning_on_int_error(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -327,7 +341,9 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -444,7 +460,9 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst}
             for vertex_name in schema_graph.vertex_class_names
@@ -560,7 +578,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_datetime(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Event"] = ("event_date",)  # Force pagination on datetime field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -669,7 +689,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_datetime_existing_filter(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         # We allow pagination on uuid as well and leave it to the pagination planner to decide to
         # paginate on event_date to prevent empty pages if the two fields are correlated.
         pagination_keys["Event"] = ("uuid", "event_date")
@@ -746,7 +768,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_existing_datetime_filter(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Event"] = ("event_date",)  # Force pagination on datetime field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -821,7 +845,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -862,7 +888,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int_few_quantiles(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -920,7 +948,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int_existing_filters(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -962,7 +992,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int_existing_filter_tiny_page(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1002,7 +1034,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_int_existing_filters_2(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1044,7 +1078,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_inline_fragment(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1089,7 +1125,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_with_existing_filters(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1129,7 +1167,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_datetime(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Event"] = ("event_date",)  # Force pagination on datetime field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1174,7 +1214,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_uuid(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1213,7 +1255,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_mssql_uuid(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst}
             for vertex_name in schema_graph.vertex_class_names
@@ -1252,7 +1296,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_mssql_uuid_with_existing_filter(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LastSixBytesFirst}
             for vertex_name in schema_graph.vertex_class_names
@@ -1294,7 +1340,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_parameter_value_generation_consecutive(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1334,7 +1382,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_query_parameterizer(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1386,7 +1436,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_query_parameterizer_name_conflict(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1441,7 +1493,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_query_parameterizer_filter_deduplication(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1498,7 +1552,9 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure pagination is not done when not needed."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1581,7 +1637,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_impossible_pagination_strong_filters_few_repeated_quantiles(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1629,7 +1687,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_impossible_pagination_strong_filters_few_quantiles(self):
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
@@ -1678,7 +1738,9 @@ class QueryPaginationTests(unittest.TestCase):
         """Test that pagination doesn't crash on any of the queries from the compiler tests."""
         schema_graph = generate_schema_graph(self.orientdb_client)
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1723,7 +1785,9 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1757,7 +1821,9 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1798,7 +1864,9 @@ class QueryPaginationTests(unittest.TestCase):
         """Ensure a basic pagination query is handled correctly."""
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}
             for vertex_name in schema_graph.vertex_class_names
@@ -1839,7 +1907,9 @@ class QueryPaginationTests(unittest.TestCase):
     def test_pagination_with_inline_fragment(self) -> None:
         schema_graph = generate_schema_graph(self.orientdb_client)  # type: ignore  # from fixture
         graphql_schema, type_equivalence_hints = get_graphql_schema_from_schema_graph(schema_graph)
-        pagination_keys = {vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names}
+        pagination_keys = {
+            vertex_name: ("uuid",) for vertex_name in schema_graph.vertex_class_names
+        }
         pagination_keys["Species"] = ("limbs",)  # Force pagination on int field
         uuid4_field_info = {
             vertex_name: {"uuid": UUIDOrdering.LeftToRight}


### PR DESCRIPTION
If fields A and B are correlated, and there's a strong inequality filter on A, then paging on B is a bad idea. Most of the pages will come back empty.

In this PR, we detect this scenario and choose A as a pagination field. To do that we need to relax the user-provided pagination field preference just a little bit -- enough to allow flexibility, but not enough to lose control.

This PR is an example of why we don't want to publish the pagination API yet. It's gonna change like this many times until we get it right.

Since there's lots of noise in the tests in this PR, I've singled out the one test that actually tests something with a comment.