### PR TITLE
Eliminate absolute imports of our own package.

### DIFF
--- a/graphql_compiler/api/orientdb.py
+++ b/graphql_compiler/api/orientdb.py
@@ -1,10 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 # pylint: disable=unused-import
-from graphql_compiler import graphql_to_gremlin, graphql_to_match  # noqa
-from graphql_compiler.schema.schema_info import (  # noqa
-    create_gremlin_schema_info,
-    create_match_schema_info,
-)
+from .. import graphql_to_gremlin, graphql_to_match  # noqa
+from ..schema.schema_info import create_gremlin_schema_info, create_match_schema_info  # noqa
 
 
 # pylint: enable=unused-import

--- a/graphql_compiler/api/redisgraph.py
+++ b/graphql_compiler/api/redisgraph.py
@@ -1,7 +1,7 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 # pylint: disable=unused-import
-from graphql_compiler import graphql_to_redisgraph_cypher  # noqa
-from graphql_compiler.schema.schema_info import create_cypher_schema_info  # noqa
+from .. import graphql_to_redisgraph_cypher  # noqa
+from ..schema.schema_info import create_cypher_schema_info  # noqa
 
 
 # pylint: enable=unused-import

--- a/graphql_compiler/api/sql/__init__.py
+++ b/graphql_compiler/api/sql/__init__.py
@@ -1,8 +1,8 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 # pylint: disable=unused-import
 # TODO: add more functions that help with SQL-related setup
-from graphql_compiler import graphql_to_sql  # noqa
-from graphql_compiler.schema_generation.sqlalchemy import get_sqlalchemy_schema_info  # noqa
+from ... import graphql_to_sql  # noqa
+from ...schema_generation.sqlalchemy import get_sqlalchemy_schema_info  # noqa
 
 
 # pylint: enable=unused-import

--- a/graphql_compiler/api/sql/mssql.py
+++ b/graphql_compiler/api/sql/mssql.py
@@ -1,6 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 # pylint: disable=unused-import
-from graphql_compiler.schema.schema_info import create_mssql_schema_info  # noqa
+from ...schema.schema_info import create_mssql_schema_info  # noqa
 
 
 # pylint: enable=unused-import

--- a/graphql_compiler/api/sql/mysql.py
+++ b/graphql_compiler/api/sql/mysql.py
@@ -1,6 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 # pylint: disable=unused-import
-from graphql_compiler.schema.schema_info import create_mysql_schema_info  # noqa
+from ...schema.schema_info import create_mysql_schema_info  # noqa
 
 
 # pylint: enable=unused-import

--- a/graphql_compiler/api/sql/postgres.py
+++ b/graphql_compiler/api/sql/postgres.py
@@ -1,6 +1,6 @@
 # Copyright 2019-present Kensho Technologies, LLC.
 # pylint: disable=unused-import
-from graphql_compiler.schema.schema_info import create_postgresql_schema_info  # noqa
+from ...schema.schema_info import create_postgresql_schema_info  # noqa
 
 
 # pylint: enable=unused-import

--- a/graphql_compiler/deserialization.py
+++ b/graphql_compiler/deserialization.py
@@ -13,10 +13,8 @@ from graphql import (
     GraphQLString,
 )
 
-from graphql_compiler.compiler.helpers import strip_non_null_from_type
-from graphql_compiler.global_utils import is_same_type
-
-from .global_utils import assert_set_equality
+from .compiler.helpers import strip_non_null_from_type
+from .global_utils import assert_set_equality, is_same_type
 from .schema import SUPPORTED_SCALAR_TYPES, GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .typedefs import QueryArgumentGraphQLType
 

--- a/graphql_compiler/tests/integration_tests/integration_test_helpers.py
+++ b/graphql_compiler/tests/integration_tests/integration_test_helpers.py
@@ -7,9 +7,6 @@ from redisgraph.client import Graph
 import six
 from sqlalchemy.engine.base import Engine
 
-from graphql_compiler.schema.schema_info import SQLAlchemySchemaInfo
-from graphql_compiler.tests.test_data_tools.neo4j_graph import Neo4jClient
-
 from ... import graphql_to_match, graphql_to_redisgraph_cypher, graphql_to_sql
 from ...compiler import compile_graphql_to_cypher, compile_graphql_to_sql
 from ...compiler.compiler_frontend import OutputMetadata
@@ -18,7 +15,8 @@ from ...compiler.sqlalchemy_extensions import (
     materialize_result_proxy,
     print_sqlalchemy_query_string,
 )
-from ...schema.schema_info import CommonSchemaInfo
+from ...schema.schema_info import CommonSchemaInfo, SQLAlchemySchemaInfo
+from ..test_data_tools.neo4j_graph import Neo4jClient
 
 
 T = TypeVar("T")

--- a/graphql_compiler/tests/test_post_processing.py
+++ b/graphql_compiler/tests/test_post_processing.py
@@ -4,10 +4,9 @@ from unittest import TestCase
 
 from graphql import GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLList, GraphQLString
 
-from graphql_compiler import GraphQLDate, GraphQLDateTime, GraphQLDecimal
-
 from ..compiler.compiler_frontend import OutputMetadata
 from ..post_processing.sql_post_processing import post_process_mssql_folds
+from ..schema import GraphQLDate, GraphQLDateTime, GraphQLDecimal
 from .test_helpers import get_sqlalchemy_schema_info
 
 


### PR DESCRIPTION
A small quality of life improvement: replace all absolute imports of our own package's submodules with relative imports of the same.

Unless there's a good reason, we should prefer to import our own submodules via relative imports rather than absolute ones. In some of the cases in this PR, we had separate absolute and relative imports of the same submodule, which makes the code more difficult to read and understand.

Currently we don't have a mechanism for enforcing that this type of lint doesn't come back, but I'm hoping that something based on https://twitter.com/PredragGruevski/status/1344725604520878080 might be able to help in the long run :)