### PR TITLE
Schema renaming: Interface and implementation suppression

### DIFF
--- a/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
+++ b/graphql_compiler/tests/schema_transformation_tests/input_schema_strings.py
@@ -133,33 +133,6 @@ class InputSchemaStrings(object):
     """
     )
 
-    multiple_interfaces_schema = dedent(
-        """\
-        schema {
-          query: SchemaQuery
-        }
-
-        interface Character {
-          id: String
-        }
-
-        interface Creature {
-          age: Int
-        }
-
-        type Human implements Character & Creature {
-          id: String
-          age: Int
-        }
-
-        type SchemaQuery {
-          Character: Character
-          Creature: Creature
-          Human: Human
-        }
-    """
-    )
-
     scalar_schema = dedent(
         """\
         schema {
@@ -322,13 +295,23 @@ class InputSchemaStrings(object):
           SHORT
         }
 
+        interface AbstractCreature {
+          name: String
+        }
+
+        interface Creature implements AbstractCreature {
+          name: String
+          age: Int
+        }
+
         interface Character {
           id: String
         }
 
-        type Human implements Character {
+        type Human implements Character & Creature {
           id: String
           name: String
+          age: Int
           birthday: Date
         }
 
@@ -344,6 +327,9 @@ class InputSchemaStrings(object):
         directive @stitch(source_field: String!, sink_field: String!) on FIELD_DEFINITION
 
         type SchemaQuery {
+          AbstractCreature: AbstractCreature
+          Creature: Creature
+          Character: Character
           Human: Human
           Giraffe: Giraffe
           Dog: Dog

--- a/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
+++ b/graphql_compiler/tests/schema_transformation_tests/test_rename_schema.py
@@ -466,24 +466,24 @@ class TestRenameSchema(unittest.TestCase):
     def test_field_renaming_in_interfaces(self) -> None:
         with self.assertRaises(NotImplementedError):
             rename_schema(
-                parse(ISS.multiple_interfaces_schema), {}, {"Character": {"id": {"new_id"}}}
+                parse(ISS.various_types_schema), {}, {"Character": {"id": {"new_id"}}}
             )
         with self.assertRaises(NotImplementedError):
             rename_schema(
-                parse(ISS.multiple_interfaces_schema), {}, {"Character": {"id": {"id", "new_id"}}}
+                parse(ISS.various_types_schema), {}, {"Character": {"id": {"id", "new_id"}}}
             )
         with self.assertRaises(NotImplementedError):
-            rename_schema(parse(ISS.multiple_interfaces_schema), {}, {"Character": {"id": set()}})
+            rename_schema(parse(ISS.various_types_schema), {}, {"Character": {"id": set()}})
         with self.assertRaises(NotImplementedError):
             # Cannot rename Human's fields because Human implements an interface and field_renamings
             # for object types that implement interfaces isn't supported yet.
-            rename_schema(parse(ISS.multiple_interfaces_schema), {}, {"Human": {"id": {"new_id"}}})
+            rename_schema(parse(ISS.various_types_schema), {}, {"Human": {"id": {"new_id"}}})
         with self.assertRaises(NotImplementedError):
             rename_schema(
-                parse(ISS.multiple_interfaces_schema), {}, {"Human": {"id": {"id", "new_id"}}}
+                parse(ISS.various_types_schema), {}, {"Human": {"id": {"id", "new_id"}}}
             )
         with self.assertRaises(NotImplementedError):
-            rename_schema(parse(ISS.multiple_interfaces_schema), {}, {"Human": {"id": set()}})
+            rename_schema(parse(ISS.various_types_schema), {}, {"Human": {"id": set()}})
 
     def test_enum_rename(self) -> None:
         renamed_schema = rename_schema(
@@ -575,7 +575,7 @@ class TestRenameSchema(unittest.TestCase):
 
     def test_multiple_interfaces_rename(self) -> None:
         renamed_schema = rename_schema(
-            parse(ISS.multiple_interfaces_schema),
+            parse(ISS.various_types_schema),
             {"Human": "NewHuman", "Character": "NewCharacter", "Creature": "NewCreature"},
             {},
         )
@@ -585,23 +585,51 @@ class TestRenameSchema(unittest.TestCase):
               query: SchemaQuery
             }
 
+            scalar Date
+
+            enum Height {
+              TALL
+              SHORT
+            }
+
+            interface AbstractCreature {
+              name: String
+            }
+
+            interface NewCreature implements AbstractCreature {
+              name: String
+              age: Int
+            }
+
             interface NewCharacter {
               id: String
             }
 
-            interface NewCreature {
-              age: Int
-            }
-
             type NewHuman implements NewCharacter & NewCreature {
               id: String
+              name: String
               age: Int
+              birthday: Date
             }
 
+            type Giraffe implements NewCharacter {
+              id: String
+              height: Height
+            }
+
+            type Dog {
+              nickname: String
+            }
+
+            directive @stitch(source_field: String!, sink_field: String!) on FIELD_DEFINITION
+
             type SchemaQuery {
-              NewCharacter: NewCharacter
+              AbstractCreature: AbstractCreature
               NewCreature: NewCreature
+              NewCharacter: NewCharacter
               NewHuman: NewHuman
+              Giraffe: Giraffe
+              Dog: Dog
             }
         """
         )


### PR DESCRIPTION
Interfaces present a challenge for schema renaming that don't show up with regular object types uninvolved with interfaces.

For example, suppressing an object type `Foo` that implements an interface `Bar` can cause problems if, later on, someone queries for all objects that implement `Bar` and ends up getting objects of suppressed type `Foo`. Likewise, if `Bar` itself were to be suppressed but `Foo` wasn't, we'd need to be careful as to what happens to `Foo`'s fields if it not longer explicitly implements `Bar`.

This PR implements interface-related suppressions. There are still some wrinkles to figure out, so I wouldn't recommend reviewing the code in here yet.