### PR TITLE
Add edges defined by a composite join clause

### DIFF
--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -906,7 +906,7 @@ class CompilationState(object):
 
         on_clause = sqlalchemy.and_(*(
             parent_alias.c[from_column] == self._current_alias.c[to_column]
-            for from_column, to_column in matching_column_pairs
+            for from_column, to_column in sorted(matching_column_pairs)
         ))
 
         # Join to where we came from.

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1,7 +1,7 @@
 # Copyright 2018-present Kensho Technologies, LLC.
 """Transform a SqlNode tree into an executable SQLAlchemy query."""
 from dataclasses import dataclass
-from typing import Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Union
+from typing import AbstractSet, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Union
 
 import six
 import sqlalchemy
@@ -868,7 +868,7 @@ class CompilationState(object):
 
         # construct on clause for join
         if isinstance(join_descriptor, DirectJoinDescriptor):
-            matching_column_pairs = {
+            matching_column_pairs: AbstractSet[Tuple[str, str]] = {
                 (join_descriptor.from_column, join_descriptor.to_column),
             }
         elif isinstance(join_descriptor, CompositeJoinDescriptor):

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -950,7 +950,8 @@ class CompilationState(object):
                     "Attempting to traverse inside a fold while the _current_location was not a "
                     f"FoldScopeLocation. _current_location was set to {self._current_location}."
                 )
-            # TODO(bojanserafimov): error if edge is composite traversal
+            if not isinstance(edge, DirectJoinDescriptor):
+                raise AssertionError("TODO")
             self._current_fold.add_traversal(edge, previous_alias, self._current_alias)
         else:
             self._join_to_parent_location(previous_alias, edge, optional)
@@ -1033,8 +1034,10 @@ class CompilationState(object):
                 f"was set to {self._current_location}."
             )
 
-        # TODO(bojanserafimov): error if composite
+
         edge = self._sql_schema_info.join_descriptors[self._current_classname][vertex_field]
+        if not isinstance(edge, DirectJoinDescriptor):
+            raise AssertionError("TODO")
         primary_key = self._get_current_primary_key_name("@recurse")
 
         # Wrap the query so far into a CTE if it would speed up the recursive query.
@@ -1146,10 +1149,11 @@ class CompilationState(object):
         edge_direction, edge_name = fold_scope_location.fold_path[0]
         full_edge_name = f"{edge_direction}_{edge_name}"
         # only works if fold scope location is the immediate child of self._current_classname
-        # TODO(bojanserafimov): Error if composite
         join_descriptor = self._sql_schema_info.join_descriptors[self._current_classname][
             full_edge_name
         ]
+        if not isinstance(join_descriptor, DirectJoinDescriptor):
+            raise AssertionError("TODO")
 
         # 3. Initialize fold object.
         self._current_fold = FoldSubqueryBuilder(

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -142,6 +142,7 @@ def _find_used_columns(
                 get_vertex_path(child_location)[-1]
             )
             vertex_field_name = f"{edge_direction}_{edge_name}"
+            # TODO(bojanserafimov): match on the kind of join descriptor
             edge = sql_schema_info.join_descriptors[location_info.type.name][vertex_field_name]
             used_columns.setdefault(get_vertex_path(location), set()).add(edge.from_column)
             used_columns.setdefault(get_vertex_path(child_location), set()).add(edge.to_column)
@@ -840,7 +841,7 @@ class CompilationState(object):
                     self._current_alias, self._current_location, output_fields
                 )
 
-    # TODO merge from_column and to_column into a joindescriptor
+    # TODO(bojanserafimov): merge from_column and to_column into a joindescriptor
     def _join_to_parent_location(
         self, parent_alias: Alias, from_column: str, to_column: str, optional: bool
     ):
@@ -932,8 +933,10 @@ class CompilationState(object):
                     "Attempting to traverse inside a fold while the _current_location was not a "
                     f"FoldScopeLocation. _current_location was set to {self._current_location}."
                 )
+            # TODO(bojanserafimov): error if edge is composite traversal
             self._current_fold.add_traversal(edge, previous_alias, self._current_alias)
         else:
