### PR TITLE
Add fold post-processing bool to SQLAlchemySchemaInfo

### DIFF
--- a/graphql_compiler/schema_generation/sqlalchemy/__init__.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/__init__.py
@@ -35,14 +35,14 @@ def get_sqlalchemy_schema_info(
     the compiler relies on these to compile GraphQL to SQL.
 
     Args:
-        vertex_name_to_table: Dictionary used to generate the GraphQL objects in the schema
+        vertex_name_to_table: dictionary used to generate the GraphQL objects in the schema
                               in the SQLAlchemySchemaInfo. Each SQLAlchemyTable will be represented
                               as a GraphQL object. The GraphQL object names are the dictionary keys.
                               The fields of the GraphQL objects will be inferred from the columns
                               of the underlying tables. The fields will have the same name as the
                               underlying columns and columns with unsupported types (SQL types
                               with no matching GraphQL type) will be ignored.
-        edges: Dictionary mapping edge name to edge descriptor. The traversal of an edge
+        edges: dictionary mapping edge name to edge descriptor. The traversal of an edge
                gets compiled to a SQL join in graphql_to_sql(). Therefore, each EdgeDescriptor not
                only specifies the source and destination GraphQL objects, but also which columns to
                use to use when generating a SQL join between the underlying source and destination
@@ -51,7 +51,7 @@ def get_sqlalchemy_schema_info(
                destination GraphQL objects respectively. The edge names must not conflict with the
                GraphQL object names.
         dialect: dialect we are compiling to (e.g. sqlalchemy.dialects.mssql.dialect()).
-        class_to_field_type_overrides: Mapping class name to a dictionary of field name to field
+        class_to_field_type_overrides: mapping class name to a dictionary of field name to field
                                        type. Used to override the type of a field in the class where
                                        it's first defined and all the class's subclasses.
         requires_fold_postprocessing: whether or not queries compiled against this schema require

--- a/graphql_compiler/schema_generation/sqlalchemy/__init__.py
+++ b/graphql_compiler/schema_generation/sqlalchemy/__init__.py
@@ -1,13 +1,25 @@
 # Copyright 2019-present Kensho Technologies, LLC.
+from typing import Dict, Optional
+
+from graphql.type.definition import GraphQLType
+from sqlalchemy import Table
+from sqlalchemy.dialects.mssql.base import MSDialect
+from sqlalchemy.engine.interfaces import Dialect
+
 from ...schema.schema_info import SQLAlchemySchemaInfo
 from ..graphql_schema import get_graphql_schema_from_schema_graph
-from .edge_descriptors import get_join_descriptors_from_edge_descriptors
+from .edge_descriptors import EdgeDescriptor, get_join_descriptors_from_edge_descriptors
 from .schema_graph_builder import get_sqlalchemy_schema_graph
 
 
 def get_sqlalchemy_schema_info(
-    vertex_name_to_table, edges, dialect, class_to_field_type_overrides=None
-):
+    vertex_name_to_table: Dict[str, Table],
+    edges: Dict[str, EdgeDescriptor],
+    dialect: Dialect,
+    class_to_field_type_overrides: Optional[Dict[str, Dict[str, GraphQLType]]] = None,
+    *,
+    requires_fold_postprocessing: Optional[bool] = None
+) -> SQLAlchemySchemaInfo:
     """Return a SQLAlchemySchemaInfo from the metadata.
 
     Relational databases are supported by compiling to SQLAlchemy core as an intermediate
@@ -23,29 +35,28 @@ def get_sqlalchemy_schema_info(
     the compiler relies on these to compile GraphQL to SQL.
 
     Args:
-        vertex_name_to_table: dict, str -> SQLAlchemy Table. This dictionary is used to generate the
-                              GraphQL objects in the schema in the SQLAlchemySchemaInfo. Each
-                              SQLAlchemyTable will be represented as a GraphQL object. The GraphQL
-                              object names are the dictionary keys. The fields of the GraphQL
-                              objects will be inferred from the columns of the underlying tables.
-                              The fields will have the same name as the underlying columns and
-                              columns with unsupported types, (SQL types with no matching GraphQL
-                              type), will be ignored.
-        edges: dict, str-> EdgeDescriptor. The traversal of an edge
-                      edge gets compiled to a SQL join in graphql_to_sql(). Therefore, each
-                      EdgeDescriptor not only specifies the source and destination GraphQL
-                      objects, but also which columns to use to use when generating a SQL join
-                      between the underlying source and destination tables. The names of the edges
-                      are the keys in the dictionary and the edges will be rendered as vertex fields
-                      named out_<edgeName> and in_<edgeName> in the source and destination GraphQL
-                      objects respectively. The edge names must not conflict with the GraphQL
-                      object names.
-        dialect: sqlalchemy.engine.interfaces.Dialect, specifying the dialect we are compiling to
-                 (e.g. sqlalchemy.dialects.mssql.dialect()).
-        class_to_field_type_overrides: optional dict, class name -> {field name -> field type},
-                                       (string -> {string -> GraphQLType}). Used to override the
-                                       type of a field in the class where it's first defined and all
-                                       the class's subclasses.
+        vertex_name_to_table: Dictionary used to generate the GraphQL objects in the schema
+                              in the SQLAlchemySchemaInfo. Each SQLAlchemyTable will be represented
+                              as a GraphQL object. The GraphQL object names are the dictionary keys.
+                              The fields of the GraphQL objects will be inferred from the columns
+                              of the underlying tables. The fields will have the same name as the
+                              underlying columns and columns with unsupported types (SQL types
+                              with no matching GraphQL type) will be ignored.
+        edges: Dictionary mapping edge name to edge descriptor. The traversal of an edge
+               gets compiled to a SQL join in graphql_to_sql(). Therefore, each EdgeDescriptor not
+               only specifies the source and destination GraphQL objects, but also which columns to
+               use to use when generating a SQL join between the underlying source and destination
+               tables. The names of the edges are the keys in the dictionary and the edges will be
+               rendered as vertex fields named out_<edgeName> and in_<edgeName> in the source and
+               destination GraphQL objects respectively. The edge names must not conflict with the
+               GraphQL object names.
+        dialect: dialect we are compiling to (e.g. sqlalchemy.dialects.mssql.dialect()).
+        class_to_field_type_overrides: Mapping class name to a dictionary of field name to field
+                                       type. Used to override the type of a field in the class where
+                                       it's first defined and all the class's subclasses.
+        requires_fold_postprocessing: whether or not queries compiled against this schema require
+                                      fold post-processing. If None, this will be inferred from the
+                                      dialect.
 
     Returns:
         SQLAlchemySchemaInfo containing the full information needed to compile SQL queries.
@@ -60,6 +71,18 @@ def get_sqlalchemy_schema_info(
 
     join_descriptors = get_join_descriptors_from_edge_descriptors(edges)
 
+    # Infer whether fold post-processing is required if not explicitly given.
+    if requires_fold_postprocessing is None:
+        if isinstance(dialect, MSDialect):
+            requires_fold_postprocessing = True
+        else:
+            requires_fold_postprocessing = False
+
     return SQLAlchemySchemaInfo(
-        graphql_schema, type_equivalence_hints, dialect, vertex_name_to_table, join_descriptors
+        graphql_schema,
+        type_equivalence_hints,
+        dialect,
+        vertex_name_to_table,
+        join_descriptors,
+        requires_fold_postprocessing,
     )

--- a/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
+++ b/graphql_compiler/tests/schema_generation_tests/test_sqlalchemy_schema_generation.py
@@ -28,6 +28,7 @@ from ...schema_generation.sqlalchemy.edge_descriptors import (
     CompositeEdgeDescriptor,
     DirectEdgeDescriptor,
     DirectJoinDescriptor,
+    EdgeDescriptor,
     generate_direct_edge_descriptors_from_foreign_keys,
 )
 from ...schema_generation.sqlalchemy.scalar_type_mapper import try_get_graphql_scalar_type
@@ -99,7 +100,12 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
         join_descriptors = get_join_descriptors_from_edge_descriptors(direct_edges)
 
         self.schema_info = SQLAlchemySchemaInfo(
-            graphql_schema, type_equivalence_hints, dialect, vertex_name_to_table, join_descriptors
+            graphql_schema,
+            type_equivalence_hints,
+            dialect,
+            vertex_name_to_table,
+            join_descriptors,
+            True,
         )
 
     def test_table_vertex_representation(self) -> None:
@@ -245,7 +251,7 @@ class SQLAlchemySchemaInfoGenerationTests(unittest.TestCase):
         )
 
     def test_composite_edge(self) -> None:
-        edges = {
+        edges: Dict[str, EdgeDescriptor] = {
             "composite_edge": CompositeEdgeDescriptor(
                 "Table1",
                 "TableWithMultiplePrimaryKeyColumns",
@@ -338,7 +344,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
         self.vertex_name_to_table = _get_test_vertex_name_to_table()
 
     def test_reference_to_non_existent_source_vertex(self) -> None:
-        direct_edges = {
+        direct_edges: Dict[str, EdgeDescriptor] = {
             "invalid_source_vertex": DirectEdgeDescriptor(
                 "InvalidVertexName", "source_column", "ArbitraryObjectName", "destination_column"
             )
@@ -347,7 +353,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_destination_vertex(self) -> None:
-        direct_edges = {
+        direct_edges: Dict[str, EdgeDescriptor] = {
             "invalid_source_vertex": DirectEdgeDescriptor(
                 "Table1", "source_column", "InvalidVertexName", "destination_column"
             )
@@ -356,7 +362,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_source_column(self) -> None:
-        direct_edges = {
+        direct_edges: Dict[str, EdgeDescriptor] = {
             "invalid_source_vertex": DirectEdgeDescriptor(
                 "Table1", "invalid_column_name", "ArbitraryObjectName", "destination_column"
             )
@@ -365,7 +371,7 @@ class SQLAlchemySchemaInfoGenerationErrorTests(unittest.TestCase):
             get_sqlalchemy_schema_info(self.vertex_name_to_table, direct_edges, dialect())
 
     def test_reference_to_non_existent_destination_column(self) -> None:
-        direct_edges = {
+        direct_edges: Dict[str, EdgeDescriptor] = {
             "invalid_destination_column": DirectEdgeDescriptor(
                 "Table1", "source_column", "ArbitraryObjectName", "invalid_column_name"
             )


### PR DESCRIPTION
Adding whether or not post-processing should be applied to `SQLAlchemySchemaInfo` based on @obi1kenobi's comment on #1008.

> Another (and perhaps even better) alternative would be to add requires_fold_postprocessing or something like it to the SQLAlchemySchemaInfo. After all, that object knows the dialect (and therefore the emitted SQL) better than anything else, so realistically it should be the one specifying whether post-processing is required or not.

I opted to default to automatic inference of whether or not fold post-processing is required based on `isinstance(dialect, MSDialect)`, which could create a bug if SQLAlchemy adds a MSSQL dialect that does not inherit from `MSDialect`. This can be overruled with the keyword arg `requires_fold_postprocessing` in both `make_sqlalchemy_schema_info` and `get_sqlalchemy_schema_info`. I thought inferring would be more user friendly, but could make explicitly setting `requires_fold_postprocessing` required if there's an argument for that approach.