### PR TITLE
Refactor cascading validation

### DIFF
--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -787,9 +787,14 @@ class RenameSchemaTypesVisitor(Visitor):
         for field_node in node.fields:
             field_name = field_node.name.value
             field_type_name = get_ast_with_non_null_and_list_stripped(field_node.type).name.value
-            field_type_suppressed = self.type_renamings.get(field_type_name, field_type_name) is None
-            field_node_suppressed = type_name in self.field_renamings and self.field_renamings[type_name].get(field_name, {field_name}) == set()
-            if field_type_suppressed and not(field_node_suppressed):
+            field_type_suppressed = (
+                self.type_renamings.get(field_type_name, field_type_name) is None
+            )
+            field_node_suppressed = (
+                type_name in self.field_renamings
+                and self.field_renamings[type_name].get(field_name, {field_name}) == set()
+            )
+            if field_type_suppressed and not (field_node_suppressed):
                 # If the type of the field is suppressed but the field itself is not, it's invalid.
                 current_type_fields_to_suppress[field_name] = field_type_name
         if current_type_fields_to_suppress != {}:

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -368,39 +368,32 @@ def _rename_and_suppress_types_and_fields(
         )
         raise CascadingSuppressionError("\n".join(error_message_components))
     if visitor.invalid_type_names or visitor.invalid_field_names:
-        explanation = (
+        error_message_components = [
             "Applying the renaming would involve names that are not valid, non-reserved "
             "GraphQL names. Valid, non-reserved GraphQL names must consist of only alphanumeric "
             "characters and underscores, must not start with a numeric character, and must not "
             "start with double underscores."
-        )
-        invalid_type_names_message = None
+        ]
         if visitor.invalid_type_names:
             sorted_invalid_type_names = sorted(visitor.invalid_type_names.items())
-            invalid_type_names_message = (
+            error_message_components.append(
                 f"The following is a list of tuples that describes what needs to be fixed for type "
                 f"renamings. Each tuple is of the form (original_name, invalid_new_name) where "
                 f"original_name is the name in the original schema and invalid_new_name is what "
                 f"original_name would be renamed to: {sorted_invalid_type_names}"
             )
-        invalid_field_names_message = None
         if visitor.invalid_field_names:
             sorted_invalid_field_names = [
                 (type_name, sorted(field_renamings.items()))
                 for type_name, field_renamings in sorted(visitor.invalid_field_names.items())
             ]
-            invalid_field_names_message = (
+            error_message_components.append(
                 f"The following is a list of tuples that describes what needs to be fixed for "
                 f"field renamings. Each tuple is of the form (type_name, field_renamings) "
                 f"where type_name is the name of the type in the original schema and "
                 f"field_renamings is a list of tuples mapping the original field name to the "
                 f"invalid GraphQL name it would be renamed to: {sorted_invalid_field_names}"
             )
-        error_message_components = [
-            explanation,
-            invalid_type_names_message,
-            invalid_field_names_message,
-        ]
         raise InvalidNameError("\n".join([i for i in error_message_components if i is not None]))
     if (
         visitor.type_name_conflicts

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -794,7 +794,7 @@ class RenameSchemaTypesVisitor(Visitor):
                 type_name in self.field_renamings
                 and self.field_renamings[type_name].get(field_name, {field_name}) == set()
             )
-            if field_type_suppressed and not (field_node_suppressed):
+            if field_type_suppressed and not field_node_suppressed:
                 # If the type of the field is suppressed but the field itself is not, it's invalid.
                 current_type_fields_to_suppress[field_name] = field_type_name
         if current_type_fields_to_suppress != {}:

--- a/graphql_compiler/schema_transformation/rename_schema.py
+++ b/graphql_compiler/schema_transformation/rename_schema.py
@@ -773,14 +773,17 @@ class RenameSchemaTypesVisitor(Visitor):
             node with fields renamed if there are no cascading suppression issues.
         """
         # Field renaming takes place in three steps:
-        # 1. For each field foo of type Bar: if Bar is going to be suppressed but foo isn't going to
+        # Step 1: detect fields that depend on types that were suppressed.
+        #    For each field foo of type Bar: if Bar is going to be suppressed but foo isn't going to
         #    be suppressed, the renamings are invalid. In that case, we should do the bare minimum
         #    necessary to continue the schema renaming and collect any other errors that occur
         #    independently while recording the problem. Once done, we return from the current type
         #    because there is no more to be done for this particular type's fields.
-        # 2. If the current type has no field renamings at all, we return immediately after doing
+        # Step 2: return immediately if we're not going to be renaming any fields.
+        #    If the current type has no field renamings at all, we return immediately after doing
         #    nothing.
-        # 3. If the current type does have field renamings, apply those field renamings.
+        # Step 3: apply the field renamings to each field.
+        #    If the current type does have field renamings, apply those field renamings.
         type_name = node.name.value
         current_type_fields_to_suppress = {}
         # Step 1: detect fields that depend on types that were suppressed.

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -1265,7 +1265,7 @@ class TestRenameSchema(unittest.TestCase):
 
     def test_field_in_list_still_depends_on_suppressed_type(self) -> None:
         with self.assertRaises(CascadingSuppressionError):
-            rename_schema(parse(ISS.list_schema), {"Height": None}, {})
+            rename_schema(parse(ISS.list_schema), {"Date": None}, {})
 
     def test_suppress_every_field_in_type(self) -> None:
         with self.assertRaises(CascadingSuppressionError):


### PR DESCRIPTION
As described in PR #994:

> Schema renaming currently has some technical debt where there is a separate validation step before actually attempting to use the renamings to modify the schema. For this to work, it requires us to keep the validation code and the processing code in sync, which we'd like to avoid in favor of attempting to modify the schema directly and gathering errors if something goes wrong.

This PR continues cleaning up this technical debt. It takes cascading suppression errors and moves the checks into the renaming code rather than having a separate validation step, simplifying the renaming process.

This PR lets us remove the entire `CascadingSuppressionCheckVisitor` class. If it'd be significantly easier to understand the changes here if I tried moving the functionality out of the `CascadingSuppressionCheckVisitor` piecemeal, just let me know and I can do that-- here I decided not to do that initially since all the code in the visitor follows the same pattern of "`foo` in the schema depends on `bar` where `bar` is to be suppressed".