+            # TODO(bojanserafimov): properly plumb composite join descriptors
             self._join_to_parent_location(
                 previous_alias, edge.from_column, edge.to_column, optional
             )
@@ -1016,6 +1019,7 @@ class CompilationState(object):
                 f"was set to {self._current_location}."
             )
 
+        # TODO(bojanserafimov): error if composite
         edge = self._sql_schema_info.join_descriptors[self._current_classname][vertex_field]
         primary_key = self._get_current_primary_key_name("@recurse")
 
@@ -1128,6 +1132,7 @@ class CompilationState(object):
         edge_direction, edge_name = fold_scope_location.fold_path[0]
         full_edge_name = f"{edge_direction}_{edge_name}"
         # only works if fold scope location is the immediate child of self._current_classname
+        # TODO(bojanserafimov): Error if composite
         join_descriptor = self._sql_schema_info.join_descriptors[self._current_classname][
             full_edge_name
         ]

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -1181,8 +1181,8 @@ class CompilationState(object):
         ]
         if not isinstance(join_descriptor, DirectJoinDescriptor):
             raise NotImplementedError(
-                f"Edge {full_edge_name} is backed by a CompositeJoinDescriptor, "
-                "so it can't be used with @fold."
+                f"Edge {full_edge_name} requires a JOIN across a composite key, which is currently "
+                "not supported for use with @fold."
             )
 
         # 3. Initialize fold object.

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -880,10 +880,20 @@ class CompilationState(object):
                 )
             )
 
+        # construct on clause for join
+        # TODO(bojanserafimov) match on the type of join descriptor
+        matching_column_pairs = {
+            (from_column, to_column),
+        }
+        on_clause = sqlalchemy.and_(*(
+            parent_alias.c[from_column] == self._current_alias.c[to_column]
+            for from_column, to_column in matching_column_pairs
+        ))
+
         # Join to where we came from.
         self._from_clause = self._from_clause.join(
             self._current_alias,
-            onclause=(parent_alias.c[from_column] == self._current_alias.c[to_column]),
+            onclause=on_clause,
             isouter=self._is_in_optional_scope(),
         )
 

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -154,6 +154,8 @@ def _find_used_columns(
             elif isinstance(edge, CompositeJoinDescriptor):
                 columns_at_location = {column_pair[0] for column_pair in edge.column_pairs}
                 columns_at_child = {column_pair[1] for column_pair in edge.column_pairs}
+            else:
+                raise AssertionError("TODO")
 
             used_columns.setdefault(get_vertex_path(location), set()).update(columns_at_location)
             used_columns.setdefault(get_vertex_path(child_location), set()).update(columns_at_child)
@@ -872,6 +874,9 @@ class CompilationState(object):
         elif isinstance(join_descriptor, CompositeJoinDescriptor):
             matching_column_pairs = join_descriptor.column_pairs
         else:
+            raise AssertionError("TODO")
+
+        if not matching_column_pairs:
             raise AssertionError("TODO")
 
         non_null_column = sorted(matching_column_pairs)[0][1]

--- a/graphql_compiler/compiler/emit_sql.py
+++ b/graphql_compiler/compiler/emit_sql.py
@@ -883,7 +883,7 @@ class CompilationState(object):
                 f"Invalid join descriptor {join_descriptor}, produced no matching column pairs."
             )
 
-        non_null_column = sorted(matching_column_pairs)[0][1]
+        _, non_null_column = sorted(matching_column_pairs)[0]
         self._came_from[self._current_alias] = self._current_alias.c[non_null_column]
 
         if self._is_in_optional_scope() and not optional:

--- a/graphql_compiler/compiler/ir_lowering_sql/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_sql/__init__.py
@@ -48,7 +48,7 @@ def _find_non_null_columns(schema_info, query_metadata_table):
             elif isinstance(edge, CompositeJoinDescriptor):
                 non_null_column[child_location.query_path] = sorted(edge.column_pairs)[0][1]
             else:
