### PR TITLE
Fix bug involving cascading suppression error

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -1116,6 +1116,9 @@ class CascadingSuppressionCheckVisitor(Visitor):
             # Therefore, we don't need to explicitly suppress the field as well and this should not
             # raise errors.
             return IDLE
+        if self.field_renamings.get(self.current_type, {}).get(field_name, {field_name}) == set():
+            # Field was also suppressed so this should not raise errors.
+            return IDLE
         if self.current_type not in self.fields_to_suppress:
             self.fields_to_suppress[self.current_type] = {}
         self.fields_to_suppress[self.current_type][field_name] = field_type


### PR DESCRIPTION
Suppose a GraphQL schema contains the following types:

```
type Human  {
  name: String
  pet: Dog
}

type Dog {
  id: String
}
```

It would be illegal to suppress the type `Dog` because the type `Human` still has a field `pet` of type `Dog`, but if the field `pet` was also suppressed, this would be a legal schema transformation. Previously, the code would incorrectly raise a `CascadingSuppressionError` regardless of whether or not `pet` was suppressed-- this PR fixes that bug.