### PR TITLE
Update python-mysqldb package name for Ubuntu 20.04

### DIFF
--- a/scripts/install_ubuntu_ci_core_dependencies.sh
+++ b/scripts/install_ubuntu_ci_core_dependencies.sh
@@ -18,7 +18,7 @@ set -e
 bash -c "wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -"
 sudo add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/"$(lsb_release -r -s)"/prod.list)"
 sudo apt-get update
-sudo apt-get install unixodbc-dev python-mysqldb libmysqlclient-dev
+sudo apt-get install unixodbc-dev python3-mysqldb libmysqlclient-dev
 ACCEPT_EULA=Y sudo apt-get install msodbcsql17
 
 # Ensure pip, setuptools, and pipenv are latest available versions.


### PR DESCRIPTION
Our scripts use `ubuntu-latest`, which is [migrating](https://github.com/actions/virtual-environments/issues/1816) from 18.04 to 20.04. The package [python-mysqldb](https://packages.ubuntu.com/bionic/python-mysqldb) in 18.04 has been renamed to [python3-mysqldb](https://packages.ubuntu.com/focal/python3-mysqldb) in 20.04. This PR makes that update for our CI scripts.