-                raise AssertionError(u"TODO")
+                raise AssertionError(f"Unknown join descriptor type {edge}: {type(edge)}")
 
     return non_null_column
 

--- a/graphql_compiler/compiler/ir_lowering_sql/__init__.py
+++ b/graphql_compiler/compiler/ir_lowering_sql/__init__.py
@@ -3,7 +3,7 @@ import six
 
 from .. import blocks, expressions
 from ...compiler.compiler_frontend import IrAndMetadata
-from ...schema.schema_info import DirectJoinDescriptor, CompositeJoinDescriptor
+from ...schema.schema_info import CompositeJoinDescriptor, DirectJoinDescriptor
 from ..helpers import FoldScopeLocation, get_edge_direction_and_name
 from ..ir_lowering_common import common
 

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -28,7 +28,8 @@ class DirectJoinDescriptor:
     JOIN origin_table.from_column = destination_table.to_column
 
     The type of join (inner vs left, etc.) is not specified.
-    The tables are not specified."""
+    The tables are not specified.
+    """
 
     from_column: str  # The column in the source table we intend to join on.
     to_column: str  # The column in the destination table we intend to join on.
@@ -45,7 +46,8 @@ class CompositeJoinDescriptor:
         origin_table.from_column_3 == destination_table.to_column_3
 
     The type of join (inner vs left, etc.) is not specified.
-    The tables are not specified."""
+    The tables are not specified.
+    """
 
     # (from_column, to_column) pairs, where from_column is on the origin table
     # and to_column is on the destination table of the join.

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, Flag, auto, unique
 from functools import partial
-from typing import Dict, Mapping, Optional, Sequence, AbstractSet, Tuple, Union
+from typing import AbstractSet, Dict, Mapping, Optional, Sequence, Tuple, Union
 
 from graphql.type import GraphQLSchema
 from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -53,6 +53,10 @@ class CompositeJoinDescriptor:
     # and to_column is on the destination table of the join.
     column_pairs: Set[Tuple[str, str]]
 
+    def __post_init__(self):
+        if not self.column_pairs:
+            raise AssertionError("TODO")
+
 
 JoinDescriptor = Union[DirectJoinDescriptor, CompositeJoinDescriptor]
 

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -56,7 +56,7 @@ class CompositeJoinDescriptor:
     def __post_init__(self) -> None:
         """Validate fields."""
         if not self.column_pairs:
-            raise AssertionError("TODO")
+            raise AssertionError("The column_pairs field is expected to be non-empty.")
 
 
 JoinDescriptor = Union[DirectJoinDescriptor, CompositeJoinDescriptor]

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 from enum import Enum, Flag, auto, unique
 from functools import partial
-from typing import Dict, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import Dict, Mapping, Optional, Sequence, AbstractSet, Tuple, Union
 
 from graphql.type import GraphQLSchema
 from graphql.type.definition import GraphQLInterfaceType, GraphQLObjectType
@@ -51,7 +51,7 @@ class CompositeJoinDescriptor:
 
     # (from_column, to_column) pairs, where from_column is on the origin table
     # and to_column is on the destination table of the join.
-    column_pairs: Set[Tuple[str, str]]
+    column_pairs: AbstractSet[Tuple[str, str]]
 
     def __post_init__(self) -> None:
         """Validate fields."""

--- a/graphql_compiler/schema/schema_info.py
+++ b/graphql_compiler/schema/schema_info.py
@@ -53,7 +53,8 @@ class CompositeJoinDescriptor:
     # and to_column is on the destination table of the join.
     column_pairs: Set[Tuple[str, str]]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
+        """Validate fields."""
         if not self.column_pairs:
             raise AssertionError("TODO")
 

--- a/graphql_compiler/schema_generation/sqlalchemy/edge_descriptors.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/edge_descriptors.py
@@ -115,6 +115,7 @@ def generate_direct_edge_descriptors_from_foreign_keys(
             else:
                 number_of_composite_foreign_keys += 1
 
+    # TODO(bojanserafimov): Infer CompositeJoinDescriptor objects
     if number_of_composite_foreign_keys:
         warnings.warn(
             "Ignored {} edges implied by composite foreign keys. We currently do not "

--- a/graphql_compiler/tests/test_compiler.py
+++ b/graphql_compiler/tests/test_compiler.py
@@ -11154,3 +11154,41 @@ class CompilerTests(unittest.TestCase):
             expected_cypher,
             expected_sql,
         )
+
+    def test_animal_born_at_traversal(self) -> None:
+        """Ensure that sql composite key traversals work."""
+        test_data = test_input_data.animal_born_at_traversal()
+
+        expected_match = SKIP_TEST
+        expected_gremlin = SKIP_TEST
+        expected_mssql = """
+            SELECT
+                [Animal_1].name AS animal_name,
+                [BirthEvent_1].name AS birth_event_name
+            FROM
+                db_1.schema_1.[Animal] AS [Animal_1]
+                JOIN db_1.schema_1.[BirthEvent] AS [BirthEvent_1]
+                    ON [Animal_1].birth_date = [BirthEvent_1].event_date
+                    AND [Animal_1].birth_uuid = [BirthEvent_1].uuid
+        """
+        expected_postgresql = """
+            SELECT
+                "Animal_1".name AS animal_name,
+                "BirthEvent_1".name AS birth_event_name
+            FROM
+                schema_1."Animal" AS "Animal_1"
+                JOIN schema_1."BirthEvent" AS "BirthEvent_1"
+                    ON "Animal_1".birth_date = "BirthEvent_1".event_date
+                    AND "Animal_1".birth_uuid = "BirthEvent_1".uuid
+        """
+        expected_cypher = SKIP_TEST
+
+        check_test_data(
+            self,
+            test_data,
+            expected_match,
+            expected_gremlin,
+            expected_mssql,
+            expected_cypher,
+            expected_postgresql,
+        )

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -31,6 +31,7 @@ from ..schema.schema_info import (
     CommonSchemaInfo,
     CompositeJoinDescriptor,
     DirectJoinDescriptor,
+    JoinDescriptor,
     SQLAlchemySchemaInfo,
     make_sqlalchemy_schema_info,
 )
@@ -774,22 +775,19 @@ def get_sqlalchemy_schema_info(dialect: str = "mssql") -> SQLAlchemySchemaInfo:
             "name": "Animal_ParentOf",
             "from_table": "Animal",
             "to_table": "Animal",
-            "from_column": "uuid",
-            "to_column": "parent",
+            "column_pairs": {("uuid", "parent")},
         },
         {
             "name": "Animal_OfSpecies",
             "from_table": "Animal",
             "to_table": "Species",
-            "from_column": "species",
-            "to_column": "uuid",
+            "column_pairs": {("uuid", "parent")},
         },
         {
             "name": "Animal_FedAt",
             "from_table": "Animal",
             "to_table": "FeedingEvent",
-            "from_column": "fed_at",
-            "to_column": "uuid",
+            "column_pairs": {("fed_at", "uuid")},
         },
         {
             "name": "Animal_BornAt",
@@ -804,64 +802,64 @@ def get_sqlalchemy_schema_info(dialect: str = "mssql") -> SQLAlchemySchemaInfo:
             "name": "Animal_LivesIn",
             "from_table": "Animal",
             "to_table": "Location",
-            "from_column": "lives_in",
-            "to_column": "uuid",
+            "column_pairs": {("lives_in", "uuid")},
         },
         {
             "name": "Animal_ImportantEvent",
             "from_table": "Animal",
             "to_table": "Union__BirthEvent__Event__FeedingEvent",
-            "from_column": "important_event",
-            "to_column": "uuid",
+            "column_pairs": {("important_event", "uuid")},
         },
         {
             "name": "Species_Eats",
             "from_table": "Species",
             "to_table": "Union__Food__FoodOrSpecies__Species",
-            "from_column": "eats",
-            "to_column": "uuid",
+            "column_pairs": {("eats", "uuid")},
         },
         {
             "name": "Entity_Related",
             "from_table": "Entity",
             "to_table": "Entity",
-            "from_column": "related_entity",
-            "to_column": "uuid",
+            "column_pairs": {("related_entity", "uuid")},
         },
         {
             "name": "Event_RelatedEvent",
             "from_table": "Union__BirthEvent__Event__FeedingEvent",
             "to_table": "Union__BirthEvent__Event__FeedingEvent",
-            "from_column": "related_event",
-            "to_column": "uuid",
+            "column_pairs": {("related_event", "uuid")},
         },
         {
             "name": "Entity_Alias",
             "from_table": "Entity",
             "to_table": "Alias",
-            "from_column": "uuid",
-            "to_column": "alias_for",
+            "column_pairs": {("uuid", "alias_for")},
         },
     ]
 
-    join_descriptors: Dict[str, Dict[str, DirectJoinDescriptor]] = {}
+    # Create the appropriate JoinDescriptor for each specified edge, in both the
+    # in and out directions.
+    join_descriptors: Dict[str, Dict[str, JoinDescriptor]] = {}
     for edge in edges:
-        if "column_pairs" in edge:
-            join_descriptors.setdefault(edge["from_table"], {})[
+        column_pairs = cast(Set[Tuple[str, str]], edge["column_pairs"])
+        from_table = cast(str, edge["from_table"])
+        to_table = cast(str, edge["to_table"])
+        if len(column_pairs) > 1:
+            join_descriptors.setdefault(from_table, {})[
                 "out_{}".format(edge["name"])
-            ] = CompositeJoinDescriptor(edge["column_pairs"])
-            join_descriptors.setdefault(edge["to_table"], {})[
+            ] = CompositeJoinDescriptor(column_pairs)
+            join_descriptors.setdefault(to_table, {})[
                 "in_{}".format(edge["name"])
             ] = CompositeJoinDescriptor(
-                {(to_column, from_column) for from_column, to_column in edge["column_pairs"]}
+                {(to_column, from_column) for from_column, to_column in column_pairs}
             )
-        else:
-            join_descriptors.setdefault(edge["from_table"], {})[
+        elif len(column_pairs) == 1:
+            from_column, to_column = next(iter(column_pairs))
+            join_descriptors.setdefault(from_table, {})[
                 "out_{}".format(edge["name"])
-            ] = DirectJoinDescriptor(edge["from_column"], edge["to_column"])
-            join_descriptors.setdefault(edge["to_table"], {})[
+            ] = DirectJoinDescriptor(from_column, to_column)
+            join_descriptors.setdefault(to_table, {})[
                 "in_{}".format(edge["name"])
-            ] = DirectJoinDescriptor(edge["to_column"], edge["from_column"])
+            ] = DirectJoinDescriptor(to_column, from_column)
 
     # Inherit join_descriptors from superclasses
     # TODO(bojanserafimov): Properties can be inferred too, instead of being explicitly inherited.

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -798,7 +798,7 @@ def get_sqlalchemy_schema_info(dialect: str = "mssql") -> SQLAlchemySchemaInfo:
             "column_pairs": {
                 ("birth_uuid", "uuid"),
                 ("birth_date", "event_date"),
-            }
+            },
         },
         {
             "name": "Animal_LivesIn",
@@ -852,10 +852,9 @@ def get_sqlalchemy_schema_info(dialect: str = "mssql") -> SQLAlchemySchemaInfo:
             ] = CompositeJoinDescriptor(edge["column_pairs"])
             join_descriptors.setdefault(edge["to_table"], {})[
                 "in_{}".format(edge["name"])
-            ] = CompositeJoinDescriptor({
-                (to_column, from_column)
-                for from_column, to_column in edge["column_pairs"]
-            })
+            ] = CompositeJoinDescriptor(
+                {(to_column, from_column) for from_column, to_column in edge["column_pairs"]}
+            )
         else:
             join_descriptors.setdefault(edge["from_table"], {})[
                 "out_{}".format(edge["name"])

--- a/graphql_compiler/tests/test_helpers.py
+++ b/graphql_compiler/tests/test_helpers.py
@@ -781,7 +781,7 @@ def get_sqlalchemy_schema_info(dialect: str = "mssql") -> SQLAlchemySchemaInfo:
             "name": "Animal_OfSpecies",
             "from_table": "Animal",
             "to_table": "Species",
-            "column_pairs": {("uuid", "parent")},
+            "column_pairs": {("species", "uuid")},
         },
         {
             "name": "Animal_FedAt",

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -3550,7 +3550,7 @@ def recursive_field_type_is_subtype_of_parent_field() -> CommonTestData:  # noqa
     )
 
 
-def animal_born_at_traversal() -> CommonTestData:  #noqa: D103
+def animal_born_at_traversal() -> CommonTestData:  # noqa: D103
     """Ensure that sql composite key traversals work."""
     graphql_input = """{
         Animal {

--- a/graphql_compiler/tests/test_input_data.py
+++ b/graphql_compiler/tests/test_input_data.py
@@ -3548,3 +3548,31 @@ def recursive_field_type_is_subtype_of_parent_field() -> CommonTestData:  # noqa
         expected_input_metadata=expected_input_metadata,
         type_equivalence_hints=type_equivalence_hints,
     )
+
+
+def animal_born_at_traversal() -> CommonTestData:  #noqa: D103
+    """Ensure that sql composite key traversals work."""
+    graphql_input = """{
+        Animal {
+            name @output(out_name: "animal_name")
+            out_Animal_BornAt {
+                name @output(out_name: "birth_event_name")
+            }
+        }
+    }"""
+    expected_output_metadata = {
+        "animal_name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+        "birth_event_name": OutputMetadata(type=GraphQLString, optional=False, folded=False),
+    }
+    expected_input_metadata: Dict[str, GraphQLSchemaFieldType] = {}
+
+    type_equivalence_hints = {
+        "Event": "Union__BirthEvent__Event__FeedingEvent",
+    }
+
+    return CommonTestData(
+        graphql_input=graphql_input,
+        expected_output_metadata=expected_output_metadata,
+        expected_input_metadata=expected_input_metadata,
+        type_equivalence_hints=type_equivalence_hints,
+    )

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -6262,4 +6262,32 @@ class IrGenerationTests(unittest.TestCase):
 
     def test_animal_born_at_traversal(self):
         """Ensure that sql composite key traversals work."""
-        # skipping ir generation testing since this is a sql-specific test
+        test_data = test_input_data.animal_born_at_traversal()
+
+        base_location = helpers.Location(("Animal",))
+        birth_location = base_location.navigate_to_subpath("out_Animal_BornAt")
+
+        expected_blocks = [
+            blocks.QueryRoot({"Animal"}),
+            blocks.MarkLocation(base_location),
+            blocks.Traverse("out", "Animal_BornAt", optional=False),
+            blocks.MarkLocation(birth_location),
+            blocks.Backtrack(base_location),
+            blocks.GlobalOperationsStart(),
+            blocks.ConstructResult(
+                {
+                    "animal_name": expressions.OutputContextField(
+                        base_location.navigate_to_field("name"), GraphQLString
+                    ),
+                    "birth_event_name": expressions.OutputContextField(
+                        birth_location.navigate_to_field("name"), GraphQLString
+                    ),
+                }
+            ),
+        ]
+        expected_location_types = {
+            base_location: "Animal",
+            birth_location: "BirthEvent",
+        }
+
+        check_test_data(self, test_data, expected_blocks, expected_location_types)

--- a/graphql_compiler/tests/test_ir_generation.py
+++ b/graphql_compiler/tests/test_ir_generation.py
@@ -6259,3 +6259,7 @@ class IrGenerationTests(unittest.TestCase):
         }
 
         check_test_data(self, test_data, expected_blocks, expected_location_types)
+
+    def test_animal_born_at_traversal(self):
+        """Ensure that sql composite key traversals work."""
+        # skipping ir generation testing since this is a sql-specific test


### PR DESCRIPTION
Allows us to define edges towards vertices with composite primary key and traverse those edges. Fold and recurse for composite traversals will not be implemented in this PR.